### PR TITLE
Add comprehensive test suite for FluxbaseAdminAI class

### DIFF
--- a/sdk-react/src/use-saml.test.ts
+++ b/sdk-react/src/use-saml.test.ts
@@ -179,7 +179,7 @@ describe('useHandleSAMLCallback', () => {
 
     expect(handleSAMLCallbackMock).toHaveBeenCalledWith('base64-response', undefined);
     expect(response).toEqual(mockResult);
-    expect(result.current.isSuccess).toBe(true);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
 
   it('should pass provider to callback handler', async () => {

--- a/sdk/src/admin-ai.test.ts
+++ b/sdk/src/admin-ai.test.ts
@@ -1,0 +1,1085 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FluxbaseAdminAI } from "./admin-ai";
+import { FluxbaseFetch } from "./fetch";
+import type {
+  AIChatbot,
+  AIChatbotSummary,
+  AIProvider,
+  SyncChatbotsResult,
+  KnowledgeBase,
+  KnowledgeBaseSummary,
+  KnowledgeBaseDocument,
+  AddDocumentResponse,
+  UploadDocumentResponse,
+  ChatbotKnowledgeBaseLink,
+  SearchKnowledgeBaseResponse,
+} from "./types";
+
+// Mock FluxbaseFetch
+vi.mock("./fetch");
+
+describe("FluxbaseAdminAI", () => {
+  let ai: FluxbaseAdminAI;
+  let mockFetch: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    };
+    ai = new FluxbaseAdminAI(mockFetch as unknown as FluxbaseFetch);
+  });
+
+  describe("Chatbot Management", () => {
+    describe("listChatbots()", () => {
+      it("should list all chatbots", async () => {
+        const response = {
+          chatbots: [
+            { id: "bot-1", name: "assistant", namespace: "default", enabled: true },
+            { id: "bot-2", name: "sql-helper", namespace: "default", enabled: false },
+          ] as AIChatbotSummary[],
+          count: 2,
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.listChatbots();
+
+        expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/ai/chatbots");
+        expect(error).toBeNull();
+        expect(data).toHaveLength(2);
+      });
+
+      it("should list chatbots by namespace", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({ chatbots: [], count: 0 });
+
+        await ai.listChatbots("custom");
+
+        expect(mockFetch.get).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/chatbots?namespace=custom"
+        );
+      });
+
+      it("should handle empty response", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({ chatbots: null, count: 0 });
+
+        const { data, error } = await ai.listChatbots();
+
+        expect(error).toBeNull();
+        expect(data).toEqual([]);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+        const { data, error } = await ai.listChatbots();
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("getChatbot()", () => {
+      it("should get a specific chatbot", async () => {
+        const response: AIChatbot = {
+          id: "bot-1",
+          name: "assistant",
+          namespace: "default",
+          enabled: true,
+          system_prompt: "You are a helpful assistant",
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.getChatbot("bot-1");
+
+        expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/ai/chatbots/bot-1");
+        expect(error).toBeNull();
+        expect(data!.name).toBe("assistant");
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+        const { data, error } = await ai.getChatbot("unknown");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("toggleChatbot()", () => {
+      it("should enable a chatbot", async () => {
+        const response: AIChatbot = {
+          id: "bot-1",
+          name: "assistant",
+          namespace: "default",
+          enabled: true,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+        const { data, error } = await ai.toggleChatbot("bot-1", true);
+
+        expect(mockFetch.put).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/chatbots/bot-1/toggle",
+          { enabled: true }
+        );
+        expect(error).toBeNull();
+        expect(data!.enabled).toBe(true);
+      });
+
+      it("should disable a chatbot", async () => {
+        const response: AIChatbot = {
+          id: "bot-1",
+          name: "assistant",
+          namespace: "default",
+          enabled: false,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+        const { data, error } = await ai.toggleChatbot("bot-1", false);
+
+        expect(data!.enabled).toBe(false);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.put).mockRejectedValue(new Error("Update failed"));
+
+        const { data, error } = await ai.toggleChatbot("bot-1", true);
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("deleteChatbot()", () => {
+      it("should delete a chatbot", async () => {
+        vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+        const { data, error } = await ai.deleteChatbot("bot-1");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith("/api/v1/admin/ai/chatbots/bot-1");
+        expect(error).toBeNull();
+        expect(data).toBeNull();
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Delete failed"));
+
+        const { data, error } = await ai.deleteChatbot("bot-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("sync()", () => {
+      it("should sync chatbots without options", async () => {
+        const response: SyncChatbotsResult = {
+          message: "Sync completed",
+          namespace: "default",
+          summary: { created: 1, updated: 0, deleted: 0, unchanged: 0, errors: 0 },
+          details: { created: ["bot-1"], updated: [], deleted: [], unchanged: [], errors: [] },
+          dry_run: false,
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const { data, error } = await ai.sync();
+
+        expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/ai/chatbots/sync", {
+          namespace: "default",
+          chatbots: undefined,
+          options: { delete_missing: false, dry_run: false },
+        });
+        expect(error).toBeNull();
+      });
+
+      it("should sync with provided chatbots", async () => {
+        const response: SyncChatbotsResult = {
+          message: "Sync completed",
+          namespace: "custom",
+          summary: { created: 1, updated: 0, deleted: 0, unchanged: 0, errors: 0 },
+          details: { created: ["my-bot"], updated: [], deleted: [], unchanged: [], errors: [] },
+          dry_run: false,
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        await ai.sync({
+          namespace: "custom",
+          chatbots: [{ name: "my-bot", code: "system: You are helpful" }],
+          options: { delete_missing: true, dry_run: false },
+        });
+
+        expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/ai/chatbots/sync", {
+          namespace: "custom",
+          chatbots: [{ name: "my-bot", code: "system: You are helpful" }],
+          options: { delete_missing: true, dry_run: false },
+        });
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(new Error("Sync failed"));
+
+        const { data, error } = await ai.sync();
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+  });
+
+  describe("Provider Management", () => {
+    describe("listProviders()", () => {
+      it("should list all providers", async () => {
+        const response = {
+          providers: [
+            { id: "prov-1", name: "openai", display_name: "OpenAI", enabled: true },
+            { id: "prov-2", name: "anthropic", display_name: "Anthropic", enabled: true },
+          ] as AIProvider[],
+          count: 2,
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.listProviders();
+
+        expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/ai/providers");
+        expect(error).toBeNull();
+        expect(data).toHaveLength(2);
+      });
+
+      it("should handle empty response", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({ providers: null, count: 0 });
+
+        const { data, error } = await ai.listProviders();
+
+        expect(error).toBeNull();
+        expect(data).toEqual([]);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+        const { data, error } = await ai.listProviders();
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("getProvider()", () => {
+      it("should get a specific provider", async () => {
+        const response: AIProvider = {
+          id: "prov-1",
+          name: "openai",
+          display_name: "OpenAI",
+          provider_type: "openai",
+          enabled: true,
+          is_default: true,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.getProvider("prov-1");
+
+        expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/ai/providers/prov-1");
+        expect(error).toBeNull();
+        expect(data!.name).toBe("openai");
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+        const { data, error } = await ai.getProvider("unknown");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("createProvider()", () => {
+      it("should create a provider", async () => {
+        const response: AIProvider = {
+          id: "prov-1",
+          name: "openai-main",
+          display_name: "OpenAI (Main)",
+          provider_type: "openai",
+          enabled: true,
+          is_default: true,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const { data, error } = await ai.createProvider({
+          name: "openai-main",
+          display_name: "OpenAI (Main)",
+          provider_type: "openai",
+          is_default: true,
+          config: { api_key: "sk-xxx", model: "gpt-4-turbo" },
+        });
+
+        expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/ai/providers", {
+          name: "openai-main",
+          display_name: "OpenAI (Main)",
+          provider_type: "openai",
+          is_default: true,
+          config: { api_key: "sk-xxx", model: "gpt-4-turbo" },
+        });
+        expect(error).toBeNull();
+      });
+
+      it("should normalize config values to strings", async () => {
+        vi.mocked(mockFetch.post).mockResolvedValue({});
+
+        await ai.createProvider({
+          name: "test",
+          provider_type: "openai",
+          config: { max_tokens: 100, temperature: 0.7 } as any,
+        });
+
+        expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/ai/providers", {
+          name: "test",
+          provider_type: "openai",
+          config: { max_tokens: "100", temperature: "0.7" },
+        });
+      });
+
+      it("should skip undefined and null config values", async () => {
+        vi.mocked(mockFetch.post).mockResolvedValue({});
+
+        await ai.createProvider({
+          name: "test",
+          provider_type: "openai",
+          config: { api_key: "key", optional: undefined, nullable: null } as any,
+        });
+
+        expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/ai/providers", {
+          name: "test",
+          provider_type: "openai",
+          config: { api_key: "key" },
+        });
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(new Error("Create failed"));
+
+        const { data, error } = await ai.createProvider({
+          name: "test",
+          provider_type: "openai",
+        });
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("updateProvider()", () => {
+      it("should update a provider", async () => {
+        const response: AIProvider = {
+          id: "prov-1",
+          name: "openai",
+          display_name: "Updated Name",
+          provider_type: "openai",
+          enabled: true,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+        const { data, error } = await ai.updateProvider("prov-1", {
+          display_name: "Updated Name",
+          enabled: true,
+        });
+
+        expect(mockFetch.put).toHaveBeenCalledWith("/api/v1/admin/ai/providers/prov-1", {
+          display_name: "Updated Name",
+          enabled: true,
+        });
+        expect(error).toBeNull();
+      });
+
+      it("should normalize config values on update", async () => {
+        vi.mocked(mockFetch.put).mockResolvedValue({});
+
+        await ai.updateProvider("prov-1", {
+          config: { max_tokens: 200 } as any,
+        });
+
+        expect(mockFetch.put).toHaveBeenCalledWith("/api/v1/admin/ai/providers/prov-1", {
+          config: { max_tokens: "200" },
+        });
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.put).mockRejectedValue(new Error("Update failed"));
+
+        const { data, error } = await ai.updateProvider("prov-1", {});
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("setDefaultProvider()", () => {
+      it("should set default provider", async () => {
+        const response: AIProvider = {
+          id: "prov-1",
+          name: "openai",
+          display_name: "OpenAI",
+          provider_type: "openai",
+          is_default: true,
+          enabled: true,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+        const { data, error } = await ai.setDefaultProvider("prov-1");
+
+        expect(mockFetch.put).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/providers/prov-1/default",
+          {}
+        );
+        expect(error).toBeNull();
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.put).mockRejectedValue(new Error("Failed"));
+
+        const { data, error } = await ai.setDefaultProvider("prov-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("deleteProvider()", () => {
+      it("should delete a provider", async () => {
+        vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+        const { data, error } = await ai.deleteProvider("prov-1");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith("/api/v1/admin/ai/providers/prov-1");
+        expect(error).toBeNull();
+        expect(data).toBeNull();
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Delete failed"));
+
+        const { data, error } = await ai.deleteProvider("prov-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("setEmbeddingProvider()", () => {
+      it("should set embedding provider", async () => {
+        const response = { id: "prov-1", use_for_embeddings: true };
+        vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+        const { data, error } = await ai.setEmbeddingProvider("prov-1");
+
+        expect(mockFetch.put).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/providers/prov-1/embedding",
+          {}
+        );
+        expect(error).toBeNull();
+        expect(data!.use_for_embeddings).toBe(true);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.put).mockRejectedValue(new Error("Failed"));
+
+        const { data, error } = await ai.setEmbeddingProvider("prov-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("clearEmbeddingProvider()", () => {
+      it("should clear embedding provider", async () => {
+        const response = { use_for_embeddings: false };
+        vi.mocked(mockFetch.delete).mockResolvedValue(response);
+
+        const { data, error } = await ai.clearEmbeddingProvider("prov-1");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/providers/prov-1/embedding"
+        );
+        expect(error).toBeNull();
+        expect(data!.use_for_embeddings).toBe(false);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Failed"));
+
+        const { data, error } = await ai.clearEmbeddingProvider("prov-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+  });
+
+  describe("Knowledge Base Management", () => {
+    describe("listKnowledgeBases()", () => {
+      it("should list all knowledge bases", async () => {
+        const response = {
+          knowledge_bases: [
+            { id: "kb-1", name: "product-docs", document_count: 10 },
+            { id: "kb-2", name: "faq", document_count: 50 },
+          ] as KnowledgeBaseSummary[],
+          count: 2,
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.listKnowledgeBases();
+
+        expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/ai/knowledge-bases");
+        expect(error).toBeNull();
+        expect(data).toHaveLength(2);
+      });
+
+      it("should handle empty response", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({ knowledge_bases: null, count: 0 });
+
+        const { data, error } = await ai.listKnowledgeBases();
+
+        expect(error).toBeNull();
+        expect(data).toEqual([]);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+        const { data, error } = await ai.listKnowledgeBases();
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("getKnowledgeBase()", () => {
+      it("should get a knowledge base", async () => {
+        const response: KnowledgeBase = {
+          id: "kb-1",
+          name: "product-docs",
+          description: "Product documentation",
+          chunk_size: 512,
+          chunk_overlap: 50,
+          enabled: true,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.getKnowledgeBase("kb-1");
+
+        expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/ai/knowledge-bases/kb-1");
+        expect(error).toBeNull();
+        expect(data!.name).toBe("product-docs");
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+        const { data, error } = await ai.getKnowledgeBase("unknown");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("createKnowledgeBase()", () => {
+      it("should create a knowledge base", async () => {
+        const response: KnowledgeBase = {
+          id: "kb-1",
+          name: "product-docs",
+          description: "Product documentation",
+          chunk_size: 512,
+          chunk_overlap: 50,
+          enabled: true,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const { data, error } = await ai.createKnowledgeBase({
+          name: "product-docs",
+          description: "Product documentation",
+          chunk_size: 512,
+          chunk_overlap: 50,
+        });
+
+        expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/ai/knowledge-bases", {
+          name: "product-docs",
+          description: "Product documentation",
+          chunk_size: 512,
+          chunk_overlap: 50,
+        });
+        expect(error).toBeNull();
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(new Error("Create failed"));
+
+        const { data, error } = await ai.createKnowledgeBase({ name: "test" });
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("updateKnowledgeBase()", () => {
+      it("should update a knowledge base", async () => {
+        const response: KnowledgeBase = {
+          id: "kb-1",
+          name: "product-docs",
+          description: "Updated description",
+          enabled: true,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+        const { data, error } = await ai.updateKnowledgeBase("kb-1", {
+          description: "Updated description",
+          enabled: true,
+        });
+
+        expect(mockFetch.put).toHaveBeenCalledWith("/api/v1/admin/ai/knowledge-bases/kb-1", {
+          description: "Updated description",
+          enabled: true,
+        });
+        expect(error).toBeNull();
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.put).mockRejectedValue(new Error("Update failed"));
+
+        const { data, error } = await ai.updateKnowledgeBase("kb-1", {});
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("deleteKnowledgeBase()", () => {
+      it("should delete a knowledge base", async () => {
+        vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+        const { data, error } = await ai.deleteKnowledgeBase("kb-1");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith("/api/v1/admin/ai/knowledge-bases/kb-1");
+        expect(error).toBeNull();
+        expect(data).toBeNull();
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Delete failed"));
+
+        const { data, error } = await ai.deleteKnowledgeBase("kb-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+  });
+
+  describe("Document Management", () => {
+    describe("listDocuments()", () => {
+      it("should list documents", async () => {
+        const response = {
+          documents: [
+            { id: "doc-1", title: "Getting Started", chunk_count: 5 },
+            { id: "doc-2", title: "API Reference", chunk_count: 20 },
+          ] as KnowledgeBaseDocument[],
+          count: 2,
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.listDocuments("kb-1");
+
+        expect(mockFetch.get).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/knowledge-bases/kb-1/documents"
+        );
+        expect(error).toBeNull();
+        expect(data).toHaveLength(2);
+      });
+
+      it("should handle empty response", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({ documents: null, count: 0 });
+
+        const { data, error } = await ai.listDocuments("kb-1");
+
+        expect(error).toBeNull();
+        expect(data).toEqual([]);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+        const { data, error } = await ai.listDocuments("kb-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("getDocument()", () => {
+      it("should get a document", async () => {
+        const response: KnowledgeBaseDocument = {
+          id: "doc-1",
+          title: "Getting Started",
+          content: "This is the content...",
+          chunk_count: 5,
+          created_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.getDocument("kb-1", "doc-1");
+
+        expect(mockFetch.get).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/knowledge-bases/kb-1/documents/doc-1"
+        );
+        expect(error).toBeNull();
+        expect(data!.title).toBe("Getting Started");
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+        const { data, error } = await ai.getDocument("kb-1", "unknown");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("addDocument()", () => {
+      it("should add a document", async () => {
+        const response: AddDocumentResponse = {
+          document_id: "doc-1",
+          message: "Document added successfully",
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const { data, error } = await ai.addDocument("kb-1", {
+          title: "Getting Started",
+          content: "This is the content...",
+          metadata: { category: "guides" },
+        });
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/knowledge-bases/kb-1/documents",
+          {
+            title: "Getting Started",
+            content: "This is the content...",
+            metadata: { category: "guides" },
+          }
+        );
+        expect(error).toBeNull();
+        expect(data!.document_id).toBe("doc-1");
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(new Error("Add failed"));
+
+        const { data, error } = await ai.addDocument("kb-1", {
+          title: "Test",
+          content: "Content",
+        });
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("uploadDocument()", () => {
+      it("should upload a document file", async () => {
+        const response: UploadDocumentResponse = {
+          document_id: "doc-1",
+          extracted_length: 5000,
+          message: "Document uploaded",
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const file = new File(["content"], "document.pdf", { type: "application/pdf" });
+        const { data, error } = await ai.uploadDocument("kb-1", file);
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/knowledge-bases/kb-1/documents/upload",
+          expect.any(FormData)
+        );
+        expect(error).toBeNull();
+        expect(data!.document_id).toBe("doc-1");
+      });
+
+      it("should upload with title", async () => {
+        vi.mocked(mockFetch.post).mockResolvedValue({ document_id: "doc-1" });
+
+        const file = new Blob(["content"], { type: "text/plain" });
+        await ai.uploadDocument("kb-1", file, "My Document");
+
+        const call = vi.mocked(mockFetch.post).mock.calls[0];
+        const formData = call[1] as FormData;
+        expect(formData.get("title")).toBe("My Document");
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(new Error("Upload failed"));
+
+        const file = new File(["content"], "doc.pdf");
+        const { data, error } = await ai.uploadDocument("kb-1", file);
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("deleteDocument()", () => {
+      it("should delete a document", async () => {
+        vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+        const { data, error } = await ai.deleteDocument("kb-1", "doc-1");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/knowledge-bases/kb-1/documents/doc-1"
+        );
+        expect(error).toBeNull();
+        expect(data).toBeNull();
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Delete failed"));
+
+        const { data, error } = await ai.deleteDocument("kb-1", "doc-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("searchKnowledgeBase()", () => {
+      it("should search knowledge base", async () => {
+        const response: SearchKnowledgeBaseResponse = {
+          results: [
+            { content: "Result 1", score: 0.95, document_id: "doc-1" },
+            { content: "Result 2", score: 0.85, document_id: "doc-2" },
+          ],
+          count: 2,
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const { data, error } = await ai.searchKnowledgeBase(
+          "kb-1",
+          "how to reset password"
+        );
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/knowledge-bases/kb-1/search",
+          {
+            query: "how to reset password",
+            max_chunks: undefined,
+            threshold: undefined,
+          }
+        );
+        expect(error).toBeNull();
+        expect(data!.results).toHaveLength(2);
+      });
+
+      it("should search with options", async () => {
+        vi.mocked(mockFetch.post).mockResolvedValue({ results: [], count: 0 });
+
+        await ai.searchKnowledgeBase("kb-1", "query", {
+          max_chunks: 5,
+          threshold: 0.7,
+        });
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/knowledge-bases/kb-1/search",
+          {
+            query: "query",
+            max_chunks: 5,
+            threshold: 0.7,
+          }
+        );
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(new Error("Search failed"));
+
+        const { data, error } = await ai.searchKnowledgeBase("kb-1", "query");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+  });
+
+  describe("Chatbot Knowledge Base Linking", () => {
+    describe("listChatbotKnowledgeBases()", () => {
+      it("should list linked knowledge bases", async () => {
+        const response = {
+          knowledge_bases: [
+            { chatbot_id: "bot-1", knowledge_base_id: "kb-1", priority: 1 },
+            { chatbot_id: "bot-1", knowledge_base_id: "kb-2", priority: 2 },
+          ] as ChatbotKnowledgeBaseLink[],
+          count: 2,
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await ai.listChatbotKnowledgeBases("bot-1");
+
+        expect(mockFetch.get).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/chatbots/bot-1/knowledge-bases"
+        );
+        expect(error).toBeNull();
+        expect(data).toHaveLength(2);
+      });
+
+      it("should handle empty response", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({ knowledge_bases: null, count: 0 });
+
+        const { data, error } = await ai.listChatbotKnowledgeBases("bot-1");
+
+        expect(error).toBeNull();
+        expect(data).toEqual([]);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+        const { data, error } = await ai.listChatbotKnowledgeBases("bot-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("linkKnowledgeBase()", () => {
+      it("should link a knowledge base", async () => {
+        const response: ChatbotKnowledgeBaseLink = {
+          chatbot_id: "bot-1",
+          knowledge_base_id: "kb-1",
+          priority: 1,
+          max_chunks: 5,
+          similarity_threshold: 0.7,
+          enabled: true,
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const { data, error } = await ai.linkKnowledgeBase("bot-1", {
+          knowledge_base_id: "kb-1",
+          priority: 1,
+          max_chunks: 5,
+          similarity_threshold: 0.7,
+        });
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/chatbots/bot-1/knowledge-bases",
+          {
+            knowledge_base_id: "kb-1",
+            priority: 1,
+            max_chunks: 5,
+            similarity_threshold: 0.7,
+          }
+        );
+        expect(error).toBeNull();
+        expect(data!.enabled).toBe(true);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(new Error("Link failed"));
+
+        const { data, error } = await ai.linkKnowledgeBase("bot-1", {
+          knowledge_base_id: "kb-1",
+        });
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("updateChatbotKnowledgeBase()", () => {
+      it("should update link configuration", async () => {
+        const response: ChatbotKnowledgeBaseLink = {
+          chatbot_id: "bot-1",
+          knowledge_base_id: "kb-1",
+          max_chunks: 10,
+          enabled: true,
+        };
+
+        vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+        const { data, error } = await ai.updateChatbotKnowledgeBase(
+          "bot-1",
+          "kb-1",
+          { max_chunks: 10, enabled: true }
+        );
+
+        expect(mockFetch.put).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/chatbots/bot-1/knowledge-bases/kb-1",
+          { max_chunks: 10, enabled: true }
+        );
+        expect(error).toBeNull();
+        expect(data!.max_chunks).toBe(10);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.put).mockRejectedValue(new Error("Update failed"));
+
+        const { data, error } = await ai.updateChatbotKnowledgeBase("bot-1", "kb-1", {});
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("unlinkKnowledgeBase()", () => {
+      it("should unlink a knowledge base", async () => {
+        vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+        const { data, error } = await ai.unlinkKnowledgeBase("bot-1", "kb-1");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith(
+          "/api/v1/admin/ai/chatbots/bot-1/knowledge-bases/kb-1"
+        );
+        expect(error).toBeNull();
+        expect(data).toBeNull();
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Unlink failed"));
+
+        const { data, error } = await ai.unlinkKnowledgeBase("bot-1", "kb-1");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+  });
+});

--- a/sdk/src/admin-functions.test.ts
+++ b/sdk/src/admin-functions.test.ts
@@ -1,0 +1,631 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FluxbaseAdminFunctions } from "./admin-functions";
+import { FluxbaseFetch } from "./fetch";
+import * as bundling from "./bundling";
+import type {
+  EdgeFunction,
+  EdgeFunctionExecution,
+  SyncFunctionsResult,
+} from "./types";
+
+// Mock FluxbaseFetch
+vi.mock("./fetch");
+
+// Mock bundling module
+vi.mock("./bundling", async () => {
+  const actual = await vi.importActual("./bundling");
+  return {
+    ...actual,
+    bundleCode: vi.fn(),
+    loadEsbuild: vi.fn(),
+    loadImportMap: vi.fn(),
+    denoExternalPlugin: vi.fn(),
+  };
+});
+
+describe("FluxbaseAdminFunctions", () => {
+  let functions: FluxbaseAdminFunctions;
+  let mockFetch: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    };
+    functions = new FluxbaseAdminFunctions(mockFetch as unknown as FluxbaseFetch);
+  });
+
+  describe("create()", () => {
+    it("should create a new edge function", async () => {
+      const response: EdgeFunction = {
+        id: "func-1",
+        name: "my-function",
+        namespace: "default",
+        version: 1,
+        enabled: true,
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await functions.create({
+        name: "my-function",
+        code: 'export default async function handler(req) { return { hello: "world" } }',
+        enabled: true,
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/functions", {
+        name: "my-function",
+        code: 'export default async function handler(req) { return { hello: "world" } }',
+        enabled: true,
+      });
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data!.name).toBe("my-function");
+    });
+
+    it("should handle create error", async () => {
+      const errorMessage = "Function already exists";
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error(errorMessage));
+
+      const { data, error } = await functions.create({
+        name: "my-function",
+        code: "export default function handler() {}",
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+      expect(error!.message).toBe(errorMessage);
+    });
+  });
+
+  describe("listNamespaces()", () => {
+    it("should list all namespaces", async () => {
+      const response = { namespaces: ["default", "custom-ns"] };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await functions.listNamespaces();
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/functions/namespaces"
+      );
+      expect(error).toBeNull();
+      expect(data).toEqual(["default", "custom-ns"]);
+    });
+
+    it("should return default namespace when empty", async () => {
+      const response = { namespaces: null };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await functions.listNamespaces();
+
+      expect(error).toBeNull();
+      expect(data).toEqual(["default"]);
+    });
+
+    it("should handle listNamespaces error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Network error"));
+
+      const { data, error } = await functions.listNamespaces();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("list()", () => {
+    it("should list all functions", async () => {
+      const response: EdgeFunction[] = [
+        {
+          id: "func-1",
+          name: "func-a",
+          namespace: "default",
+          version: 1,
+          enabled: true,
+          created_at: "2024-01-26T10:00:00Z",
+          updated_at: "2024-01-26T10:00:00Z",
+        },
+        {
+          id: "func-2",
+          name: "func-b",
+          namespace: "default",
+          version: 1,
+          enabled: false,
+          created_at: "2024-01-26T11:00:00Z",
+          updated_at: "2024-01-26T11:00:00Z",
+        },
+      ];
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await functions.list();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/functions");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(2);
+    });
+
+    it("should list functions by namespace", async () => {
+      const response: EdgeFunction[] = [];
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await functions.list("my-namespace");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/functions?namespace=my-namespace"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle list error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Unauthorized"));
+
+      const { data, error } = await functions.list();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("get()", () => {
+    it("should get a specific function", async () => {
+      const response: EdgeFunction = {
+        id: "func-1",
+        name: "my-function",
+        namespace: "default",
+        version: 1,
+        enabled: true,
+        code: 'export default function handler() { return { ok: true } }',
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await functions.get("my-function");
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/functions/my-function");
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data!.name).toBe("my-function");
+    });
+
+    it("should handle get error for non-existent function", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Function not found"));
+
+      const { data, error } = await functions.get("non-existent");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+      expect(error!.message).toBe("Function not found");
+    });
+  });
+
+  describe("update()", () => {
+    it("should update a function", async () => {
+      const response: EdgeFunction = {
+        id: "func-1",
+        name: "my-function",
+        namespace: "default",
+        version: 2,
+        enabled: false,
+        description: "Updated description",
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T12:00:00Z",
+      };
+
+      vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+      const { data, error } = await functions.update("my-function", {
+        enabled: false,
+        description: "Updated description",
+      });
+
+      expect(mockFetch.put).toHaveBeenCalledWith("/api/v1/functions/my-function", {
+        enabled: false,
+        description: "Updated description",
+      });
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data!.version).toBe(2);
+    });
+
+    it("should handle update error", async () => {
+      vi.mocked(mockFetch.put).mockRejectedValue(new Error("Update failed"));
+
+      const { data, error } = await functions.update("my-function", {
+        enabled: true,
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("delete()", () => {
+    it("should delete a function", async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+      const { data, error } = await functions.delete("my-function");
+
+      expect(mockFetch.delete).toHaveBeenCalledWith(
+        "/api/v1/functions/my-function"
+      );
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("should handle delete error", async () => {
+      vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Delete failed"));
+
+      const { data, error } = await functions.delete("my-function");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("getExecutions()", () => {
+    it("should get function executions", async () => {
+      const response: EdgeFunctionExecution[] = [
+        {
+          id: "exec-1",
+          function_name: "my-function",
+          status: "success",
+          duration_ms: 150,
+          executed_at: "2024-01-26T10:00:00Z",
+        },
+        {
+          id: "exec-2",
+          function_name: "my-function",
+          status: "error",
+          duration_ms: 50,
+          error: "Timeout",
+          executed_at: "2024-01-26T11:00:00Z",
+        },
+      ];
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await functions.getExecutions("my-function");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/functions/my-function/executions"
+      );
+      expect(error).toBeNull();
+      expect(data).toHaveLength(2);
+    });
+
+    it("should get function executions with limit", async () => {
+      const response: EdgeFunctionExecution[] = [];
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await functions.getExecutions("my-function", 10);
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/functions/my-function/executions?limit=10"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle getExecutions error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await functions.getExecutions("my-function");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("sync()", () => {
+    it("should sync functions", async () => {
+      const response: SyncFunctionsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 2,
+          updated: 1,
+          deleted: 0,
+          unchanged: 3,
+          errors: 0,
+        },
+        details: {
+          created: ["new-func-1", "new-func-2"],
+          updated: ["updated-func"],
+          deleted: [],
+          unchanged: ["func-a", "func-b", "func-c"],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await functions.sync({
+        namespace: "default",
+        functions: [
+          { name: "new-func-1", code: "export default function() {}" },
+          { name: "new-func-2", code: "export default function() {}" },
+        ],
+        options: { delete_missing: false, dry_run: false },
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/functions/sync", {
+        namespace: "default",
+        functions: [
+          { name: "new-func-1", code: "export default function() {}" },
+          { name: "new-func-2", code: "export default function() {}" },
+        ],
+        options: { delete_missing: false, dry_run: false },
+      });
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data!.summary.created).toBe(2);
+    });
+
+    it("should handle sync error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Sync failed"));
+
+      const { data, error } = await functions.sync({
+        namespace: "default",
+        functions: [],
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("syncWithBundling()", () => {
+    it("should sync with empty functions array", async () => {
+      const syncResponse: SyncFunctionsResult = {
+        message: "Nothing to sync",
+        namespace: "default",
+        summary: {
+          created: 0,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: [],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      const { data, error } = await functions.syncWithBundling({
+        namespace: "default",
+        functions: [],
+      });
+
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should sync without functions (calls sync directly)", async () => {
+      const syncResponse: SyncFunctionsResult = {
+        message: "Synced from filesystem",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["func-1"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      const { data, error } = await functions.syncWithBundling({
+        namespace: "default",
+      });
+
+      expect(error).toBeNull();
+    });
+
+    it("should return error when esbuild is not available", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(false);
+
+      const { data, error } = await functions.syncWithBundling({
+        namespace: "default",
+        functions: [
+          { name: "func-1", code: 'import { foo } from "./bar"' },
+        ],
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+      expect(error!.message).toContain("esbuild is required");
+    });
+
+    it("should bundle functions before syncing", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(true);
+      vi.mocked(bundling.bundleCode).mockResolvedValue({
+        code: "// bundled code",
+        map: undefined,
+      });
+
+      const syncResponse: SyncFunctionsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["func-1"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      const { data, error } = await functions.syncWithBundling({
+        namespace: "default",
+        functions: [
+          { name: "func-1", code: 'import { foo } from "./bar"' },
+        ],
+      });
+
+      expect(bundling.bundleCode).toHaveBeenCalled();
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should skip bundling for pre-bundled functions", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(true);
+
+      const syncResponse: SyncFunctionsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["func-1"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      const { data, error } = await functions.syncWithBundling({
+        namespace: "default",
+        functions: [
+          {
+            name: "func-1",
+            code: "// already bundled",
+            is_pre_bundled: true,
+          },
+        ],
+      });
+
+      expect(bundling.bundleCode).not.toHaveBeenCalled();
+      expect(error).toBeNull();
+    });
+
+    it("should handle bundling error", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(true);
+      vi.mocked(bundling.bundleCode).mockRejectedValue(
+        new Error("Bundle failed")
+      );
+
+      const { data, error } = await functions.syncWithBundling({
+        namespace: "default",
+        functions: [
+          { name: "func-1", code: "invalid code syntax {{{" },
+        ],
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+      expect(error!.message).toBe("Bundle failed");
+    });
+
+    it("should use per-function sourceDir and nodePaths", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(true);
+      vi.mocked(bundling.bundleCode).mockResolvedValue({
+        code: "// bundled",
+        map: undefined,
+      });
+
+      const syncResponse: SyncFunctionsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["func-1"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      await functions.syncWithBundling(
+        {
+          namespace: "default",
+          functions: [
+            {
+              name: "func-1",
+              code: 'import x from "./local"',
+              sourceDir: "/custom/path",
+              nodePaths: ["/extra/modules"],
+            },
+          ],
+        },
+        { minify: true }
+      );
+
+      expect(bundling.bundleCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'import x from "./local"',
+          baseDir: "/custom/path",
+          nodePaths: ["/extra/modules"],
+          minify: true,
+        })
+      );
+    });
+  });
+
+  describe("bundleCode() static method", () => {
+    it("should call bundleCode utility", async () => {
+      vi.mocked(bundling.bundleCode).mockResolvedValue({
+        code: "// bundled",
+        map: undefined,
+      });
+
+      const result = await FluxbaseAdminFunctions.bundleCode({
+        code: 'export default function() { return "hello" }',
+      });
+
+      expect(bundling.bundleCode).toHaveBeenCalled();
+      expect(result.code).toBe("// bundled");
+    });
+  });
+});

--- a/sdk/src/admin-jobs.test.ts
+++ b/sdk/src/admin-jobs.test.ts
@@ -1,0 +1,806 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FluxbaseAdminJobs } from "./admin-jobs";
+import { FluxbaseFetch } from "./fetch";
+import * as bundling from "./bundling";
+import type {
+  JobFunction,
+  Job,
+  JobStats,
+  JobWorker,
+  SyncJobsResult,
+} from "./types";
+
+// Mock FluxbaseFetch
+vi.mock("./fetch");
+
+// Mock bundling module
+vi.mock("./bundling", async () => {
+  const actual = await vi.importActual("./bundling");
+  return {
+    ...actual,
+    bundleCode: vi.fn(),
+    loadEsbuild: vi.fn(),
+    loadImportMap: vi.fn(),
+    denoExternalPlugin: vi.fn(),
+  };
+});
+
+describe("FluxbaseAdminJobs", () => {
+  let jobs: FluxbaseAdminJobs;
+  let mockFetch: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    };
+    jobs = new FluxbaseAdminJobs(mockFetch as unknown as FluxbaseFetch);
+  });
+
+  describe("create()", () => {
+    it("should create a new job function", async () => {
+      const response: JobFunction = {
+        id: "job-1",
+        name: "process-data",
+        namespace: "default",
+        version: 1,
+        enabled: true,
+        timeout_seconds: 300,
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await jobs.create({
+        name: "process-data",
+        code: 'export async function handler(req) { return { success: true } }',
+        enabled: true,
+        timeout_seconds: 300,
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/jobs/functions", {
+        name: "process-data",
+        code: 'export async function handler(req) { return { success: true } }',
+        enabled: true,
+        timeout_seconds: 300,
+      });
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data!.name).toBe("process-data");
+    });
+
+    it("should handle create error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Job already exists"));
+
+      const { data, error } = await jobs.create({
+        name: "process-data",
+        code: "export async function handler() {}",
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("listNamespaces()", () => {
+    it("should list all namespaces", async () => {
+      const response = { namespaces: ["default", "batch"] };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await jobs.listNamespaces();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/jobs/namespaces");
+      expect(error).toBeNull();
+      expect(data).toEqual(["default", "batch"]);
+    });
+
+    it("should return default namespace when empty", async () => {
+      const response = { namespaces: null };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await jobs.listNamespaces();
+
+      expect(error).toBeNull();
+      expect(data).toEqual(["default"]);
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Network error"));
+
+      const { data, error } = await jobs.listNamespaces();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("list()", () => {
+    it("should list all job functions", async () => {
+      const response: JobFunction[] = [
+        {
+          id: "job-1",
+          name: "job-a",
+          namespace: "default",
+          version: 1,
+          enabled: true,
+          created_at: "2024-01-26T10:00:00Z",
+          updated_at: "2024-01-26T10:00:00Z",
+        },
+      ];
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await jobs.list();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/jobs/functions");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+
+    it("should list jobs by namespace", async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue([]);
+
+      const { data, error } = await jobs.list("batch");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/functions?namespace=batch"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Unauthorized"));
+
+      const { data, error } = await jobs.list();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("get()", () => {
+    it("should get a specific job function", async () => {
+      const response: JobFunction = {
+        id: "job-1",
+        name: "process-data",
+        namespace: "default",
+        version: 1,
+        enabled: true,
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await jobs.get("default", "process-data");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/functions/default/process-data"
+      );
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+      const { data, error } = await jobs.get("default", "unknown");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("update()", () => {
+    it("should update a job function", async () => {
+      const response: JobFunction = {
+        id: "job-1",
+        name: "process-data",
+        namespace: "default",
+        version: 2,
+        enabled: false,
+        timeout_seconds: 600,
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T12:00:00Z",
+      };
+
+      vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+      const { data, error } = await jobs.update("default", "process-data", {
+        enabled: false,
+        timeout_seconds: 600,
+      });
+
+      expect(mockFetch.put).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/functions/default/process-data",
+        { enabled: false, timeout_seconds: 600 }
+      );
+      expect(error).toBeNull();
+      expect(data!.version).toBe(2);
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.put).mockRejectedValue(new Error("Update failed"));
+
+      const { data, error } = await jobs.update("default", "process-data", {
+        enabled: true,
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("delete()", () => {
+    it("should delete a job function", async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+      const { data, error } = await jobs.delete("default", "process-data");
+
+      expect(mockFetch.delete).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/functions/default/process-data"
+      );
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Delete failed"));
+
+      const { data, error } = await jobs.delete("default", "process-data");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("listJobs()", () => {
+    it("should list all jobs", async () => {
+      const response: Job[] = [
+        {
+          id: "exec-1",
+          job_name: "process-data",
+          namespace: "default",
+          status: "completed",
+          created_at: "2024-01-26T10:00:00Z",
+        },
+      ];
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await jobs.listJobs();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/jobs/queue");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+
+    it("should list jobs with filters", async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue([]);
+
+      const { data, error } = await jobs.listJobs({
+        status: "running",
+        namespace: "default",
+        limit: 50,
+        offset: 10,
+        includeResult: true,
+      });
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/queue?status=running&namespace=default&limit=50&offset=10&include_result=true"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await jobs.listJobs();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("getJob()", () => {
+    it("should get a specific job", async () => {
+      const response: Job = {
+        id: "job-uuid",
+        job_name: "process-data",
+        namespace: "default",
+        status: "completed",
+        created_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await jobs.getJob("job-uuid");
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/jobs/queue/job-uuid");
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+      const { data, error } = await jobs.getJob("unknown");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("cancel()", () => {
+    it("should cancel a job", async () => {
+      vi.mocked(mockFetch.post).mockResolvedValue({});
+
+      const { data, error } = await jobs.cancel("job-uuid");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/queue/job-uuid/cancel",
+        {}
+      );
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Cannot cancel"));
+
+      const { data, error } = await jobs.cancel("job-uuid");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("terminate()", () => {
+    it("should terminate a job", async () => {
+      vi.mocked(mockFetch.post).mockResolvedValue({});
+
+      const { data, error } = await jobs.terminate("job-uuid");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/queue/job-uuid/terminate",
+        {}
+      );
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Cannot terminate"));
+
+      const { data, error } = await jobs.terminate("job-uuid");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("retry()", () => {
+    it("should retry a job", async () => {
+      const response: Job = {
+        id: "new-job-uuid",
+        job_name: "process-data",
+        namespace: "default",
+        status: "pending",
+        created_at: "2024-01-26T12:00:00Z",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await jobs.retry("job-uuid");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/queue/job-uuid/retry",
+        {}
+      );
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Cannot retry"));
+
+      const { data, error } = await jobs.retry("job-uuid");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("getStats()", () => {
+    it("should get job statistics", async () => {
+      const response: JobStats = {
+        pending: 5,
+        running: 2,
+        completed: 100,
+        failed: 3,
+        cancelled: 1,
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await jobs.getStats();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/jobs/stats");
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data!.pending).toBe(5);
+    });
+
+    it("should get stats by namespace", async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue({});
+
+      const { data, error } = await jobs.getStats("batch");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/jobs/stats?namespace=batch"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await jobs.getStats();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("listWorkers()", () => {
+    it("should list active workers", async () => {
+      const response: JobWorker[] = [
+        {
+          id: "worker-1",
+          hostname: "host-1",
+          current_jobs: 2,
+          max_concurrent: 5,
+          started_at: "2024-01-26T08:00:00Z",
+        },
+      ];
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await jobs.listWorkers();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/jobs/workers");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await jobs.listWorkers();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("sync()", () => {
+    it("should sync jobs with options object", async () => {
+      const response: SyncJobsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["new-job"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await jobs.sync({
+        namespace: "default",
+        functions: [{ name: "new-job", code: "export function handler() {}" }],
+        options: { delete_missing: true, dry_run: false },
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/jobs/sync", {
+        namespace: "default",
+        jobs: [{ name: "new-job", code: "export function handler() {}" }],
+        options: { delete_missing: true, dry_run: false },
+      });
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should sync with legacy string namespace", async () => {
+      const response: SyncJobsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 0,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: [],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await jobs.sync("default");
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/jobs/sync", {
+        namespace: "default",
+        jobs: undefined,
+        options: { delete_missing: false, dry_run: false },
+      });
+      expect(error).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Sync failed"));
+
+      const { data, error } = await jobs.sync({ namespace: "default" });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("syncWithBundling()", () => {
+    it("should sync with empty functions array", async () => {
+      const syncResponse: SyncJobsResult = {
+        message: "Nothing to sync",
+        namespace: "default",
+        summary: {
+          created: 0,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: [],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      const { data, error } = await jobs.syncWithBundling({
+        namespace: "default",
+        functions: [],
+      });
+
+      expect(error).toBeNull();
+    });
+
+    it("should sync without functions", async () => {
+      const syncResponse: SyncJobsResult = {
+        message: "Synced from filesystem",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["job-1"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      const { data, error } = await jobs.syncWithBundling({
+        namespace: "default",
+      });
+
+      expect(error).toBeNull();
+    });
+
+    it("should return error when esbuild is not available", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(false);
+
+      const { data, error } = await jobs.syncWithBundling({
+        namespace: "default",
+        functions: [{ name: "job-1", code: 'import { foo } from "./bar"' }],
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+      expect(error!.message).toContain("esbuild is required");
+    });
+
+    it("should bundle functions before syncing", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(true);
+      vi.mocked(bundling.bundleCode).mockResolvedValue({
+        code: "// bundled code",
+        map: undefined,
+      });
+
+      const syncResponse: SyncJobsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["job-1"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      const { data, error } = await jobs.syncWithBundling({
+        namespace: "default",
+        functions: [{ name: "job-1", code: 'import { foo } from "./bar"' }],
+      });
+
+      expect(bundling.bundleCode).toHaveBeenCalled();
+      expect(error).toBeNull();
+    });
+
+    it("should skip bundling for pre-bundled functions", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(true);
+
+      const syncResponse: SyncJobsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["job-1"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      const { data, error } = await jobs.syncWithBundling({
+        namespace: "default",
+        functions: [
+          { name: "job-1", code: "// already bundled", is_pre_bundled: true },
+        ],
+      });
+
+      expect(bundling.bundleCode).not.toHaveBeenCalled();
+      expect(error).toBeNull();
+    });
+
+    it("should handle bundling error", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(true);
+      vi.mocked(bundling.bundleCode).mockRejectedValue(
+        new Error("Bundle failed")
+      );
+
+      const { data, error } = await jobs.syncWithBundling({
+        namespace: "default",
+        functions: [{ name: "job-1", code: "invalid code {{{" }],
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+
+    it("should use per-function sourceDir and nodePaths", async () => {
+      vi.mocked(bundling.loadEsbuild).mockResolvedValue(true);
+      vi.mocked(bundling.bundleCode).mockResolvedValue({
+        code: "// bundled",
+        map: undefined,
+      });
+
+      const syncResponse: SyncJobsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["job-1"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(syncResponse);
+
+      await jobs.syncWithBundling(
+        {
+          namespace: "default",
+          functions: [
+            {
+              name: "job-1",
+              code: 'import x from "./local"',
+              sourceDir: "/custom/path",
+              nodePaths: ["/extra/modules"],
+            },
+          ],
+        },
+        { minify: true }
+      );
+
+      expect(bundling.bundleCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'import x from "./local"',
+          baseDir: "/custom/path",
+          nodePaths: ["/extra/modules"],
+          minify: true,
+        })
+      );
+    });
+  });
+
+  describe("bundleCode() static method", () => {
+    it("should call bundleCode utility", async () => {
+      vi.mocked(bundling.bundleCode).mockResolvedValue({
+        code: "// bundled",
+        map: undefined,
+      });
+
+      const result = await FluxbaseAdminJobs.bundleCode({
+        code: 'export async function handler() { return "hello" }',
+      });
+
+      expect(bundling.bundleCode).toHaveBeenCalled();
+      expect(result.code).toBe("// bundled");
+    });
+  });
+});

--- a/sdk/src/admin-migrations.test.ts
+++ b/sdk/src/admin-migrations.test.ts
@@ -1,0 +1,710 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FluxbaseAdminMigrations } from "./admin-migrations";
+import { FluxbaseFetch } from "./fetch";
+import type {
+  Migration,
+  MigrationExecution,
+  SyncMigrationsResult,
+} from "./types";
+
+// Mock FluxbaseFetch
+vi.mock("./fetch");
+
+describe("FluxbaseAdminMigrations", () => {
+  let migrations: FluxbaseAdminMigrations;
+  let mockFetch: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    };
+    migrations = new FluxbaseAdminMigrations(mockFetch as unknown as FluxbaseFetch);
+  });
+
+  describe("register()", () => {
+    it("should register a migration", () => {
+      const { error } = migrations.register({
+        name: "001_create_users",
+        namespace: "myapp",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+        down_sql: "DROP TABLE users",
+        description: "Create users table",
+      });
+
+      expect(error).toBeNull();
+    });
+
+    it("should register migration without namespace (default)", () => {
+      const { error } = migrations.register({
+        name: "001_create_users",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+      });
+
+      expect(error).toBeNull();
+    });
+
+    it("should return error when name is missing", () => {
+      const { error } = migrations.register({
+        name: "",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+      });
+
+      expect(error).toBeDefined();
+      expect(error!.message).toContain("name and up_sql are required");
+    });
+
+    it("should return error when up_sql is missing", () => {
+      const { error } = migrations.register({
+        name: "001_create_users",
+        up_sql: "",
+      });
+
+      expect(error).toBeDefined();
+      expect(error!.message).toContain("name and up_sql are required");
+    });
+  });
+
+  describe("sync()", () => {
+    it("should sync registered migrations", async () => {
+      // Register some migrations
+      migrations.register({
+        name: "001_create_users",
+        namespace: "myapp",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+        down_sql: "DROP TABLE users",
+      });
+
+      const response: SyncMigrationsResult = {
+        message: "Sync completed",
+        namespace: "myapp",
+        summary: {
+          created: 1,
+          updated: 0,
+          unchanged: 0,
+          skipped: 0,
+          applied: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["001_create_users"],
+          updated: [],
+          unchanged: [],
+          skipped: [],
+          applied: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await migrations.sync();
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/sync",
+        expect.objectContaining({
+          namespace: "myapp",
+          migrations: expect.arrayContaining([
+            expect.objectContaining({
+              name: "001_create_users",
+            }),
+          ]),
+        })
+      );
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data!.summary.created).toBe(1);
+    });
+
+    it("should sync with auto_apply option", async () => {
+      migrations.register({
+        name: "001_create_users",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+      });
+
+      const response: SyncMigrationsResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          unchanged: 0,
+          skipped: 0,
+          applied: 1,
+          errors: 0,
+        },
+        details: {
+          created: ["001_create_users"],
+          updated: [],
+          unchanged: [],
+          skipped: [],
+          applied: ["001_create_users"],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+      vi.mocked(mockFetch.post).mockResolvedValueOnce(response);
+      // Mock schema refresh
+      vi.mocked(mockFetch.post).mockResolvedValue({ message: "Refreshed", tables: 1, views: 0 });
+
+      const { data, error } = await migrations.sync({ auto_apply: true });
+
+      expect(error).toBeNull();
+    });
+
+    it("should handle dry_run option", async () => {
+      migrations.register({
+        name: "001_create_users",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+      });
+
+      const response: SyncMigrationsResult = {
+        message: "Dry run completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          unchanged: 0,
+          skipped: 0,
+          applied: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["001_create_users"],
+          updated: [],
+          unchanged: [],
+          skipped: [],
+          applied: [],
+          errors: [],
+        },
+        dry_run: true,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await migrations.sync({ dry_run: true });
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/sync",
+        expect.objectContaining({
+          options: expect.objectContaining({
+            dry_run: true,
+          }),
+        })
+      );
+      expect(error).toBeNull();
+      expect(data!.dry_run).toBe(true);
+    });
+
+    it("should handle sync errors with 422 status", async () => {
+      migrations.register({
+        name: "001_invalid",
+        namespace: "test",
+        up_sql: "INVALID SQL",
+      });
+
+      const syncError = new Error("Sync failed") as any;
+      syncError.status = 422;
+      syncError.details = {
+        message: "Sync failed with errors",
+        namespace: "test",
+        summary: {
+          created: 0,
+          updated: 0,
+          unchanged: 0,
+          skipped: 0,
+          applied: 0,
+          errors: 1,
+        },
+        details: {
+          created: [],
+          updated: [],
+          unchanged: [],
+          skipped: [],
+          applied: [],
+          errors: [{ name: "001_invalid", error: "Invalid SQL" }],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockRejectedValue(syncError);
+
+      const { data, error } = await migrations.sync();
+
+      expect(data).toBeDefined();
+      expect(error).toBeDefined();
+    });
+
+    it("should handle non-422 errors", async () => {
+      migrations.register({
+        name: "001_test",
+        up_sql: "CREATE TABLE test (id INT)",
+      });
+
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Network error"));
+
+      const { data, error } = await migrations.sync();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+      expect(error!.message).toBe("Network error");
+    });
+
+    it("should combine results from multiple namespaces", async () => {
+      migrations.register({
+        name: "001_ns1",
+        namespace: "ns1",
+        up_sql: "CREATE TABLE t1 (id INT)",
+      });
+      migrations.register({
+        name: "001_ns2",
+        namespace: "ns2",
+        up_sql: "CREATE TABLE t2 (id INT)",
+      });
+
+      const response1: SyncMigrationsResult = {
+        message: "Sync ns1",
+        namespace: "ns1",
+        summary: {
+          created: 1,
+          updated: 0,
+          unchanged: 0,
+          skipped: 0,
+          applied: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["001_ns1"],
+          updated: [],
+          unchanged: [],
+          skipped: [],
+          applied: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      const response2: SyncMigrationsResult = {
+        message: "Sync ns2",
+        namespace: "ns2",
+        summary: {
+          created: 1,
+          updated: 0,
+          unchanged: 0,
+          skipped: 0,
+          applied: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["001_ns2"],
+          updated: [],
+          unchanged: [],
+          skipped: [],
+          applied: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post)
+        .mockResolvedValueOnce(response1)
+        .mockResolvedValueOnce(response2);
+
+      const { data, error } = await migrations.sync();
+
+      expect(error).toBeNull();
+      expect(data!.summary.created).toBe(2);
+      expect(data!.details.created).toContain("001_ns1");
+      expect(data!.details.created).toContain("001_ns2");
+    });
+  });
+
+  describe("create()", () => {
+    it("should create a migration", async () => {
+      const response: Migration = {
+        id: "mig-1",
+        name: "001_create_users",
+        namespace: "myapp",
+        status: "pending",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+        down_sql: "DROP TABLE users",
+        created_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await migrations.create({
+        namespace: "myapp",
+        name: "001_create_users",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+        down_sql: "DROP TABLE users",
+        description: "Create users table",
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/migrations", {
+        namespace: "myapp",
+        name: "001_create_users",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+        down_sql: "DROP TABLE users",
+        description: "Create users table",
+      });
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should handle create error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Already exists"));
+
+      const { data, error } = await migrations.create({
+        name: "001_create_users",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+      });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("list()", () => {
+    it("should list migrations", async () => {
+      const response: Migration[] = [
+        {
+          id: "mig-1",
+          name: "001_create_users",
+          namespace: "default",
+          status: "applied",
+          created_at: "2024-01-26T10:00:00Z",
+        },
+        {
+          id: "mig-2",
+          name: "002_add_posts",
+          namespace: "default",
+          status: "pending",
+          created_at: "2024-01-26T11:00:00Z",
+        },
+      ];
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await migrations.list();
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations?namespace=default"
+      );
+      expect(error).toBeNull();
+      expect(data).toHaveLength(2);
+    });
+
+    it("should list migrations by namespace and status", async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue([]);
+
+      const { data, error } = await migrations.list("myapp", "pending");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations?namespace=myapp&status=pending"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await migrations.list();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("get()", () => {
+    it("should get a specific migration", async () => {
+      const response: Migration = {
+        id: "mig-1",
+        name: "001_create_users",
+        namespace: "default",
+        status: "applied",
+        up_sql: "CREATE TABLE users (id UUID PRIMARY KEY)",
+        created_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await migrations.get("001_create_users");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users?namespace=default"
+      );
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should get migration with namespace", async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue({});
+
+      await migrations.get("001_create_users", "myapp");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users?namespace=myapp"
+      );
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+      const { data, error } = await migrations.get("unknown");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("update()", () => {
+    it("should update a migration", async () => {
+      const response: Migration = {
+        id: "mig-1",
+        name: "001_create_users",
+        namespace: "default",
+        status: "pending",
+        description: "Updated description",
+        created_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+      const { data, error } = await migrations.update(
+        "001_create_users",
+        { description: "Updated description" }
+      );
+
+      expect(mockFetch.put).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users?namespace=default",
+        { description: "Updated description" }
+      );
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should update with namespace", async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue({});
+
+      await migrations.update(
+        "001_create_users",
+        { description: "Updated" },
+        "myapp"
+      );
+
+      expect(mockFetch.put).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users?namespace=myapp",
+        { description: "Updated" }
+      );
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.put).mockRejectedValue(new Error("Update failed"));
+
+      const { data, error } = await migrations.update("001_create_users", {});
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("delete()", () => {
+    it("should delete a migration", async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+      const { data, error } = await migrations.delete("001_create_users");
+
+      expect(mockFetch.delete).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users?namespace=default"
+      );
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("should delete with namespace", async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+      await migrations.delete("001_create_users", "myapp");
+
+      expect(mockFetch.delete).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users?namespace=myapp"
+      );
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Cannot delete"));
+
+      const { data, error } = await migrations.delete("001_create_users");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("apply()", () => {
+    it("should apply a migration", async () => {
+      const response = { message: "Migration applied successfully" };
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await migrations.apply("001_create_users");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users/apply",
+        { namespace: "default" }
+      );
+      expect(error).toBeNull();
+      expect(data!.message).toBe("Migration applied successfully");
+    });
+
+    it("should apply with namespace", async () => {
+      vi.mocked(mockFetch.post).mockResolvedValue({ message: "Applied" });
+
+      await migrations.apply("001_create_users", "myapp");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users/apply",
+        { namespace: "myapp" }
+      );
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Apply failed"));
+
+      const { data, error } = await migrations.apply("001_create_users");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("rollback()", () => {
+    it("should rollback a migration", async () => {
+      const response = { message: "Migration rolled back successfully" };
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await migrations.rollback("001_create_users");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users/rollback",
+        { namespace: "default" }
+      );
+      expect(error).toBeNull();
+      expect(data!.message).toBe("Migration rolled back successfully");
+    });
+
+    it("should rollback with namespace", async () => {
+      vi.mocked(mockFetch.post).mockResolvedValue({ message: "Rolled back" });
+
+      await migrations.rollback("001_create_users", "myapp");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users/rollback",
+        { namespace: "myapp" }
+      );
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Rollback failed"));
+
+      const { data, error } = await migrations.rollback("001_create_users");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("applyPending()", () => {
+    it("should apply all pending migrations", async () => {
+      const response = {
+        message: "Applied 2 migrations",
+        applied: ["001_create_users", "002_add_posts"],
+        failed: [],
+      };
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await migrations.applyPending();
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/apply-pending",
+        { namespace: "default" }
+      );
+      expect(error).toBeNull();
+      expect(data!.applied).toHaveLength(2);
+    });
+
+    it("should apply pending with namespace", async () => {
+      vi.mocked(mockFetch.post).mockResolvedValue({
+        message: "Applied",
+        applied: [],
+        failed: [],
+      });
+
+      await migrations.applyPending("myapp");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/apply-pending",
+        { namespace: "myapp" }
+      );
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Apply failed"));
+
+      const { data, error } = await migrations.applyPending();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("getExecutions()", () => {
+    it("should get execution history", async () => {
+      const response: MigrationExecution[] = [
+        {
+          id: "exec-1",
+          migration_name: "001_create_users",
+          action: "apply",
+          status: "success",
+          executed_at: "2024-01-26T10:00:00Z",
+          duration_ms: 150,
+        },
+      ];
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await migrations.getExecutions("001_create_users");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users/executions?namespace=default&limit=50"
+      );
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+
+    it("should get executions with custom namespace and limit", async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue([]);
+
+      await migrations.getExecutions("001_create_users", "myapp", 10);
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/migrations/001_create_users/executions?namespace=myapp&limit=10"
+      );
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await migrations.getExecutions("001_create_users");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+});

--- a/sdk/src/admin-realtime.test.ts
+++ b/sdk/src/admin-realtime.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FluxbaseAdminRealtime } from "./admin-realtime";
+import { FluxbaseFetch } from "./fetch";
+import type {
+  EnableRealtimeResponse,
+  RealtimeTableStatus,
+  ListRealtimeTablesResponse,
+} from "./types";
+
+// Mock FluxbaseFetch
+vi.mock("./fetch");
+
+describe("FluxbaseAdminRealtime", () => {
+  let realtime: FluxbaseAdminRealtime;
+  let mockFetch: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    };
+    realtime = new FluxbaseAdminRealtime(mockFetch as unknown as FluxbaseFetch);
+  });
+
+  describe("enableRealtime()", () => {
+    it("should enable realtime on a table", async () => {
+      const response: EnableRealtimeResponse = {
+        success: true,
+        message: "Realtime enabled for public.products",
+        schema: "public",
+        table: "products",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const result = await realtime.enableRealtime("products");
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/realtime/tables", {
+        schema: "public",
+        table: "products",
+        events: undefined,
+        exclude: undefined,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should enable realtime with custom schema", async () => {
+      const response: EnableRealtimeResponse = {
+        success: true,
+        message: "Realtime enabled for sales.orders",
+        schema: "sales",
+        table: "orders",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const result = await realtime.enableRealtime("orders", {
+        schema: "sales",
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/realtime/tables", {
+        schema: "sales",
+        table: "orders",
+        events: undefined,
+        exclude: undefined,
+      });
+      expect(result.schema).toBe("sales");
+    });
+
+    it("should enable realtime with specific events", async () => {
+      const response: EnableRealtimeResponse = {
+        success: true,
+        message: "Realtime enabled",
+        schema: "public",
+        table: "audit_log",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const result = await realtime.enableRealtime("audit_log", {
+        events: ["INSERT"],
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/realtime/tables", {
+        schema: "public",
+        table: "audit_log",
+        events: ["INSERT"],
+        exclude: undefined,
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should enable realtime with excluded columns", async () => {
+      const response: EnableRealtimeResponse = {
+        success: true,
+        message: "Realtime enabled",
+        schema: "public",
+        table: "posts",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const result = await realtime.enableRealtime("posts", {
+        exclude: ["content", "raw_html"],
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/realtime/tables", {
+        schema: "public",
+        table: "posts",
+        events: undefined,
+        exclude: ["content", "raw_html"],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("should enable realtime with all options", async () => {
+      const response: EnableRealtimeResponse = {
+        success: true,
+        message: "Realtime enabled",
+        schema: "app",
+        table: "documents",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const result = await realtime.enableRealtime("documents", {
+        schema: "app",
+        events: ["INSERT", "UPDATE"],
+        exclude: ["blob_data"],
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/realtime/tables", {
+        schema: "app",
+        table: "documents",
+        events: ["INSERT", "UPDATE"],
+        exclude: ["blob_data"],
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("disableRealtime()", () => {
+    it("should disable realtime on a table", async () => {
+      const response = {
+        success: true,
+        message: "Realtime disabled for public.products",
+      };
+
+      vi.mocked(mockFetch.delete).mockResolvedValue(response);
+
+      const result = await realtime.disableRealtime("public", "products");
+
+      expect(mockFetch.delete).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables/public/products"
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("should handle special characters in names", async () => {
+      const response = { success: true, message: "Disabled" };
+      vi.mocked(mockFetch.delete).mockResolvedValue(response);
+
+      await realtime.disableRealtime("my-schema", "my-table");
+
+      expect(mockFetch.delete).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables/my-schema/my-table"
+      );
+    });
+  });
+
+  describe("listTables()", () => {
+    it("should list all realtime-enabled tables", async () => {
+      const response: ListRealtimeTablesResponse = {
+        tables: [
+          {
+            schema: "public",
+            table: "products",
+            realtime_enabled: true,
+            events: ["INSERT", "UPDATE", "DELETE"],
+          },
+          {
+            schema: "public",
+            table: "orders",
+            realtime_enabled: true,
+            events: ["INSERT"],
+          },
+        ],
+        count: 2,
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const result = await realtime.listTables();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/realtime/tables");
+      expect(result.count).toBe(2);
+      expect(result.tables).toHaveLength(2);
+    });
+
+    it("should list tables including disabled", async () => {
+      const response: ListRealtimeTablesResponse = {
+        tables: [],
+        count: 0,
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const result = await realtime.listTables({ includeDisabled: true });
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables?enabled=false"
+      );
+    });
+
+    it("should list tables without options", async () => {
+      const response: ListRealtimeTablesResponse = {
+        tables: [],
+        count: 0,
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const result = await realtime.listTables();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/realtime/tables");
+    });
+  });
+
+  describe("getStatus()", () => {
+    it("should get realtime status for a table", async () => {
+      const response: RealtimeTableStatus = {
+        schema: "public",
+        table: "products",
+        realtime_enabled: true,
+        events: ["INSERT", "UPDATE", "DELETE"],
+        excluded_columns: ["internal_notes"],
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const result = await realtime.getStatus("public", "products");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables/public/products"
+      );
+      expect(result.realtime_enabled).toBe(true);
+      expect(result.events).toContain("INSERT");
+    });
+
+    it("should get status for disabled table", async () => {
+      const response: RealtimeTableStatus = {
+        schema: "public",
+        table: "archived",
+        realtime_enabled: false,
+        events: [],
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const result = await realtime.getStatus("public", "archived");
+
+      expect(result.realtime_enabled).toBe(false);
+    });
+
+    it("should handle special characters in table name", async () => {
+      const response: RealtimeTableStatus = {
+        schema: "my_schema",
+        table: "my_table",
+        realtime_enabled: true,
+        events: ["INSERT"],
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      await realtime.getStatus("my_schema", "my_table");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables/my_schema/my_table"
+      );
+    });
+  });
+
+  describe("updateConfig()", () => {
+    it("should update realtime config", async () => {
+      const response = {
+        success: true,
+        message: "Config updated",
+      };
+
+      vi.mocked(mockFetch.patch).mockResolvedValue(response);
+
+      const result = await realtime.updateConfig("public", "products", {
+        events: ["INSERT", "UPDATE"],
+      });
+
+      expect(mockFetch.patch).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables/public/products",
+        { events: ["INSERT", "UPDATE"] }
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("should update excluded columns", async () => {
+      const response = { success: true, message: "Updated" };
+      vi.mocked(mockFetch.patch).mockResolvedValue(response);
+
+      const result = await realtime.updateConfig("public", "posts", {
+        exclude: ["raw_content", "search_vector"],
+      });
+
+      expect(mockFetch.patch).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables/public/posts",
+        { exclude: ["raw_content", "search_vector"] }
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("should clear excluded columns", async () => {
+      const response = { success: true, message: "Updated" };
+      vi.mocked(mockFetch.patch).mockResolvedValue(response);
+
+      const result = await realtime.updateConfig("public", "posts", {
+        exclude: [],
+      });
+
+      expect(mockFetch.patch).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables/public/posts",
+        { exclude: [] }
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it("should update both events and exclude", async () => {
+      const response = { success: true, message: "Updated" };
+      vi.mocked(mockFetch.patch).mockResolvedValue(response);
+
+      const result = await realtime.updateConfig("app", "documents", {
+        events: ["INSERT"],
+        exclude: ["blob_data"],
+      });
+
+      expect(mockFetch.patch).toHaveBeenCalledWith(
+        "/api/v1/admin/realtime/tables/app/documents",
+        { events: ["INSERT"], exclude: ["blob_data"] }
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/sdk/src/admin-rpc.test.ts
+++ b/sdk/src/admin-rpc.test.ts
@@ -1,0 +1,536 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FluxbaseAdminRPC } from "./admin-rpc";
+import { FluxbaseFetch } from "./fetch";
+import type {
+  RPCProcedure,
+  RPCProcedureSummary,
+  RPCExecution,
+  RPCExecutionLog,
+  SyncRPCResult,
+} from "./types";
+
+// Mock FluxbaseFetch
+vi.mock("./fetch");
+
+describe("FluxbaseAdminRPC", () => {
+  let rpc: FluxbaseAdminRPC;
+  let mockFetch: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      delete: vi.fn(),
+    };
+    rpc = new FluxbaseAdminRPC(mockFetch as unknown as FluxbaseFetch);
+  });
+
+  describe("sync()", () => {
+    it("should sync RPC procedures without options", async () => {
+      const response: SyncRPCResult = {
+        message: "Sync completed",
+        namespace: "default",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["get-user-orders"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await rpc.sync();
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/rpc/sync", {
+        namespace: "default",
+        procedures: undefined,
+        options: { delete_missing: false, dry_run: false },
+      });
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+    });
+
+    it("should sync with provided procedures", async () => {
+      const response: SyncRPCResult = {
+        message: "Sync completed",
+        namespace: "custom",
+        summary: {
+          created: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+          errors: 0,
+        },
+        details: {
+          created: ["my-procedure"],
+          updated: [],
+          deleted: [],
+          unchanged: [],
+          errors: [],
+        },
+        dry_run: false,
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await rpc.sync({
+        namespace: "custom",
+        procedures: [{ name: "my-procedure", code: "SELECT * FROM users" }],
+        options: { delete_missing: true, dry_run: false },
+      });
+
+      expect(mockFetch.post).toHaveBeenCalledWith("/api/v1/admin/rpc/sync", {
+        namespace: "custom",
+        procedures: [{ name: "my-procedure", code: "SELECT * FROM users" }],
+        options: { delete_missing: true, dry_run: false },
+      });
+      expect(error).toBeNull();
+    });
+
+    it("should handle sync error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Sync failed"));
+
+      const { data, error } = await rpc.sync();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("list()", () => {
+    it("should list all procedures", async () => {
+      const response = {
+        procedures: [
+          {
+            id: "proc-1",
+            name: "get-user-orders",
+            namespace: "default",
+            enabled: true,
+          },
+          {
+            id: "proc-2",
+            name: "calculate-total",
+            namespace: "default",
+            enabled: true,
+          },
+        ] as RPCProcedureSummary[],
+        count: 2,
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.list();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/rpc/procedures");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(2);
+    });
+
+    it("should list procedures by namespace", async () => {
+      const response = { procedures: [], count: 0 };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.list("custom");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/procedures?namespace=custom"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle empty response", async () => {
+      const response = { procedures: null, count: 0 };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.list();
+
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await rpc.list();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("listNamespaces()", () => {
+    it("should list all namespaces", async () => {
+      const response = { namespaces: ["default", "custom", "admin"] };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.listNamespaces();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/rpc/namespaces");
+      expect(error).toBeNull();
+      expect(data).toEqual(["default", "custom", "admin"]);
+    });
+
+    it("should handle empty namespaces", async () => {
+      const response = { namespaces: null };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.listNamespaces();
+
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Network error"));
+
+      const { data, error } = await rpc.listNamespaces();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("get()", () => {
+    it("should get a specific procedure", async () => {
+      const response: RPCProcedure = {
+        id: "proc-1",
+        name: "get-user-orders",
+        namespace: "default",
+        sql_query: "SELECT * FROM orders WHERE user_id = $1",
+        enabled: true,
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.get("default", "get-user-orders");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/procedures/default/get-user-orders"
+      );
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data!.name).toBe("get-user-orders");
+    });
+
+    it("should handle special characters in names", async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue({});
+
+      await rpc.get("my-namespace", "my-procedure");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/procedures/my-namespace/my-procedure"
+      );
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+      const { data, error } = await rpc.get("default", "unknown");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("update()", () => {
+    it("should update a procedure", async () => {
+      const response: RPCProcedure = {
+        id: "proc-1",
+        name: "get-user-orders",
+        namespace: "default",
+        enabled: false,
+        max_execution_time_seconds: 60,
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T12:00:00Z",
+      };
+
+      vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+      const { data, error } = await rpc.update("default", "get-user-orders", {
+        enabled: false,
+        max_execution_time_seconds: 60,
+      });
+
+      expect(mockFetch.put).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/procedures/default/get-user-orders",
+        { enabled: false, max_execution_time_seconds: 60 }
+      );
+      expect(error).toBeNull();
+      expect(data!.enabled).toBe(false);
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.put).mockRejectedValue(new Error("Update failed"));
+
+      const { data, error } = await rpc.update("default", "proc", { enabled: true });
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("toggle()", () => {
+    it("should enable a procedure", async () => {
+      const response: RPCProcedure = {
+        id: "proc-1",
+        name: "get-user-orders",
+        namespace: "default",
+        enabled: true,
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T12:00:00Z",
+      };
+
+      vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+      const { data, error } = await rpc.toggle("default", "get-user-orders", true);
+
+      expect(mockFetch.put).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/procedures/default/get-user-orders",
+        { enabled: true }
+      );
+      expect(error).toBeNull();
+      expect(data!.enabled).toBe(true);
+    });
+
+    it("should disable a procedure", async () => {
+      const response: RPCProcedure = {
+        id: "proc-1",
+        name: "get-user-orders",
+        namespace: "default",
+        enabled: false,
+        created_at: "2024-01-26T10:00:00Z",
+        updated_at: "2024-01-26T12:00:00Z",
+      };
+
+      vi.mocked(mockFetch.put).mockResolvedValue(response);
+
+      const { data, error } = await rpc.toggle("default", "get-user-orders", false);
+
+      expect(mockFetch.put).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/procedures/default/get-user-orders",
+        { enabled: false }
+      );
+      expect(error).toBeNull();
+      expect(data!.enabled).toBe(false);
+    });
+  });
+
+  describe("delete()", () => {
+    it("should delete a procedure", async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+      const { data, error } = await rpc.delete("default", "get-user-orders");
+
+      expect(mockFetch.delete).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/procedures/default/get-user-orders"
+      );
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.delete).mockRejectedValue(new Error("Delete failed"));
+
+      const { data, error } = await rpc.delete("default", "proc");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("listExecutions()", () => {
+    it("should list all executions", async () => {
+      const response = {
+        executions: [
+          {
+            id: "exec-1",
+            procedure_name: "get-user-orders",
+            namespace: "default",
+            status: "success",
+            duration_ms: 50,
+            executed_at: "2024-01-26T10:00:00Z",
+          },
+        ] as RPCExecution[],
+        count: 1,
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.listExecutions();
+
+      expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/admin/rpc/executions");
+      expect(error).toBeNull();
+      expect(data).toHaveLength(1);
+    });
+
+    it("should list executions with filters", async () => {
+      const response = { executions: [], count: 0 };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.listExecutions({
+        namespace: "default",
+        procedure: "get-user-orders",
+        status: "failed",
+        user_id: "user-123",
+        limit: 10,
+        offset: 5,
+      });
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/executions?namespace=default&procedure_name=get-user-orders&status=failed&user_id=user-123&limit=10&offset=5"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle empty executions", async () => {
+      const response = { executions: null, count: 0 };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.listExecutions();
+
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await rpc.listExecutions();
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("getExecution()", () => {
+    it("should get a specific execution", async () => {
+      const response: RPCExecution = {
+        id: "exec-1",
+        procedure_name: "get-user-orders",
+        namespace: "default",
+        status: "success",
+        duration_ms: 50,
+        result: { orders: [] },
+        executed_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.getExecution("exec-1");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/executions/exec-1"
+      );
+      expect(error).toBeNull();
+      expect(data!.status).toBe("success");
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Not found"));
+
+      const { data, error } = await rpc.getExecution("unknown");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("getExecutionLogs()", () => {
+    it("should get execution logs", async () => {
+      const response = {
+        logs: [
+          { line: 1, level: "info", message: "Starting execution", timestamp: "2024-01-26T10:00:00Z" },
+          { line: 2, level: "info", message: "Query completed", timestamp: "2024-01-26T10:00:01Z" },
+        ] as RPCExecutionLog[],
+        count: 2,
+      };
+
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.getExecutionLogs("exec-1");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/executions/exec-1/logs"
+      );
+      expect(error).toBeNull();
+      expect(data).toHaveLength(2);
+    });
+
+    it("should get logs after specific line", async () => {
+      const response = { logs: [], count: 0 };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.getExecutionLogs("exec-1", 10);
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/executions/exec-1/logs?after=10"
+      );
+      expect(error).toBeNull();
+    });
+
+    it("should handle empty logs", async () => {
+      const response = { logs: null, count: 0 };
+      vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+      const { data, error } = await rpc.getExecutionLogs("exec-1");
+
+      expect(error).toBeNull();
+      expect(data).toEqual([]);
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+      const { data, error } = await rpc.getExecutionLogs("exec-1");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe("cancelExecution()", () => {
+    it("should cancel an execution", async () => {
+      const response: RPCExecution = {
+        id: "exec-1",
+        procedure_name: "get-user-orders",
+        namespace: "default",
+        status: "cancelled",
+        executed_at: "2024-01-26T10:00:00Z",
+      };
+
+      vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+      const { data, error } = await rpc.cancelExecution("exec-1");
+
+      expect(mockFetch.post).toHaveBeenCalledWith(
+        "/api/v1/admin/rpc/executions/exec-1/cancel",
+        {}
+      );
+      expect(error).toBeNull();
+      expect(data!.status).toBe("cancelled");
+    });
+
+    it("should handle error", async () => {
+      vi.mocked(mockFetch.post).mockRejectedValue(new Error("Cannot cancel"));
+
+      const { data, error } = await rpc.cancelExecution("exec-1");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+  });
+});

--- a/sdk/src/admin-storage.test.ts
+++ b/sdk/src/admin-storage.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { FluxbaseAdminStorage } from "./admin-storage";
+import { FluxbaseFetch } from "./fetch";
+import type {
+  AdminListBucketsResponse,
+  AdminListObjectsResponse,
+  AdminStorageObject,
+  SignedUrlResponse,
+} from "./types";
+
+// Mock FluxbaseFetch
+vi.mock("./fetch");
+
+describe("FluxbaseAdminStorage", () => {
+  let storage: FluxbaseAdminStorage;
+  let mockFetch: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      delete: vi.fn(),
+      getBlob: vi.fn(),
+    };
+    storage = new FluxbaseAdminStorage(mockFetch as unknown as FluxbaseFetch);
+  });
+
+  describe("Bucket Operations", () => {
+    describe("listBuckets()", () => {
+      it("should list all buckets", async () => {
+        const response: AdminListBucketsResponse = {
+          buckets: [
+            { name: "avatars", created_at: "2024-01-26T10:00:00Z" },
+            { name: "documents", created_at: "2024-01-26T11:00:00Z" },
+          ],
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await storage.listBuckets();
+
+        expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/storage/buckets");
+        expect(error).toBeNull();
+        expect(data).toBeDefined();
+        expect(data!.buckets).toHaveLength(2);
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Access denied"));
+
+        const { data, error } = await storage.listBuckets();
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+        expect(error!.message).toBe("Access denied");
+      });
+    });
+
+    describe("createBucket()", () => {
+      it("should create a bucket", async () => {
+        const response = { message: "Bucket created successfully" };
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const { data, error } = await storage.createBucket("my-bucket");
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/storage/buckets/my-bucket"
+        );
+        expect(error).toBeNull();
+        expect(data!.message).toBe("Bucket created successfully");
+      });
+
+      it("should handle special characters in bucket name", async () => {
+        vi.mocked(mockFetch.post).mockResolvedValue({ message: "Created" });
+
+        await storage.createBucket("my-bucket-123");
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/storage/buckets/my-bucket-123"
+        );
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(
+          new Error("Bucket already exists")
+        );
+
+        const { data, error } = await storage.createBucket("existing");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("deleteBucket()", () => {
+      it("should delete a bucket", async () => {
+        const response = { message: "Bucket deleted successfully" };
+        vi.mocked(mockFetch.delete).mockResolvedValue(response);
+
+        const { data, error } = await storage.deleteBucket("my-bucket");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith(
+          "/api/v1/storage/buckets/my-bucket"
+        );
+        expect(error).toBeNull();
+        expect(data!.message).toBe("Bucket deleted successfully");
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.delete).mockRejectedValue(
+          new Error("Bucket not empty")
+        );
+
+        const { data, error } = await storage.deleteBucket("my-bucket");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+  });
+
+  describe("Object Operations", () => {
+    describe("listObjects()", () => {
+      it("should list all objects in a bucket", async () => {
+        const response: AdminListObjectsResponse = {
+          objects: [
+            {
+              key: "file1.txt",
+              size: 1024,
+              content_type: "text/plain",
+              created_at: "2024-01-26T10:00:00Z",
+            },
+            {
+              key: "file2.pdf",
+              size: 2048,
+              content_type: "application/pdf",
+              created_at: "2024-01-26T11:00:00Z",
+            },
+          ],
+          prefixes: [],
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await storage.listObjects("my-bucket");
+
+        expect(mockFetch.get).toHaveBeenCalledWith("/api/v1/storage/my-bucket");
+        expect(error).toBeNull();
+        expect(data!.objects).toHaveLength(2);
+      });
+
+      it("should list objects with prefix", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({ objects: [], prefixes: [] });
+
+        await storage.listObjects("my-bucket", "folder/");
+
+        expect(mockFetch.get).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket?prefix=folder%2F"
+        );
+      });
+
+      it("should list objects with prefix and delimiter", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({ objects: [], prefixes: [] });
+
+        await storage.listObjects("my-bucket", "folder/", "/");
+
+        expect(mockFetch.get).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket?prefix=folder%2F&delimiter=%2F"
+        );
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Bucket not found"));
+
+        const { data, error } = await storage.listObjects("unknown");
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("getObjectMetadata()", () => {
+      it("should get object metadata", async () => {
+        const response: AdminStorageObject = {
+          key: "path/to/file.txt",
+          size: 1024,
+          content_type: "text/plain",
+          etag: '"abc123"',
+          created_at: "2024-01-26T10:00:00Z",
+          updated_at: "2024-01-26T10:00:00Z",
+        };
+
+        vi.mocked(mockFetch.get).mockResolvedValue(response);
+
+        const { data, error } = await storage.getObjectMetadata(
+          "my-bucket",
+          "path/to/file.txt"
+        );
+
+        expect(mockFetch.get).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/path/to/file.txt",
+          { headers: { "X-Metadata-Only": "true" } }
+        );
+        expect(error).toBeNull();
+        expect(data!.size).toBe(1024);
+      });
+
+      it("should handle special characters in key", async () => {
+        vi.mocked(mockFetch.get).mockResolvedValue({});
+
+        await storage.getObjectMetadata("my-bucket", "path/with spaces/file.txt");
+
+        expect(mockFetch.get).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/path/with%20spaces/file.txt",
+          { headers: { "X-Metadata-Only": "true" } }
+        );
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.get).mockRejectedValue(new Error("Object not found"));
+
+        const { data, error } = await storage.getObjectMetadata(
+          "my-bucket",
+          "unknown.txt"
+        );
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("downloadObject()", () => {
+      it("should download an object", async () => {
+        const mockBlob = new Blob(["file content"], { type: "text/plain" });
+        vi.mocked(mockFetch.getBlob).mockResolvedValue(mockBlob);
+
+        const { data, error } = await storage.downloadObject(
+          "my-bucket",
+          "file.txt"
+        );
+
+        expect(mockFetch.getBlob).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/file.txt"
+        );
+        expect(error).toBeNull();
+        expect(data).toBeInstanceOf(Blob);
+      });
+
+      it("should handle path with multiple segments", async () => {
+        const mockBlob = new Blob(["content"]);
+        vi.mocked(mockFetch.getBlob).mockResolvedValue(mockBlob);
+
+        await storage.downloadObject("my-bucket", "path/to/deep/file.pdf");
+
+        expect(mockFetch.getBlob).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/path/to/deep/file.pdf"
+        );
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.getBlob).mockRejectedValue(
+          new Error("Download failed")
+        );
+
+        const { data, error } = await storage.downloadObject(
+          "my-bucket",
+          "file.txt"
+        );
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("deleteObject()", () => {
+      it("should delete an object", async () => {
+        vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+        const { error } = await storage.deleteObject("my-bucket", "file.txt");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/file.txt"
+        );
+        expect(error).toBeNull();
+      });
+
+      it("should handle path with special characters", async () => {
+        vi.mocked(mockFetch.delete).mockResolvedValue({});
+
+        await storage.deleteObject("my-bucket", "path/with spaces/file.txt");
+
+        expect(mockFetch.delete).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/path/with%20spaces/file.txt"
+        );
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.delete).mockRejectedValue(
+          new Error("Delete failed")
+        );
+
+        const { error } = await storage.deleteObject("my-bucket", "file.txt");
+
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("createFolder()", () => {
+      it("should create a folder", async () => {
+        vi.mocked(mockFetch.post).mockResolvedValue({});
+
+        const { error } = await storage.createFolder("my-bucket", "new-folder/");
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/new-folder/",
+          null,
+          { headers: { "Content-Type": "application/x-directory" } }
+        );
+        expect(error).toBeNull();
+      });
+
+      it("should handle nested folder path", async () => {
+        vi.mocked(mockFetch.post).mockResolvedValue({});
+
+        await storage.createFolder("my-bucket", "path/to/folder/");
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/path/to/folder/",
+          null,
+          { headers: { "Content-Type": "application/x-directory" } }
+        );
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(
+          new Error("Create folder failed")
+        );
+
+        const { error } = await storage.createFolder("my-bucket", "folder/");
+
+        expect(error).toBeDefined();
+      });
+    });
+
+    describe("generateSignedUrl()", () => {
+      it("should generate a signed URL", async () => {
+        const response: SignedUrlResponse = {
+          url: "https://storage.example.com/my-bucket/file.pdf?token=abc123",
+          expires_in: 3600,
+        };
+
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        const { data, error } = await storage.generateSignedUrl(
+          "my-bucket",
+          "file.pdf",
+          3600
+        );
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/file.pdf/signed-url",
+          { expires_in: 3600 }
+        );
+        expect(error).toBeNull();
+        expect(data!.url).toContain("file.pdf");
+        expect(data!.expires_in).toBe(3600);
+      });
+
+      it("should handle path with segments", async () => {
+        const response: SignedUrlResponse = {
+          url: "https://storage.example.com/signed",
+          expires_in: 7200,
+        };
+        vi.mocked(mockFetch.post).mockResolvedValue(response);
+
+        await storage.generateSignedUrl("my-bucket", "path/to/file.pdf", 7200);
+
+        expect(mockFetch.post).toHaveBeenCalledWith(
+          "/api/v1/storage/my-bucket/path/to/file.pdf/signed-url",
+          { expires_in: 7200 }
+        );
+      });
+
+      it("should handle error", async () => {
+        vi.mocked(mockFetch.post).mockRejectedValue(
+          new Error("Failed to generate URL")
+        );
+
+        const { data, error } = await storage.generateSignedUrl(
+          "my-bucket",
+          "file.pdf",
+          3600
+        );
+
+        expect(data).toBeNull();
+        expect(error).toBeDefined();
+      });
+    });
+  });
+});

--- a/sdk/src/ai.test.ts
+++ b/sdk/src/ai.test.ts
@@ -2,18 +2,71 @@
  * AI Module Tests
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { FluxbaseAI, FluxbaseAIChat } from './ai'
 import type { AIChatbotSummary, AIChatbotLookupResponse, ListConversationsResult, AIUserConversationDetail } from './types'
 
-// Mock WebSocket constants (not available in Node.js)
-// Only need the constants, not a full mock, since these tests don't actually connect
-(global as any).WebSocket = {
-  CONNECTING: 0,
-  OPEN: 1,
-  CLOSING: 2,
-  CLOSED: 3,
-};
+// Mock WebSocket implementation
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  readyState = MockWebSocket.CONNECTING;
+  url: string;
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event: { error: Error }) => void) | null = null;
+
+  sentMessages: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  // Simulate successful connection
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    if (this.onopen) {
+      this.onopen();
+    }
+  }
+
+  // Simulate receiving a message
+  simulateMessage(data: object) {
+    if (this.onmessage) {
+      this.onmessage({ data: JSON.stringify(data) });
+    }
+  }
+
+  // Simulate connection close
+  simulateClose(code = 1000, reason = 'Normal closure') {
+    this.readyState = MockWebSocket.CLOSED;
+    if (this.onclose) {
+      this.onclose({ code, reason });
+    }
+  }
+
+  // Simulate error
+  simulateError(error = new Error('WebSocket error')) {
+    if (this.onerror) {
+      this.onerror({ error });
+    }
+  }
+
+  send(data: string) {
+    this.sentMessages.push(data);
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED;
+  }
+}
+
+// Install mock WebSocket globally
+(global as any).WebSocket = MockWebSocket;
 
 // Mock fetch interface
 class MockFetch {
@@ -339,6 +392,26 @@ describe('FluxbaseAI', () => {
 })
 
 describe('FluxbaseAIChat', () => {
+  let mockWs: MockWebSocket;
+  let originalWebSocket: any;
+
+  beforeEach(() => {
+    // Capture the WebSocket constructor to access the created instance
+    originalWebSocket = (global as any).WebSocket;
+    (global as any).WebSocket = function(url: string) {
+      mockWs = new MockWebSocket(url);
+      return mockWs;
+    };
+    (global as any).WebSocket.OPEN = MockWebSocket.OPEN;
+    (global as any).WebSocket.CLOSED = MockWebSocket.CLOSED;
+    (global as any).WebSocket.CONNECTING = MockWebSocket.CONNECTING;
+    (global as any).WebSocket.CLOSING = MockWebSocket.CLOSING;
+  });
+
+  afterEach(() => {
+    (global as any).WebSocket = originalWebSocket;
+  });
+
   describe('without connection', () => {
     it('should return false for isConnected when never connected', () => {
       const chat = new FluxbaseAIChat({
@@ -393,9 +466,746 @@ describe('FluxbaseAIChat', () => {
     })
   })
 
-  // Note: WebSocket-based tests (connect, sendMessage, startChat, message handling)
-  // require complex async mocking that is difficult to achieve reliably in unit tests.
-  // These are better covered by integration tests or E2E tests.
-  // The REST API methods (FluxbaseAI) are fully tested above.
+  describe('connect()', () => {
+    it('should connect successfully', async () => {
+      const onEvent = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onEvent,
+      });
+
+      const connectPromise = chat.connect();
+
+      // Simulate WebSocket opening
+      mockWs.simulateOpen();
+
+      await connectPromise;
+
+      expect(chat.isConnected()).toBe(true);
+      expect(onEvent).toHaveBeenCalledWith({ type: 'connected' });
+    });
+
+    it('should build URL with token', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        token: 'my-jwt-token',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      expect(mockWs.url).toBe('ws://localhost:8080/ai/ws?token=my-jwt-token');
+    });
+
+    it('should handle URL with existing query params and token', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws?param=value',
+        token: 'my-token',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      expect(mockWs.url).toBe('ws://localhost:8080/ai/ws?param=value&token=my-token');
+    });
+
+    it('should reject on WebSocket error', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+
+      // Simulate WebSocket error
+      mockWs.simulateError();
+
+      await expect(connectPromise).rejects.toThrow('WebSocket connection failed');
+    });
+
+    it('should use default wsUrl when not provided', async () => {
+      const chat = new FluxbaseAIChat({});
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      expect(mockWs.url).toBe('/ai/ws');
+    });
+  });
+
+  describe('disconnect()', () => {
+    it('should close WebSocket connection', async () => {
+      const onEvent = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onEvent,
+        reconnectAttempts: 0, // Disable reconnect for this test
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      chat.disconnect();
+
+      expect(mockWs.readyState).toBe(MockWebSocket.CLOSED);
+    });
+  });
+
+  describe('startChat()', () => {
+    it('should start chat and resolve with conversation ID', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      const startChatPromise = chat.startChat('sql-assistant', 'default');
+
+      // Simulate server response
+      mockWs.simulateMessage({
+        type: 'chat_started',
+        conversation_id: 'conv-123',
+        chatbot: 'sql-assistant',
+      });
+
+      const convId = await startChatPromise;
+      expect(convId).toBe('conv-123');
+
+      // Check the sent message
+      const sentMessage = JSON.parse(mockWs.sentMessages[0]);
+      expect(sentMessage.type).toBe('start_chat');
+      expect(sentMessage.chatbot).toBe('sql-assistant');
+      expect(sentMessage.namespace).toBe('default');
+    });
+
+    it('should use default namespace when not provided and no lookup function', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      const startChatPromise = chat.startChat('sql-assistant');
+      mockWs.simulateMessage({
+        type: 'chat_started',
+        conversation_id: 'conv-123',
+      });
+      await startChatPromise;
+
+      const sentMessage = JSON.parse(mockWs.sentMessages[0]);
+      expect(sentMessage.namespace).toBe('default');
+    });
+
+    it('should use smart namespace resolution with _lookupChatbot', async () => {
+      const lookupMock = vi.fn().mockResolvedValue({
+        data: { chatbot: { name: 'sql-assistant', namespace: 'custom' } },
+        error: null,
+      });
+
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        _lookupChatbot: lookupMock,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      // Start chat (this triggers the lookup)
+      const startChatPromise = chat.startChat('sql-assistant');
+
+      // Wait for the lookup to complete and the message to be sent
+      await vi.waitFor(() => expect(mockWs.sentMessages.length).toBeGreaterThan(0), { timeout: 1000 });
+
+      // Now simulate server response
+      mockWs.simulateMessage({
+        type: 'chat_started',
+        conversation_id: 'conv-123',
+      });
+
+      await startChatPromise;
+
+      expect(lookupMock).toHaveBeenCalledWith('sql-assistant');
+      const sentMessage = JSON.parse(mockWs.sentMessages[0]);
+      expect(sentMessage.namespace).toBe('custom');
+    });
+
+    it('should throw on lookup error', async () => {
+      const lookupMock = vi.fn().mockResolvedValue({
+        data: null,
+        error: new Error('Lookup failed'),
+      });
+
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        _lookupChatbot: lookupMock,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      await expect(chat.startChat('sql-assistant')).rejects.toThrow('Failed to lookup chatbot: Lookup failed');
+    });
+
+    it('should throw when chatbot not found', async () => {
+      const lookupMock = vi.fn().mockResolvedValue({
+        data: null,
+        error: null,
+      });
+
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        _lookupChatbot: lookupMock,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      await expect(chat.startChat('unknown')).rejects.toThrow("Chatbot 'unknown' not found");
+    });
+
+    it('should throw on ambiguous chatbot', async () => {
+      const lookupMock = vi.fn().mockResolvedValue({
+        data: {
+          ambiguous: true,
+          namespaces: ['ns1', 'ns2'],
+        },
+        error: null,
+      });
+
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        _lookupChatbot: lookupMock,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      await expect(chat.startChat('common')).rejects.toThrow(
+        "Chatbot 'common' exists in multiple namespaces: ns1, ns2"
+      );
+    });
+
+    it('should throw when lookup returns error message', async () => {
+      const lookupMock = vi.fn().mockResolvedValue({
+        data: { error: 'Permission denied' },
+        error: null,
+      });
+
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        _lookupChatbot: lookupMock,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      await expect(chat.startChat('sql-assistant')).rejects.toThrow('Permission denied');
+    });
+
+    it('should include impersonate_user_id when provided', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      const startChatPromise = chat.startChat('sql-assistant', 'default', undefined, 'user-456');
+      mockWs.simulateMessage({
+        type: 'chat_started',
+        conversation_id: 'conv-123',
+      });
+      await startChatPromise;
+
+      const sentMessage = JSON.parse(mockWs.sentMessages[0]);
+      expect(sentMessage.impersonate_user_id).toBe('user-456');
+    });
+
+    it('should include conversation_id when resuming', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      const startChatPromise = chat.startChat('sql-assistant', 'default', 'existing-conv');
+      mockWs.simulateMessage({
+        type: 'chat_started',
+        conversation_id: 'existing-conv',
+      });
+      await startChatPromise;
+
+      const sentMessage = JSON.parse(mockWs.sentMessages[0]);
+      expect(sentMessage.conversation_id).toBe('existing-conv');
+    });
+
+    it('should reject on server error during startChat', async () => {
+      const onError = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onError,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      const startChatPromise = chat.startChat('sql-assistant');
+
+      // Simulate error response
+      mockWs.simulateMessage({
+        type: 'error',
+        error: 'Chatbot not found',
+        code: 'NOT_FOUND',
+      });
+
+      await expect(startChatPromise).rejects.toThrow('Chatbot not found');
+      expect(onError).toHaveBeenCalledWith('Chatbot not found', 'NOT_FOUND', undefined);
+    });
+  });
+
+  describe('sendMessage()', () => {
+    it('should send message to conversation', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      chat.sendMessage('conv-123', 'Hello, how are you?');
+
+      const sentMessage = JSON.parse(mockWs.sentMessages[0]);
+      expect(sentMessage.type).toBe('message');
+      expect(sentMessage.conversation_id).toBe('conv-123');
+      expect(sentMessage.content).toBe('Hello, how are you?');
+    });
+
+    it('should reset accumulated content when sending message', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      chat.sendMessage('conv-123', 'First message');
+      expect(chat.getAccumulatedContent('conv-123')).toBe('');
+    });
+  });
+
+  describe('cancel()', () => {
+    it('should send cancel message', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      chat.cancel('conv-123');
+
+      const sentMessage = JSON.parse(mockWs.sentMessages[0]);
+      expect(sentMessage.type).toBe('cancel');
+      expect(sentMessage.conversation_id).toBe('conv-123');
+    });
+  });
+
+  describe('message handling', () => {
+    it('should handle content messages and accumulate', async () => {
+      const onContent = vi.fn();
+      const onEvent = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onContent,
+        onEvent,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      // Clear the connected event
+      onEvent.mockClear();
+
+      mockWs.simulateMessage({
+        type: 'content',
+        conversation_id: 'conv-123',
+        delta: 'Hello',
+      });
+
+      mockWs.simulateMessage({
+        type: 'content',
+        conversation_id: 'conv-123',
+        delta: ' world',
+      });
+
+      expect(onContent).toHaveBeenCalledTimes(2);
+      expect(onContent).toHaveBeenCalledWith('Hello', 'conv-123');
+      expect(onContent).toHaveBeenCalledWith(' world', 'conv-123');
+      expect(chat.getAccumulatedContent('conv-123')).toBe('Hello world');
+    });
+
+    it('should handle progress messages', async () => {
+      const onProgress = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onProgress,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'progress',
+        conversation_id: 'conv-123',
+        step: 'query_generation',
+        message: 'Generating SQL query...',
+      });
+
+      expect(onProgress).toHaveBeenCalledWith(
+        'query_generation',
+        'Generating SQL query...',
+        'conv-123'
+      );
+    });
+
+    it('should handle query_result messages', async () => {
+      const onQueryResult = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onQueryResult,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'query_result',
+        conversation_id: 'conv-123',
+        query: 'SELECT * FROM users',
+        summary: 'Found 10 users',
+        row_count: 10,
+        data: [{ id: 1, name: 'Alice' }],
+      });
+
+      expect(onQueryResult).toHaveBeenCalledWith(
+        'SELECT * FROM users',
+        'Found 10 users',
+        10,
+        [{ id: 1, name: 'Alice' }],
+        'conv-123'
+      );
+    });
+
+    it('should handle tool_result messages with query data', async () => {
+      const onQueryResult = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onQueryResult,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'tool_result',
+        conversation_id: 'conv-123',
+        query: 'SELECT COUNT(*) FROM orders',
+        summary: '500 orders total',
+        row_count: 1,
+        data: [{ count: 500 }],
+      });
+
+      expect(onQueryResult).toHaveBeenCalledWith(
+        'SELECT COUNT(*) FROM orders',
+        '500 orders total',
+        1,
+        [{ count: 500 }],
+        'conv-123'
+      );
+    });
+
+    it('should handle done messages', async () => {
+      const onDone = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onDone,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'done',
+        conversation_id: 'conv-123',
+        usage: {
+          total_tokens: 150,
+          prompt_tokens: 100,
+          completion_tokens: 50,
+        },
+      });
+
+      expect(onDone).toHaveBeenCalledWith(
+        { total_tokens: 150, prompt_tokens: 100, completion_tokens: 50 },
+        'conv-123'
+      );
+    });
+
+    it('should handle error messages', async () => {
+      const onError = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onError,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'error',
+        conversation_id: 'conv-123',
+        error: 'Query execution failed',
+        code: 'QUERY_ERROR',
+      });
+
+      expect(onError).toHaveBeenCalledWith('Query execution failed', 'QUERY_ERROR', 'conv-123');
+    });
+
+    it('should handle error messages with default values', async () => {
+      const onError = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onError,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'error',
+      });
+
+      expect(onError).toHaveBeenCalledWith('Unknown error', undefined, undefined);
+    });
+
+    it('should handle invalid JSON gracefully', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      // Manually trigger invalid message
+      if (mockWs.onmessage) {
+        mockWs.onmessage({ data: 'invalid json {' });
+      }
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should emit events for all message types', async () => {
+      const onEvent = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onEvent,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+      onEvent.mockClear();
+
+      mockWs.simulateMessage({
+        type: 'progress',
+        conversation_id: 'conv-123',
+        chatbot: 'sql-assistant',
+        step: 'thinking',
+        message: 'Processing...',
+      });
+
+      expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'progress',
+        conversationId: 'conv-123',
+        chatbot: 'sql-assistant',
+        step: 'thinking',
+        message: 'Processing...',
+      }));
+    });
+  });
+
+  describe('connection close and reconnect', () => {
+    it('should emit disconnected event on close', async () => {
+      const onEvent = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onEvent,
+        reconnectAttempts: 0,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+      onEvent.mockClear();
+
+      mockWs.simulateClose();
+
+      expect(onEvent).toHaveBeenCalledWith({ type: 'disconnected' });
+    });
+
+    it('should attempt reconnect on close', async () => {
+      vi.useFakeTimers();
+
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        reconnectAttempts: 3,
+        reconnectDelay: 1000,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      // Close connection to trigger reconnect
+      mockWs.simulateClose();
+
+      // Fast-forward past the reconnect delay
+      vi.advanceTimersByTime(1000);
+
+      // A new WebSocket should have been created
+      expect(mockWs.url).toBe('ws://localhost:8080/ai/ws');
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('content accumulation without callback', () => {
+    it('should accumulate content even without onContent callback', async () => {
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'content',
+        conversation_id: 'conv-123',
+        delta: 'Test content',
+      });
+
+      expect(chat.getAccumulatedContent('conv-123')).toBe('Test content');
+    });
+  });
+
+  describe('callbacks with missing data', () => {
+    it('should not call onProgress without required fields', async () => {
+      const onProgress = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onProgress,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'progress',
+        conversation_id: 'conv-123',
+        // Missing step and message
+      });
+
+      expect(onProgress).not.toHaveBeenCalled();
+    });
+
+    it('should not call onQueryResult without conversation_id', async () => {
+      const onQueryResult = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onQueryResult,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'query_result',
+        // Missing conversation_id
+        query: 'SELECT 1',
+      });
+
+      expect(onQueryResult).not.toHaveBeenCalled();
+    });
+
+    it('should not call onDone without conversation_id', async () => {
+      const onDone = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onDone,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'done',
+        // Missing conversation_id
+      });
+
+      expect(onDone).not.toHaveBeenCalled();
+    });
+
+    it('should not accumulate content without conversation_id or delta', async () => {
+      const onContent = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onContent,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      mockWs.simulateMessage({
+        type: 'content',
+        // Missing conversation_id
+        delta: 'test',
+      });
+
+      expect(onContent).not.toHaveBeenCalled();
+    });
+  });
 })
 

--- a/sdk/src/realtime.test.ts
+++ b/sdk/src/realtime.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { FluxbaseRealtime, RealtimeChannel } from "./realtime";
+import { FluxbaseRealtime, RealtimeChannel, ExecutionLogsChannel } from "./realtime";
 
 // Mock CloseEvent (not available in Node.js)
 class MockCloseEvent extends Event {
@@ -806,6 +806,761 @@ describe("FluxbaseRealtime - Token Refresh Callback", () => {
 
     // Callback is set - not called until needed
     expect(refreshCallback).not.toHaveBeenCalled();
+
+    realtime.removeAllChannels();
+  });
+
+  it("should set token refresh callback on existing channels", () => {
+    const realtime = new FluxbaseRealtime("http://localhost:8080", "test-token");
+    const channel = realtime.channel("test");
+    const refreshCallback = vi.fn().mockResolvedValue("new-token");
+
+    realtime.setTokenRefreshCallback(refreshCallback);
+
+    // Verify callback is set on channel
+    const setCallbackSpy = vi.spyOn(channel, 'setTokenRefreshCallback');
+    realtime.setTokenRefreshCallback(refreshCallback);
+    expect(setCallbackSpy).toHaveBeenCalledWith(refreshCallback);
+
+    realtime.removeAllChannels();
+  });
+});
+
+describe("RealtimeChannel - off() method", () => {
+  let channel: RealtimeChannel;
+
+  beforeEach(async () => {
+    channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test-channel",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  });
+
+  afterEach(async () => {
+    await channel.unsubscribe();
+  });
+
+  it("should remove callback with off()", async () => {
+    const callback = vi.fn();
+    channel.on("INSERT", callback);
+
+    // Verify callback is added
+    lastMockWebSocket!.simulateMessage({
+      type: "postgres_changes",
+      payload: { type: "INSERT", table: "test" },
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // Remove callback
+    channel.off("INSERT", callback);
+
+    // Callback should no longer be called
+    lastMockWebSocket!.simulateMessage({
+      type: "postgres_changes",
+      payload: { type: "INSERT", table: "test" },
+    });
+    expect(callback).toHaveBeenCalledTimes(1); // Still 1, not 2
+  });
+
+  it("should handle off() for non-existent event", () => {
+    const callback = vi.fn();
+    // Should not throw
+    channel.off("DELETE", callback);
+    expect(true).toBe(true);
+  });
+});
+
+describe("RealtimeChannel - Subscribe Status Callback", () => {
+  it("should call callback with SUBSCRIBED status", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+
+    const statusCallback = vi.fn();
+    channel.subscribe(statusCallback);
+
+    // Wait for connection
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(statusCallback).toHaveBeenCalledWith("SUBSCRIBED");
+
+    await channel.unsubscribe();
+  });
+
+  it("should call callback with CHANNEL_ERROR on connection failure", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+
+    const statusCallback = vi.fn();
+    channel.subscribe(statusCallback);
+
+    // Wait for connection then close it
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    lastMockWebSocket!.close();
+
+    // Wait for status check
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(statusCallback).toHaveBeenCalledWith("CHANNEL_ERROR", expect.any(Error));
+  });
+});
+
+describe("RealtimeChannel - Unsubscribe with Subscription IDs", () => {
+  it("should send unsubscribe for each subscription ID", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Simulate server sending subscription acknowledgment
+    lastMockWebSocket!.simulateMessage({
+      type: "ack",
+      payload: {
+        subscription_id: "sub-123",
+        schema: "public",
+        table: "users",
+      },
+    });
+
+    await channel.unsubscribe();
+
+    // Should have sent unsubscribe message
+    const unsubscribeMsg = lastMockWebSocket!.sentMessages.find((msg) => {
+      const parsed = JSON.parse(msg);
+      return parsed.type === "unsubscribe";
+    });
+    expect(unsubscribeMsg).toBeDefined();
+  });
+
+  it("should return ok when already unsubscribed", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+
+    // Never subscribed, so ws is null
+    const result = await channel.unsubscribe();
+    expect(result).toBe("ok");
+  });
+});
+
+describe("RealtimeChannel - Broadcast with Acknowledgment", () => {
+  let channel: RealtimeChannel;
+
+  beforeEach(async () => {
+    channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "chat",
+      "test-token",
+      { broadcast: { ack: true, ackTimeout: 1000 } },
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  });
+
+  afterEach(async () => {
+    await channel.unsubscribe();
+  });
+
+  it("should wait for acknowledgment when ack is enabled", async () => {
+    const sendPromise = channel.send({
+      type: "broadcast",
+      event: "message",
+      payload: { text: "Hello" },
+    });
+
+    // Simulate ack response
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const sentMsg = lastMockWebSocket!.sentMessages.find((msg) => {
+      const parsed = JSON.parse(msg);
+      return parsed.type === "broadcast";
+    });
+    const parsedSentMsg = JSON.parse(sentMsg!);
+
+    lastMockWebSocket!.simulateMessage({
+      type: "ack",
+      messageId: parsedSentMsg.messageId,
+      status: "ok",
+    });
+
+    const result = await sendPromise;
+    expect(result).toBe("ok");
+  });
+
+  it("should return error when not connected", async () => {
+    await channel.unsubscribe();
+
+    const result = await channel.send({
+      type: "broadcast",
+      event: "message",
+      payload: { text: "Hello" },
+    });
+
+    expect(result).toBe("error");
+  });
+
+  it("should return error on send failure", async () => {
+    // Create a channel with ack but force an error
+    const errorChannel = new RealtimeChannel(
+      "http://localhost:8080",
+      "error-test",
+      "test-token",
+      { broadcast: { ack: true, ackTimeout: 100 } },
+    );
+    errorChannel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const result = await errorChannel.send({
+      type: "broadcast",
+      event: "test",
+      payload: {},
+    });
+
+    // Will timeout since no ack is sent
+    expect(result).toBe("error");
+
+    await errorChannel.unsubscribe();
+  });
+});
+
+describe("RealtimeChannel - Broadcast Self-filtering", () => {
+  it("should filter self-messages when self is false", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "chat",
+      "test-token",
+      { broadcast: { self: false } },
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const callback = vi.fn();
+    channel.on("broadcast", { event: "message" }, callback);
+
+    // Simulate self-message from server
+    lastMockWebSocket!.simulateMessage({
+      type: "broadcast",
+      broadcast: {
+        event: "message",
+        payload: { text: "My message" },
+        self: true,
+      },
+    });
+
+    // Should be filtered out
+    expect(callback).not.toHaveBeenCalled();
+
+    await channel.unsubscribe();
+  });
+
+  it("should receive wildcard broadcast events", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "chat",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const callback = vi.fn();
+    channel.on("broadcast", { event: "*" }, callback);
+
+    // Simulate broadcast message
+    lastMockWebSocket!.simulateMessage({
+      type: "broadcast",
+      broadcast: {
+        event: "any-event",
+        payload: { data: "test" },
+      },
+    });
+
+    expect(callback).toHaveBeenCalled();
+
+    await channel.unsubscribe();
+  });
+});
+
+describe("RealtimeChannel - Presence Events", () => {
+  it("should receive join events", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "room",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const callback = vi.fn();
+    channel.on("presence", { event: "join" }, callback);
+
+    lastMockWebSocket!.simulateMessage({
+      type: "presence",
+      presence: {
+        event: "join",
+        key: "user-1",
+        newPresences: [{ status: "online" }],
+      },
+    });
+
+    expect(callback).toHaveBeenCalled();
+
+    await channel.unsubscribe();
+  });
+
+  it("should receive leave events", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "room",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const callback = vi.fn();
+    channel.on("presence", { event: "leave" }, callback);
+
+    lastMockWebSocket!.simulateMessage({
+      type: "presence",
+      presence: {
+        event: "leave",
+        key: "user-1",
+        leftPresences: [{ status: "online" }],
+      },
+    });
+
+    expect(callback).toHaveBeenCalled();
+
+    await channel.unsubscribe();
+  });
+
+  it("should update presence state on sync", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "room",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    channel.on("presence", { event: "sync" }, vi.fn());
+
+    lastMockWebSocket!.simulateMessage({
+      type: "presence",
+      presence: {
+        event: "sync",
+        currentPresences: {
+          "user-1": [{ status: "online" }],
+          "user-2": [{ status: "away" }],
+        },
+      },
+    });
+
+    const state = channel.presenceState();
+    expect(state["user-1"]).toBeDefined();
+    expect(state["user-2"]).toBeDefined();
+
+    await channel.unsubscribe();
+  });
+});
+
+describe("RealtimeChannel - Track and Untrack", () => {
+  it("should use custom presence key when provided", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "room",
+      "test-token",
+      { presence: { key: "my-custom-key" } },
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    await channel.track({ user: "john" });
+
+    const presenceMsg = lastMockWebSocket!.sentMessages.find((msg) => {
+      const parsed = JSON.parse(msg);
+      return parsed.type === "presence" && parsed.event === "track";
+    });
+
+    expect(presenceMsg).toBeDefined();
+    const parsed = JSON.parse(presenceMsg!);
+    expect(parsed.payload.key).toBe("my-custom-key");
+
+    await channel.unsubscribe();
+  });
+
+  it("should return error when track is called without connection", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "room",
+      "test-token",
+    );
+
+    const result = await channel.track({ user: "john" });
+    expect(result).toBe("error");
+  });
+
+  it("should return ok when untrack called without previous track", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "room",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const result = await channel.untrack();
+    expect(result).toBe("ok");
+
+    await channel.unsubscribe();
+  });
+
+  it("should return error when untrack called without connection", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "room",
+      "test-token",
+    );
+
+    // First need to have tracked something
+    (channel as any).myPresenceKey = "test-key";
+
+    const result = await channel.untrack();
+    expect(result).toBe("error");
+  });
+});
+
+describe("RealtimeChannel - Token Handling", () => {
+  it("should not send update when token is the same", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const initialMsgCount = lastMockWebSocket!.sentMessages.length;
+
+    // Update with same token
+    channel.updateToken("test-token");
+
+    // No new message should be sent
+    expect(lastMockWebSocket!.sentMessages.length).toBe(initialMsgCount);
+
+    await channel.unsubscribe();
+  });
+
+  it("should reconnect when token is set to null", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    channel.updateToken(null);
+
+    // Should trigger reconnect - new WebSocket will be created
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(lastMockWebSocket).not.toBeNull();
+
+    await channel.unsubscribe();
+  });
+
+  it("should not send update when not connected", () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+
+    // Not subscribed, so ws is null
+    channel.updateToken("new-token");
+
+    // Should not throw
+    expect(true).toBe(true);
+  });
+});
+
+describe("RealtimeChannel - Execution Log Events", () => {
+  it("should receive execution log events", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "execution:123",
+      "test-token",
+    );
+
+    const callback = vi.fn();
+    channel.on("execution_log", { execution_id: "123", type: "function" }, callback);
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Simulate execution log event
+    lastMockWebSocket!.simulateMessage({
+      type: "execution_log",
+      payload: {
+        execution_id: "123",
+        level: "info",
+        message: "Function started",
+        timestamp: new Date().toISOString(),
+      },
+    });
+
+    expect(callback).toHaveBeenCalled();
+
+    await channel.unsubscribe();
+  });
+});
+
+describe("RealtimeChannel - Message Handling", () => {
+  it("should handle malformed JSON gracefully", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Simulate malformed message
+    if (lastMockWebSocket!.onmessage) {
+      lastMockWebSocket!.onmessage(
+        new MessageEvent("message", { data: "invalid json{" }),
+      );
+    }
+
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+
+    await channel.unsubscribe();
+  });
+
+  it("should handle ack with subscription_id in payload", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Simulate ack with subscription_id
+    lastMockWebSocket!.simulateMessage({
+      type: "ack",
+      payload: {
+        type: "subscription",
+        subscription_id: "sub-456",
+        schema: "public",
+        table: "posts",
+      },
+    });
+
+    // No error should be thrown
+    expect(true).toBe(true);
+
+    await channel.unsubscribe();
+  });
+
+  it("should handle ack for access_token update", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // First update token to set up the pending ack
+    channel.updateToken("new-token");
+
+    // Then simulate ack response
+    lastMockWebSocket!.simulateMessage({
+      type: "ack",
+      payload: {
+        type: "access_token",
+        updated: true,
+      },
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Token updated"));
+    consoleSpy.mockRestore();
+
+    await channel.unsubscribe();
+  });
+
+  it("should handle error message when access_token update pending", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Update token to set up the pending ack
+    channel.updateToken("new-token");
+
+    // Simulate error response
+    lastMockWebSocket!.simulateMessage({
+      type: "error",
+      error: "Invalid token",
+    });
+
+    // Should trigger reconnect
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await channel.unsubscribe();
+  });
+});
+
+describe("RealtimeChannel - Postgres Changes Callback Errors", () => {
+  it("should catch errors in postgres_changes callbacks", async () => {
+    const channel = new RealtimeChannel(
+      "http://localhost:8080",
+      "test",
+      "test-token",
+    );
+
+    const errorCallback = vi.fn().mockImplementation(() => {
+      throw new Error("Callback error");
+    });
+    channel.on("postgres_changes", { event: "*", schema: "public", table: "test" }, errorCallback);
+    channel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    lastMockWebSocket!.simulateMessage({
+      type: "postgres_changes",
+      payload: { type: "INSERT", schema: "public", table: "test" },
+    });
+
+    expect(errorCallback).toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+
+    await channel.unsubscribe();
+  });
+});
+
+describe("FluxbaseRealtime - ExecutionLogs", () => {
+  let realtime: FluxbaseRealtime;
+
+  beforeEach(() => {
+    realtime = new FluxbaseRealtime("http://localhost:8080", "test-token");
+  });
+
+  afterEach(() => {
+    realtime.removeAllChannels();
+  });
+
+  it("should create execution logs channel", () => {
+    const logsChannel = realtime.executionLogs("exec-123", "function");
+    expect(logsChannel).toBeDefined();
+  });
+
+  it("should subscribe to execution logs", async () => {
+    const logsChannel = realtime.executionLogs("exec-123", "function");
+    const callback = vi.fn();
+
+    logsChannel.onLog(callback);
+
+    // Subscribe with status callback
+    const statusCallback = vi.fn();
+    logsChannel.subscribe(statusCallback);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // The channel should be subscribed (status callback called)
+    expect(statusCallback).toHaveBeenCalledWith("SUBSCRIBED");
+
+    await logsChannel.unsubscribe();
+  });
+
+  it("should handle callback errors in execution logs", async () => {
+    const logsChannel = realtime.executionLogs("exec-456", "job");
+    const errorCallback = vi.fn().mockImplementation(() => {
+      throw new Error("Callback error");
+    });
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    logsChannel.onLog(errorCallback);
+    logsChannel.subscribe();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    lastMockWebSocket!.simulateMessage({
+      type: "execution_log",
+      payload: {
+        execution_id: "exec-456",
+        level: "error",
+        message: "Error log",
+      },
+    });
+
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+
+    await logsChannel.unsubscribe();
+  });
+
+  it("should use default execution type", () => {
+    const logsChannel = realtime.executionLogs("exec-789");
+    // Default type is 'function'
+    expect(logsChannel).toBeDefined();
+  });
+
+  it("should use token refresh callback if available", () => {
+    const refreshCallback = vi.fn().mockResolvedValue("new-token");
+    realtime.setTokenRefreshCallback(refreshCallback);
+
+    const logsChannel = realtime.executionLogs("exec-123");
+    expect(logsChannel).toBeDefined();
+  });
+});
+
+describe("FluxbaseRealtime - removeChannel", () => {
+  it("should return error when removing non-existent channel", async () => {
+    const realtime = new FluxbaseRealtime("http://localhost:8080", "test-token");
+    const orphanChannel = new RealtimeChannel(
+      "http://localhost:8080",
+      "orphan",
+      "test-token",
+    );
+
+    const result = await realtime.removeChannel(orphanChannel);
+    expect(result).toBe("error");
+
+    realtime.removeAllChannels();
+  });
+});
+
+describe("FluxbaseRealtime - channel with config", () => {
+  it("should create different channels for different configs", () => {
+    const realtime = new FluxbaseRealtime("http://localhost:8080", "test-token");
+
+    const channel1 = realtime.channel("room", { presence: { key: "user1" } });
+    const channel2 = realtime.channel("room", { presence: { key: "user2" } });
+
+    expect(channel1).not.toBe(channel2);
 
     realtime.removeAllChannels();
   });

--- a/sdk/src/settings.test.ts
+++ b/sdk/src/settings.test.ts
@@ -1,10 +1,22 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { SystemSettingsManager, AppSettingsManager, FluxbaseSettings, SettingsClient } from './settings'
+import {
+  SystemSettingsManager,
+  AppSettingsManager,
+  EmailTemplateManager,
+  EmailSettingsManager,
+  FluxbaseSettings,
+  SettingsClient
+} from './settings'
 import type { FluxbaseFetch } from './fetch'
 import type {
   SystemSetting,
   AppSettings,
   CustomSetting,
+  EmailTemplate,
+  EmailProviderSettings,
+  SecretSettingMetadata,
+  UserSetting,
+  UserSettingWithSource,
 } from './types'
 
 describe('SystemSettingsManager', () => {
@@ -597,8 +609,971 @@ describe('SettingsClient', () => {
   })
 })
 
+describe('AppSettingsManager - Email Configuration', () => {
+  let manager: AppSettingsManager
+  let mockFetch: any
+
+  const mockAppSettings: AppSettings = {
+    authentication: { enable_signup: true },
+    features: { enable_realtime: true },
+    email: { enabled: true, provider: 'smtp' },
+    security: { enable_global_rate_limit: false },
+  }
+
+  beforeEach(() => {
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }
+    manager = new AppSettingsManager(mockFetch as unknown as FluxbaseFetch)
+  })
+
+  describe('configureSMTP', () => {
+    it('should configure SMTP provider', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.configureSMTP({
+        host: 'smtp.gmail.com',
+        port: 587,
+        username: 'test@gmail.com',
+        password: 'app-password',
+        use_tls: true,
+        from_address: 'noreply@app.com',
+        from_name: 'My App',
+      })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        email: {
+          enabled: true,
+          provider: 'smtp',
+          from_address: 'noreply@app.com',
+          from_name: 'My App',
+          reply_to_address: undefined,
+          smtp: {
+            host: 'smtp.gmail.com',
+            port: 587,
+            username: 'test@gmail.com',
+            password: 'app-password',
+            use_tls: true,
+          },
+        },
+      })
+    })
+  })
+
+  describe('configureSendGrid', () => {
+    it('should configure SendGrid provider', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.configureSendGrid('SG.xxx', {
+        from_address: 'noreply@app.com',
+        from_name: 'My App',
+      })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        email: {
+          enabled: true,
+          provider: 'sendgrid',
+          from_address: 'noreply@app.com',
+          from_name: 'My App',
+          reply_to_address: undefined,
+          sendgrid: {
+            api_key: 'SG.xxx',
+          },
+        },
+      })
+    })
+
+    it('should work without options', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.configureSendGrid('SG.xxx')
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        email: {
+          enabled: true,
+          provider: 'sendgrid',
+          from_address: undefined,
+          from_name: undefined,
+          reply_to_address: undefined,
+          sendgrid: {
+            api_key: 'SG.xxx',
+          },
+        },
+      })
+    })
+  })
+
+  describe('configureMailgun', () => {
+    it('should configure Mailgun provider', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.configureMailgun('key-xxx', 'mg.app.com', {
+        eu_region: true,
+        from_address: 'noreply@app.com',
+      })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        email: {
+          enabled: true,
+          provider: 'mailgun',
+          from_address: 'noreply@app.com',
+          from_name: undefined,
+          reply_to_address: undefined,
+          mailgun: {
+            api_key: 'key-xxx',
+            domain: 'mg.app.com',
+            eu_region: true,
+          },
+        },
+      })
+    })
+
+    it('should default eu_region to false', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.configureMailgun('key-xxx', 'mg.app.com')
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', expect.objectContaining({
+        email: expect.objectContaining({
+          mailgun: expect.objectContaining({
+            eu_region: false,
+          }),
+        }),
+      }))
+    })
+  })
+
+  describe('configureSES', () => {
+    it('should configure AWS SES provider', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.configureSES('AKIAIOSFODNN7EXAMPLE', 'secret-key', 'us-east-1', {
+        from_address: 'noreply@app.com',
+      })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        email: {
+          enabled: true,
+          provider: 'ses',
+          from_address: 'noreply@app.com',
+          from_name: undefined,
+          reply_to_address: undefined,
+          ses: {
+            access_key_id: 'AKIAIOSFODNN7EXAMPLE',
+            secret_access_key: 'secret-key',
+            region: 'us-east-1',
+          },
+        },
+      })
+    })
+  })
+
+  describe('setEmailEnabled', () => {
+    it('should enable email', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.setEmailEnabled(true)
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        email: { enabled: true },
+      })
+    })
+
+    it('should disable email', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.setEmailEnabled(false)
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        email: { enabled: false },
+      })
+    })
+  })
+})
+
+describe('AppSettingsManager - Additional Methods', () => {
+  let manager: AppSettingsManager
+  let mockFetch: any
+
+  const mockAppSettings: AppSettings = {
+    authentication: {
+      enable_signup: true,
+      password_min_length: 8,
+      password_require_uppercase: true,
+      password_require_lowercase: true,
+      password_require_number: true,
+      password_require_special: true,
+      session_timeout_minutes: 30,
+      max_sessions_per_user: 3,
+      require_email_verification: true,
+    },
+    features: { enable_realtime: true, enable_storage: true, enable_functions: true },
+    email: { enabled: true, provider: 'smtp' },
+    security: { enable_global_rate_limit: false },
+  }
+
+  beforeEach(() => {
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }
+    manager = new AppSettingsManager(mockFetch as unknown as FluxbaseFetch)
+  })
+
+  describe('setPasswordComplexity', () => {
+    it('should set password complexity requirements', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.setPasswordComplexity({
+        min_length: 12,
+        require_uppercase: true,
+        require_lowercase: true,
+        require_number: true,
+        require_special: true,
+      })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        authentication: {
+          password_min_length: 12,
+          password_require_uppercase: true,
+          password_require_lowercase: true,
+          password_require_number: true,
+          password_require_special: true,
+        },
+      })
+    })
+  })
+
+  describe('setSessionSettings', () => {
+    it('should set session timeout and max sessions', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.setSessionSettings(30, 3)
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        authentication: {
+          session_timeout_minutes: 30,
+          max_sessions_per_user: 3,
+        },
+      })
+    })
+  })
+
+  describe('setEmailVerificationRequired', () => {
+    it('should enable email verification', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.setEmailVerificationRequired(true)
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        authentication: { require_email_verification: true },
+      })
+    })
+
+    it('should disable email verification', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.setEmailVerificationRequired(false)
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        authentication: { require_email_verification: false },
+      })
+    })
+  })
+
+  describe('setFeature - functions', () => {
+    it('should enable functions feature', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockAppSettings)
+
+      await manager.setFeature('functions', true)
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/app/settings', {
+        features: { enable_functions: true },
+      })
+    })
+  })
+
+  describe('listSettings', () => {
+    it('should list all custom settings', async () => {
+      const mockSettings: CustomSetting[] = [
+        {
+          id: '1',
+          key: 'billing.tiers',
+          value: { free: 1000 },
+          value_type: 'json',
+          description: '',
+          editable_by: [],
+          metadata: {},
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      ]
+      vi.mocked(mockFetch.get).mockResolvedValue(mockSettings)
+
+      const result = await manager.listSettings()
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/admin/settings/custom')
+      expect(result).toEqual(mockSettings)
+    })
+  })
+
+  describe('deleteSetting', () => {
+    it('should delete a custom setting', async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue(undefined)
+
+      await manager.deleteSetting('billing.tiers')
+
+      expect(mockFetch.delete).toHaveBeenCalledWith('/api/v1/admin/settings/custom/billing.tiers')
+    })
+  })
+})
+
+describe('AppSettingsManager - Secret Settings', () => {
+  let manager: AppSettingsManager
+  let mockFetch: any
+
+  beforeEach(() => {
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }
+    manager = new AppSettingsManager(mockFetch as unknown as FluxbaseFetch)
+  })
+
+  describe('setSecretSetting', () => {
+    it('should update existing secret', async () => {
+      const mockMetadata: SecretSettingMetadata = {
+        key: 'stripe_api_key',
+        description: 'Stripe key',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      vi.mocked(mockFetch.put).mockResolvedValue(mockMetadata)
+
+      const result = await manager.setSecretSetting('stripe_api_key', 'sk-xxx', {
+        description: 'Stripe key',
+      })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/settings/custom/secret/stripe_api_key', {
+        value: 'sk-xxx',
+        description: 'Stripe key',
+      })
+      expect(result).toEqual(mockMetadata)
+    })
+
+    it('should create new secret if not found', async () => {
+      const mockMetadata: SecretSettingMetadata = {
+        key: 'new_secret',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      vi.mocked(mockFetch.put).mockRejectedValue({ status: 404 })
+      vi.mocked(mockFetch.post).mockResolvedValue(mockMetadata)
+
+      const result = await manager.setSecretSetting('new_secret', 'secret-value')
+
+      expect(mockFetch.post).toHaveBeenCalledWith('/api/v1/admin/settings/custom/secret', {
+        key: 'new_secret',
+        value: 'secret-value',
+        description: undefined,
+      })
+      expect(result).toEqual(mockMetadata)
+    })
+
+    it('should rethrow non-404 errors', async () => {
+      vi.mocked(mockFetch.put).mockRejectedValue({ status: 500, message: 'Server error' })
+
+      await expect(manager.setSecretSetting('key', 'value')).rejects.toEqual({ status: 500, message: 'Server error' })
+    })
+  })
+
+  describe('getSecretSetting', () => {
+    it('should get secret metadata', async () => {
+      const mockMetadata: SecretSettingMetadata = {
+        key: 'stripe_api_key',
+        description: 'Stripe key',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      vi.mocked(mockFetch.get).mockResolvedValue(mockMetadata)
+
+      const result = await manager.getSecretSetting('stripe_api_key')
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/admin/settings/custom/secret/stripe_api_key')
+      expect(result).toEqual(mockMetadata)
+    })
+  })
+
+  describe('listSecretSettings', () => {
+    it('should list all secret settings', async () => {
+      const mockSecrets: SecretSettingMetadata[] = [
+        { key: 'stripe_api_key', created_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z' },
+        { key: 'openai_key', created_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z' },
+      ]
+      vi.mocked(mockFetch.get).mockResolvedValue(mockSecrets)
+
+      const result = await manager.listSecretSettings()
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/admin/settings/custom/secrets')
+      expect(result).toEqual(mockSecrets)
+    })
+  })
+
+  describe('deleteSecretSetting', () => {
+    it('should delete secret', async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue(undefined)
+
+      await manager.deleteSecretSetting('stripe_api_key')
+
+      expect(mockFetch.delete).toHaveBeenCalledWith('/api/v1/admin/settings/custom/secret/stripe_api_key')
+    })
+  })
+
+  describe('getUserSecretValue', () => {
+    it('should get decrypted user secret value', async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue({ value: 'decrypted-secret' })
+
+      const result = await manager.getUserSecretValue('user-123', 'api_key')
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/admin/settings/user/user-123/secret/api_key/decrypt')
+      expect(result).toBe('decrypted-secret')
+    })
+  })
+})
+
+describe('AppSettingsManager - setSetting edge cases', () => {
+  let manager: AppSettingsManager
+  let mockFetch: any
+
+  beforeEach(() => {
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }
+    manager = new AppSettingsManager(mockFetch as unknown as FluxbaseFetch)
+  })
+
+  it('should update existing setting', async () => {
+    const mockSetting: CustomSetting = {
+      id: '1',
+      key: 'existing.key',
+      value: { updated: true },
+      value_type: 'json',
+      description: '',
+      editable_by: [],
+      metadata: {},
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    }
+    vi.mocked(mockFetch.put).mockResolvedValue(mockSetting)
+
+    const result = await manager.setSetting('existing.key', { updated: true })
+
+    expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/settings/custom/existing.key', {
+      value: { updated: true },
+      value_type: 'json',
+      description: undefined,
+      is_public: undefined,
+      is_secret: undefined,
+    })
+    expect(result).toEqual(mockSetting)
+  })
+
+  it('should wrap primitive values in object', async () => {
+    const mockSetting: CustomSetting = {
+      id: '1',
+      key: 'primitive.key',
+      value: { value: 42 },
+      value_type: 'json',
+      description: '',
+      editable_by: [],
+      metadata: {},
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    }
+    vi.mocked(mockFetch.put).mockResolvedValue(mockSetting)
+
+    await manager.setSetting('primitive.key', 42)
+
+    expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/settings/custom/primitive.key', expect.objectContaining({
+      value: { value: 42 },
+    }))
+  })
+
+  it('should wrap array values in object', async () => {
+    const mockSetting: CustomSetting = {
+      id: '1',
+      key: 'array.key',
+      value: { value: [1, 2, 3] },
+      value_type: 'json',
+      description: '',
+      editable_by: [],
+      metadata: {},
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    }
+    vi.mocked(mockFetch.put).mockResolvedValue(mockSetting)
+
+    await manager.setSetting('array.key', [1, 2, 3])
+
+    expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/settings/custom/array.key', expect.objectContaining({
+      value: { value: [1, 2, 3] },
+    }))
+  })
+
+  it('should wrap null in object', async () => {
+    const mockSetting: CustomSetting = {
+      id: '1',
+      key: 'null.key',
+      value: { value: null },
+      value_type: 'json',
+      description: '',
+      editable_by: [],
+      metadata: {},
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    }
+    vi.mocked(mockFetch.put).mockResolvedValue(mockSetting)
+
+    await manager.setSetting('null.key', null)
+
+    expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/settings/custom/null.key', expect.objectContaining({
+      value: { value: null },
+    }))
+  })
+
+  it('should handle non-404 errors on setSetting', async () => {
+    vi.mocked(mockFetch.put).mockRejectedValue({ status: 500, message: 'Server error' })
+
+    await expect(manager.setSetting('key', { val: 1 })).rejects.toEqual({ status: 500, message: 'Server error' })
+  })
+})
+
+describe('EmailTemplateManager', () => {
+  let manager: EmailTemplateManager
+  let mockFetch: any
+
+  const mockTemplate: EmailTemplate = {
+    type: 'magic_link',
+    subject: 'Sign in to {{.AppName}}',
+    html_body: '<a href="{{.MagicLink}}">Sign In</a>',
+    text_body: 'Sign in: {{.MagicLink}}',
+    is_custom: false,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  }
+
+  beforeEach(() => {
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }
+    manager = new EmailTemplateManager(mockFetch as unknown as FluxbaseFetch)
+  })
+
+  describe('list', () => {
+    it('should list all email templates', async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue([mockTemplate])
+
+      const result = await manager.list()
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/admin/email/templates')
+      expect(result.templates).toHaveLength(1)
+    })
+
+    it('should handle non-array response', async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue(undefined)
+
+      const result = await manager.list()
+
+      expect(result.templates).toEqual([])
+    })
+  })
+
+  describe('get', () => {
+    it('should get template by type', async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue(mockTemplate)
+
+      const result = await manager.get('magic_link')
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/admin/email/templates/magic_link')
+      expect(result).toEqual(mockTemplate)
+    })
+  })
+
+  describe('update', () => {
+    it('should update template', async () => {
+      const updated = { ...mockTemplate, subject: 'New Subject' }
+      vi.mocked(mockFetch.put).mockResolvedValue(updated)
+
+      const result = await manager.update('magic_link', {
+        subject: 'New Subject',
+        html_body: '<p>Custom</p>',
+      })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/email/templates/magic_link', {
+        subject: 'New Subject',
+        html_body: '<p>Custom</p>',
+      })
+      expect(result.subject).toBe('New Subject')
+    })
+  })
+
+  describe('reset', () => {
+    it('should reset template to default', async () => {
+      vi.mocked(mockFetch.post).mockResolvedValue(mockTemplate)
+
+      const result = await manager.reset('magic_link')
+
+      expect(mockFetch.post).toHaveBeenCalledWith('/api/v1/admin/email/templates/magic_link/reset', {})
+      expect(result).toEqual(mockTemplate)
+    })
+  })
+
+  describe('test', () => {
+    it('should send test email', async () => {
+      vi.mocked(mockFetch.post).mockResolvedValue(undefined)
+
+      await manager.test('magic_link', 'test@example.com')
+
+      expect(mockFetch.post).toHaveBeenCalledWith('/api/v1/admin/email/templates/magic_link/test', {
+        recipient_email: 'test@example.com',
+      })
+    })
+  })
+})
+
+describe('EmailSettingsManager', () => {
+  let manager: EmailSettingsManager
+  let mockFetch: any
+
+  const mockSettings: EmailProviderSettings = {
+    enabled: true,
+    provider: 'smtp',
+    from_address: 'noreply@app.com',
+    from_name: 'My App',
+    smtp_host: 'smtp.gmail.com',
+    smtp_port: 587,
+    smtp_username: 'user@gmail.com',
+    smtp_password_set: true,
+    smtp_tls: true,
+    _overrides: {},
+  }
+
+  beforeEach(() => {
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }
+    manager = new EmailSettingsManager(mockFetch as unknown as FluxbaseFetch)
+  })
+
+  describe('get', () => {
+    it('should get email settings', async () => {
+      vi.mocked(mockFetch.get).mockResolvedValue(mockSettings)
+
+      const result = await manager.get()
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/admin/email/settings')
+      expect(result).toEqual(mockSettings)
+    })
+  })
+
+  describe('update', () => {
+    it('should update email settings', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue(mockSettings)
+
+      const result = await manager.update({
+        provider: 'sendgrid',
+        sendgrid_api_key: 'SG.xxx',
+      })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/email/settings', {
+        provider: 'sendgrid',
+        sendgrid_api_key: 'SG.xxx',
+      })
+      expect(result).toEqual(mockSettings)
+    })
+  })
+
+  describe('test', () => {
+    it('should send test email', async () => {
+      const mockResponse = { success: true, message: 'Test email sent' }
+      vi.mocked(mockFetch.post).mockResolvedValue(mockResponse)
+
+      const result = await manager.test('admin@app.com')
+
+      expect(mockFetch.post).toHaveBeenCalledWith('/api/v1/admin/email/settings/test', {
+        recipient_email: 'admin@app.com',
+      })
+      expect(result).toEqual(mockResponse)
+    })
+  })
+
+  describe('enable', () => {
+    it('should enable email', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue({ ...mockSettings, enabled: true })
+
+      const result = await manager.enable()
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/email/settings', { enabled: true })
+      expect(result.enabled).toBe(true)
+    })
+  })
+
+  describe('disable', () => {
+    it('should disable email', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue({ ...mockSettings, enabled: false })
+
+      const result = await manager.disable()
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/email/settings', { enabled: false })
+      expect(result.enabled).toBe(false)
+    })
+  })
+
+  describe('setProvider', () => {
+    it('should set email provider', async () => {
+      vi.mocked(mockFetch.put).mockResolvedValue({ ...mockSettings, provider: 'sendgrid' })
+
+      const result = await manager.setProvider('sendgrid')
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/admin/email/settings', { provider: 'sendgrid' })
+      expect(result.provider).toBe('sendgrid')
+    })
+  })
+})
+
+describe('SettingsClient - User Settings', () => {
+  let client: SettingsClient
+  let mockFetch: any
+
+  beforeEach(() => {
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }
+    client = new SettingsClient(mockFetch as unknown as FluxbaseFetch)
+  })
+
+  describe('getSetting', () => {
+    it('should get setting with fallback', async () => {
+      const mockResult: UserSettingWithSource = {
+        key: 'theme',
+        value: { mode: 'dark' },
+        source: 'user',
+      }
+      vi.mocked(mockFetch.get).mockResolvedValue(mockResult)
+
+      const result = await client.getSetting('theme')
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/settings/user/theme')
+      expect(result).toEqual(mockResult)
+    })
+  })
+
+  describe('getUserSetting', () => {
+    it('should get user own setting', async () => {
+      const mockSetting: UserSetting = {
+        id: '1',
+        key: 'theme',
+        value: { mode: 'dark' },
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      vi.mocked(mockFetch.get).mockResolvedValue(mockSetting)
+
+      const result = await client.getUserSetting('theme')
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/settings/user/own/theme')
+      expect(result).toEqual(mockSetting)
+    })
+  })
+
+  describe('getSystemSetting', () => {
+    it('should get system default setting', async () => {
+      const mockSetting = { key: 'theme', value: { mode: 'light' } }
+      vi.mocked(mockFetch.get).mockResolvedValue(mockSetting)
+
+      const result = await client.getSystemSetting('theme')
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/settings/user/system/theme')
+      expect(result).toEqual(mockSetting)
+    })
+  })
+
+  describe('setSetting', () => {
+    it('should set user setting', async () => {
+      const mockSetting: UserSetting = {
+        id: '1',
+        key: 'theme',
+        value: { mode: 'dark' },
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      vi.mocked(mockFetch.put).mockResolvedValue(mockSetting)
+
+      const result = await client.setSetting('theme', { mode: 'dark' }, { description: 'User theme' })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/settings/user/theme', {
+        value: { mode: 'dark' },
+        description: 'User theme',
+      })
+      expect(result).toEqual(mockSetting)
+    })
+  })
+
+  describe('listSettings', () => {
+    it('should list user settings', async () => {
+      const mockSettings: UserSetting[] = [
+        { id: '1', key: 'theme', value: { mode: 'dark' }, created_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z' },
+      ]
+      vi.mocked(mockFetch.get).mockResolvedValue(mockSettings)
+
+      const result = await client.listSettings()
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/settings/user/list')
+      expect(result).toEqual(mockSettings)
+    })
+  })
+
+  describe('deleteSetting', () => {
+    it('should delete user setting', async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue(undefined)
+
+      await client.deleteSetting('theme')
+
+      expect(mockFetch.delete).toHaveBeenCalledWith('/api/v1/settings/user/theme')
+    })
+  })
+})
+
+describe('SettingsClient - User Secrets', () => {
+  let client: SettingsClient
+  let mockFetch: any
+
+  beforeEach(() => {
+    mockFetch = {
+      get: vi.fn(),
+      post: vi.fn(),
+      put: vi.fn(),
+      patch: vi.fn(),
+      delete: vi.fn(),
+    }
+    client = new SettingsClient(mockFetch as unknown as FluxbaseFetch)
+  })
+
+  describe('setSecret', () => {
+    it('should update existing secret', async () => {
+      const mockMetadata: SecretSettingMetadata = {
+        key: 'openai_key',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      vi.mocked(mockFetch.put).mockResolvedValue(mockMetadata)
+
+      const result = await client.setSecret('openai_key', 'sk-xxx', { description: 'OpenAI API key' })
+
+      expect(mockFetch.put).toHaveBeenCalledWith('/api/v1/settings/secret/openai_key', {
+        value: 'sk-xxx',
+        description: 'OpenAI API key',
+      })
+      expect(result).toEqual(mockMetadata)
+    })
+
+    it('should create new secret if not found', async () => {
+      const mockMetadata: SecretSettingMetadata = {
+        key: 'new_key',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      vi.mocked(mockFetch.put).mockRejectedValue({ status: 404, message: 'not found' })
+      vi.mocked(mockFetch.post).mockResolvedValue(mockMetadata)
+
+      const result = await client.setSecret('new_key', 'secret')
+
+      expect(mockFetch.post).toHaveBeenCalledWith('/api/v1/settings/secret/', {
+        key: 'new_key',
+        value: 'secret',
+        description: undefined,
+      })
+      expect(result).toEqual(mockMetadata)
+    })
+
+    it('should rethrow non-404 errors', async () => {
+      vi.mocked(mockFetch.put).mockRejectedValue({ status: 500, message: 'Server error' })
+
+      await expect(client.setSecret('key', 'value')).rejects.toEqual({ status: 500, message: 'Server error' })
+    })
+  })
+
+  describe('getSecret', () => {
+    it('should get secret metadata', async () => {
+      const mockMetadata: SecretSettingMetadata = {
+        key: 'openai_key',
+        description: 'OpenAI API key',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z',
+      }
+      vi.mocked(mockFetch.get).mockResolvedValue(mockMetadata)
+
+      const result = await client.getSecret('openai_key')
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/settings/secret/openai_key')
+      expect(result).toEqual(mockMetadata)
+    })
+  })
+
+  describe('listSecrets', () => {
+    it('should list all user secrets', async () => {
+      const mockSecrets: SecretSettingMetadata[] = [
+        { key: 'openai_key', created_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z' },
+        { key: 'stripe_key', created_at: '2024-01-01T00:00:00Z', updated_at: '2024-01-01T00:00:00Z' },
+      ]
+      vi.mocked(mockFetch.get).mockResolvedValue(mockSecrets)
+
+      const result = await client.listSecrets()
+
+      expect(mockFetch.get).toHaveBeenCalledWith('/api/v1/settings/secret/')
+      expect(result).toEqual(mockSecrets)
+    })
+  })
+
+  describe('deleteSecret', () => {
+    it('should delete user secret', async () => {
+      vi.mocked(mockFetch.delete).mockResolvedValue(undefined)
+
+      await client.deleteSecret('openai_key')
+
+      expect(mockFetch.delete).toHaveBeenCalledWith('/api/v1/settings/secret/openai_key')
+    })
+  })
+})
+
 describe('FluxbaseSettings', () => {
-  it('should initialize both managers', () => {
+  it('should initialize all managers', () => {
     const mockFetch = {
       get: vi.fn(),
       post: vi.fn(),
@@ -611,5 +1586,19 @@ describe('FluxbaseSettings', () => {
 
     expect(settings.system).toBeInstanceOf(SystemSettingsManager)
     expect(settings.app).toBeInstanceOf(AppSettingsManager)
+    expect(settings.email).toBeInstanceOf(EmailSettingsManager)
+  })
+
+  describe('SystemSettingsManager - list with non-array response', () => {
+    it('should handle non-array response', async () => {
+      const mockFetch = {
+        get: vi.fn().mockResolvedValue(null),
+      } as unknown as FluxbaseFetch
+
+      const manager = new SystemSettingsManager(mockFetch)
+      const result = await manager.list()
+
+      expect(result.settings).toEqual([])
+    })
   })
 })

--- a/sdk/src/utils/error-handling.test.ts
+++ b/sdk/src/utils/error-handling.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+import { wrapAsync, wrapAsyncVoid, wrapSync } from "./error-handling";
+
+describe("error-handling utilities", () => {
+  describe("wrapAsync()", () => {
+    it("should return data on success", async () => {
+      const result = await wrapAsync(async () => {
+        return { message: "success" };
+      });
+
+      expect(result.data).toEqual({ message: "success" });
+      expect(result.error).toBeNull();
+    });
+
+    it("should return primitive data types", async () => {
+      const numberResult = await wrapAsync(async () => 42);
+      expect(numberResult.data).toBe(42);
+      expect(numberResult.error).toBeNull();
+
+      const stringResult = await wrapAsync(async () => "hello");
+      expect(stringResult.data).toBe("hello");
+      expect(stringResult.error).toBeNull();
+
+      const boolResult = await wrapAsync(async () => true);
+      expect(boolResult.data).toBe(true);
+      expect(boolResult.error).toBeNull();
+    });
+
+    it("should return null data on Error", async () => {
+      const error = new Error("Something went wrong");
+      const result = await wrapAsync(async () => {
+        throw error;
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBe(error);
+    });
+
+    it("should convert non-Error to Error", async () => {
+      const result = await wrapAsync(async () => {
+        throw "string error";
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toBe("string error");
+    });
+
+    it("should handle numbers thrown as errors", async () => {
+      const result = await wrapAsync(async () => {
+        throw 404;
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toBe("404");
+    });
+
+    it("should handle objects thrown as errors", async () => {
+      const result = await wrapAsync(async () => {
+        throw { code: "ERR_001", message: "Custom error" };
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBeInstanceOf(Error);
+    });
+
+    it("should handle async operations with delay", async () => {
+      const result = await wrapAsync(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return "delayed result";
+      });
+
+      expect(result.data).toBe("delayed result");
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle arrays", async () => {
+      const result = await wrapAsync(async () => {
+        return [1, 2, 3];
+      });
+
+      expect(result.data).toEqual([1, 2, 3]);
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle null return value", async () => {
+      const result = await wrapAsync(async () => {
+        return null;
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle undefined return value", async () => {
+      const result = await wrapAsync(async () => {
+        return undefined;
+      });
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("wrapAsyncVoid()", () => {
+    it("should return null error on success", async () => {
+      let sideEffect = false;
+      const result = await wrapAsyncVoid(async () => {
+        sideEffect = true;
+      });
+
+      expect(result.error).toBeNull();
+      expect(sideEffect).toBe(true);
+    });
+
+    it("should return error on failure", async () => {
+      const error = new Error("Void operation failed");
+      const result = await wrapAsyncVoid(async () => {
+        throw error;
+      });
+
+      expect(result.error).toBe(error);
+    });
+
+    it("should convert non-Error to Error", async () => {
+      const result = await wrapAsyncVoid(async () => {
+        throw "string error in void";
+      });
+
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toBe("string error in void");
+    });
+
+    it("should handle async operations with delay", async () => {
+      let completed = false;
+      const result = await wrapAsyncVoid(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        completed = true;
+      });
+
+      expect(result.error).toBeNull();
+      expect(completed).toBe(true);
+    });
+
+    it("should handle delayed error", async () => {
+      const result = await wrapAsyncVoid(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        throw new Error("Delayed error");
+      });
+
+      expect(result.error).toBeDefined();
+      expect(result.error!.message).toBe("Delayed error");
+    });
+  });
+
+  describe("wrapSync()", () => {
+    it("should return data on success", () => {
+      const result = wrapSync(() => {
+        return { value: 42 };
+      });
+
+      expect(result.data).toEqual({ value: 42 });
+      expect(result.error).toBeNull();
+    });
+
+    it("should return primitive data types", () => {
+      const numberResult = wrapSync(() => 100);
+      expect(numberResult.data).toBe(100);
+      expect(numberResult.error).toBeNull();
+
+      const stringResult = wrapSync(() => "sync hello");
+      expect(stringResult.data).toBe("sync hello");
+      expect(stringResult.error).toBeNull();
+
+      const boolResult = wrapSync(() => false);
+      expect(boolResult.data).toBe(false);
+      expect(boolResult.error).toBeNull();
+    });
+
+    it("should return null data on Error", () => {
+      const error = new Error("Sync error");
+      const result = wrapSync(() => {
+        throw error;
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBe(error);
+    });
+
+    it("should convert non-Error to Error", () => {
+      const result = wrapSync(() => {
+        throw "sync string error";
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toBe("sync string error");
+    });
+
+    it("should handle numbers thrown as errors", () => {
+      const result = wrapSync(() => {
+        throw 500;
+      });
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error!.message).toBe("500");
+    });
+
+    it("should handle arrays", () => {
+      const result = wrapSync(() => ["a", "b", "c"]);
+
+      expect(result.data).toEqual(["a", "b", "c"]);
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle null return value", () => {
+      const result = wrapSync(() => null);
+
+      expect(result.data).toBeNull();
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle undefined return value", () => {
+      const result = wrapSync(() => undefined);
+
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeNull();
+    });
+
+    it("should handle complex objects", () => {
+      const complexObject = {
+        nested: {
+          deeply: {
+            value: "found",
+          },
+        },
+        array: [1, 2, 3],
+        date: new Date("2024-01-26"),
+      };
+
+      const result = wrapSync(() => complexObject);
+
+      expect(result.data).toEqual(complexObject);
+      expect(result.error).toBeNull();
+    });
+  });
+
+  describe("type safety", () => {
+    it("should preserve types correctly for wrapAsync", async () => {
+      interface User {
+        id: string;
+        name: string;
+      }
+
+      const result = await wrapAsync<User>(async () => {
+        return { id: "1", name: "Test User" };
+      });
+
+      // Type should be inferred correctly
+      if (result.data) {
+        expect(result.data.id).toBe("1");
+        expect(result.data.name).toBe("Test User");
+      }
+    });
+
+    it("should preserve types correctly for wrapSync", () => {
+      interface Config {
+        setting: boolean;
+        value: number;
+      }
+
+      const result = wrapSync<Config>(() => {
+        return { setting: true, value: 42 };
+      });
+
+      if (result.data) {
+        expect(result.data.setting).toBe(true);
+        expect(result.data.value).toBe(42);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a comprehensive test suite for the `FluxbaseAdminAI` class with 1000+ lines of test coverage, and fixes a race condition in the SAML callback test.

## Key Changes

- **Added `admin-ai.test.ts`**: Complete test suite for FluxbaseAdminAI covering:
  - Chatbot management (list, get, toggle, delete, sync operations)
  - Provider management (CRUD operations, default/embedding provider configuration)
  - Knowledge base management (create, read, update, delete operations)
  - Document management (add, upload, delete, search operations)
  - Chatbot-knowledge base linking (list, link, update, unlink operations)
  - Error handling for all operations
  - Config normalization for provider creation/updates
  - FormData handling for file uploads

- **Fixed race condition in `use-saml.test.ts`**: Wrapped assertion in `waitFor()` to ensure state update completes before checking `isSuccess` flag

## Implementation Details

- Tests use Vitest with mocked `FluxbaseFetch` dependency
- Comprehensive coverage of both success and error scenarios
- Tests validate correct API endpoints and request payloads
- Config value normalization tested (converting numbers to strings, filtering undefined/null values)
- File upload tested with FormData handling
- All list operations tested for null/empty response handling