### PR TITLE
fix: Correct health check display in admin overview

### DIFF
--- a/admin/src/features/dashboard/components/health-indicators.tsx
+++ b/admin/src/features/dashboard/components/health-indicators.tsx
@@ -27,26 +27,24 @@ export function HealthIndicators() {
     {
       name: 'API',
       status: health?.status === 'ok' ? 'healthy' : 'down',
-      details: health?.status === 'ok' ? 'All endpoints operational' : 'Service unavailable',
+      details:
+        health?.status === 'ok'
+          ? 'All endpoints operational'
+          : 'Service unavailable',
     },
     {
       name: 'Database',
-      status: health?.services.database?.status === 'healthy' ? 'healthy' : 'down',
-      details: health?.services.database?.status === 'healthy'
-        ? `Connected (${health.services.database.latency_ms}ms)`
-        : health?.services.database?.message || 'Connection failed',
+      status: health?.services.database === true ? 'healthy' : 'down',
+      details:
+        health?.services.database === true ? 'Connected' : 'Connection failed',
     },
     {
       name: 'Realtime',
-      status: health?.services.realtime?.status === 'healthy' ? 'healthy' : 'degraded',
-      details: health?.services.realtime?.message || 'WebSocket server running',
-    },
-    {
-      name: 'Jobs',
-      status: (health?.services.jobs?.status === 'healthy' || health?.services.jobs?.status === 'degraded')
-        ? (health.services.jobs.status as 'healthy' | 'degraded')
-        : 'down',
-      details: health?.services.jobs?.message || 'Job system unavailable',
+      status: health?.services.realtime === true ? 'healthy' : 'down',
+      details:
+        health?.services.realtime === true
+          ? 'WebSocket server running'
+          : 'Disabled',
     },
   ]
 
@@ -57,8 +55,10 @@ export function HealthIndicators() {
 
     // Use backend's overall status
     const status = health.status
-    if (status === 'healthy') return { icon: 'success', text: 'All systems operational' }
-    if (status === 'degraded') return { icon: 'warning', text: 'Some systems degraded' }
+    if (status === 'ok')
+      return { icon: 'success', text: 'All systems operational' }
+    if (status === 'degraded')
+      return { icon: 'warning', text: 'Some systems degraded' }
     return { icon: 'error', text: 'Systems unavailable' }
   }
 
@@ -70,7 +70,7 @@ export function HealthIndicators() {
         <div className='flex items-center justify-between'>
           <div className='flex items-center gap-2'>
             {overallStatus.icon === 'loading' ? (
-              <Loader2 className='h-4 w-4 animate-spin text-muted-foreground' />
+              <Loader2 className='text-muted-foreground h-4 w-4 animate-spin' />
             ) : overallStatus.icon === 'success' ? (
               <CheckCircle2 className='h-4 w-4 text-green-500' />
             ) : overallStatus.icon === 'warning' ? (
@@ -78,9 +78,7 @@ export function HealthIndicators() {
             ) : (
               <XCircle className='h-4 w-4 text-red-500' />
             )}
-            <span className='text-sm font-medium'>
-              {overallStatus.text}
-            </span>
+            <span className='text-sm font-medium'>{overallStatus.text}</span>
           </div>
           <div className='flex gap-3'>
             {services.map((service) => (
@@ -102,7 +100,9 @@ export function HealthIndicators() {
                     {service.status === 'down' && (
                       <XCircle className='h-3.5 w-3.5 text-red-500' />
                     )}
-                    <span className='text-xs text-muted-foreground'>{service.name}</span>
+                    <span className='text-muted-foreground text-xs'>
+                      {service.name}
+                    </span>
                   </>
                 )}
               </div>

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2026.2.4",
       "license": "MIT",
       "dependencies": {
+        "@rollup/rollup-darwin-arm64": "*",
         "cross-fetch": "^4.1.0"
       },
       "devDependencies": {
@@ -25,6 +26,9 @@
       },
       "engines": {
         "node": ">=24.14.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "^4.59.0"
       },
       "peerDependencies": {
         "esbuild": ">=0.27.3"
@@ -643,13 +647,12 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2088,6 +2091,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -81,5 +81,8 @@
   },
   "engines": {
     "node": ">=24.14.0"
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-darwin-arm64": "^4.59.0"
   }
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -3625,7 +3625,7 @@ export interface UpdateTableExportSyncConfig {
 // ============================================================================
 
 /**
- * Individual service health status
+ * Individual service health status (for detailed monitoring endpoint)
  */
 export interface ServiceHealth {
   status: string; // "healthy", "degraded", "unhealthy"
@@ -3634,11 +3634,15 @@ export interface ServiceHealth {
 }
 
 /**
- * System health status response
+ * System health status response from public /health endpoint
+ * Services are represented as booleans indicating availability
  */
 export interface HealthResponse {
-  status: string; // "healthy", "degraded", "unhealthy"
-  services: Record<string, ServiceHealth>;
+  status: string; // "ok" or "degraded"
+  services: {
+    database: boolean;
+    realtime: boolean;
+  };
   timestamp?: string;
 }
 


### PR DESCRIPTION
The HealthIndicators component expected a detailed health response format but the /health endpoint returns a simple format with booleans. This caused the overview page to show "Systems unavailable" with red crosses even when all systems were healthy.

- Update HealthIndicators to use boolean checks for database/realtime status
- Fix overall status check to use 'ok' instead of 'healthy'
- Remove Jobs service display (not in /health response)
- Update SDK HealthResponse type to match actual backend response
- Add missing @rollup/rollup-darwin-arm64 optional dependency