### PR TITLE
fix(oauth): correct refresh token handling for all providers

### DIFF
--- a/docs/src/content/docs/guides/oauth-providers.md
+++ b/docs/src/content/docs/guides/oauth-providers.md
@@ -18,21 +18,46 @@ OAuth authentication enables:
 
 Fluxbase includes built-in support for well-known providers and custom OIDC providers:
 
-| Provider | Type | Auto-Discovery |
-|----------|------|----------------|
-| Google | Well-known | Yes |
-| GitHub | Well-known | Yes |
-| Microsoft/Azure AD | Well-known | Yes |
-| Apple | Well-known | Yes |
-| Facebook | Well-known | Yes |
-| Twitter | Well-known | Yes |
-| LinkedIn | Well-known | Yes |
-| GitLab | Well-known | Yes |
-| Bitbucket | Well-known | Yes |
-| Keycloak | Custom OIDC | Requires `issuer_url` |
-| Auth0 | Custom OIDC | Requires `issuer_url` |
-| Authelia | Custom OIDC | Requires `issuer_url` |
-| Any OIDC Provider | Custom OIDC | Requires `issuer_url` |
+| Provider           | Type        | Auto-Discovery        |
+| ------------------ | ----------- | --------------------- |
+| Google             | Well-known  | Yes                   |
+| GitHub             | Well-known  | Yes                   |
+| Microsoft/Azure AD | Well-known  | Yes                   |
+| Apple              | Well-known  | Yes                   |
+| Facebook           | Well-known  | Yes                   |
+| Twitter (X)        | Well-known  | Yes                   |
+| LinkedIn           | Well-known  | Yes                   |
+| GitLab             | Well-known  | Yes                   |
+| Bitbucket          | Well-known  | Yes                   |
+| Keycloak           | Custom OIDC | Requires `issuer_url` |
+| Auth0              | Custom OIDC | Requires `issuer_url` |
+| Authelia           | Custom OIDC | Requires `issuer_url` |
+| Any OIDC Provider  | Custom OIDC | Requires `issuer_url` |
+
+### Provider-Specific Configuration
+
+Each OAuth provider has different requirements for scopes and refresh tokens:
+
+| Provider           | OIDC | Refresh Token Mechanism                         | Required Scopes                                  |
+| ------------------ | ---- | ----------------------------------------------- | ------------------------------------------------ |
+| **Google**         | Yes  | `access_type=offline` + `prompt=consent` (auto) | `openid`, `email`, `profile`                     |
+| **GitHub**         | No   | Different mechanism (GitHub Apps)               | `read:user`, `user:email`                        |
+| **Microsoft**      | Yes  | OIDC authorization code flow                    | `openid`, `email`, `profile`, `offline_access`   |
+| **GitLab**         | Yes  | OIDC authorization code flow                    | `read_user`, `openid`, `email`, `offline_access` |
+| **Apple**          | No   | Short-lived tokens only                         | `email`, `name`                                  |
+| **Facebook**       | No   | Long-lived tokens via API (no refresh)          | `email`, `public_profile`                        |
+| **Twitter (X)**    | No   | OAuth 2.0 PKCE flow                             | `offline.access`, `users.read`, `tweet.read`     |
+| **LinkedIn**       | No   | Auto-issued refresh_token                       | `openid`, `profile`, `email`                     |
+| **Bitbucket**      | Yes  | Rotating refresh tokens                         | `account`, `email`                               |
+| **OIDC Providers** | Yes  | OIDC authorization code flow                    | `openid`, `email`, `profile`, `offline_access`   |
+
+**Notes:**
+
+- **Google**: Fluxbase automatically adds `access_type=offline` and `prompt=consent` parameters
+- **GitHub**: Not fully OIDC-compliant; refresh tokens require GitHub Apps setup
+- **Apple**: Tokens are short-lived; users must re-authenticate periodically
+- **Facebook**: No standard refresh tokens; consider implementing long-lived token exchange
+- **Twitter (X)**: Note the scope uses a **dot** (`offline.access`), not underscore
 
 ## Configuration
 
@@ -62,7 +87,7 @@ auth:
       enabled: true
       client_id: "YOUR_AZURE_AD_CLIENT_ID"
       client_secret: "YOUR_CLIENT_SECRET"
-      scopes: [openid, email, profile]
+      scopes: [openid, email, profile, offline_access]
       display_name: "Microsoft"
 
     - name: apple
@@ -78,7 +103,7 @@ auth:
       issuer_url: "https://auth.example.com/realms/main"
       client_id: "fluxbase-client"
       client_secret: "YOUR_CLIENT_SECRET"
-      scopes: [openid, email, profile]
+      scopes: [openid, email, profile, offline_access]
       display_name: "Corporate SSO"
 
     - name: auth0
@@ -86,31 +111,31 @@ auth:
       issuer_url: "https://your-tenant.auth0.com"
       client_id: "YOUR_AUTH0_CLIENT_ID"
       client_secret: "YOUR_CLIENT_SECRET"
-      scopes: [openid, email, profile]
+      scopes: [openid, email, profile, offline_access]
       display_name: "Auth0"
 ```
 
 ### Configuration Options
 
-| Option | Description | Required |
-|--------|-------------|----------|
-| `name` | Provider identifier (lowercase, e.g., "google", "keycloak") | Yes |
-| `enabled` | Enable this provider | Yes |
-| `client_id` | OAuth client ID from the provider | Yes |
-| `client_secret` | OAuth client secret | Yes (except Apple) |
-| `issuer_url` | OIDC issuer URL for discovery | Required for custom providers |
-| `scopes` | OAuth scopes to request | No (defaults provided) |
-| `display_name` | Human-friendly name for UI | No |
+| Option          | Description                                                 | Required                      |
+| --------------- | ----------------------------------------------------------- | ----------------------------- |
+| `name`          | Provider identifier (lowercase, e.g., "google", "keycloak") | Yes                           |
+| `enabled`       | Enable this provider                                        | Yes                           |
+| `client_id`     | OAuth client ID from the provider                           | Yes                           |
+| `client_secret` | OAuth client secret                                         | Yes (except Apple)            |
+| `issuer_url`    | OIDC issuer URL for discovery                               | Required for custom providers |
+| `scopes`        | OAuth scopes to request                                     | No (defaults provided)        |
+| `display_name`  | Human-friendly name for UI                                  | No                            |
 
 **Additional options (via Admin API or database):**
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `authorization_url` | Custom authorization endpoint | Auto-discovered |
-| `token_url` | Custom token endpoint | Auto-discovered |
-| `user_info_url` | Custom userinfo endpoint | Auto-discovered |
-| `allow_dashboard_login` | Allow for admin dashboard SSO | false |
-| `allow_app_login` | Allow for app user authentication | true |
+| Option                  | Description                       | Default         |
+| ----------------------- | --------------------------------- | --------------- |
+| `authorization_url`     | Custom authorization endpoint     | Auto-discovered |
+| `token_url`             | Custom token endpoint             | Auto-discovered |
+| `user_info_url`         | Custom userinfo endpoint          | Auto-discovered |
+| `allow_dashboard_login` | Allow for admin dashboard SSO     | false           |
+| `allow_app_login`       | Allow for app user authentication | true            |
 
 ### Via Admin Dashboard
 
@@ -119,6 +144,7 @@ You can also configure OAuth providers through the admin UI at **Authentication 
 ![Add OAuth Provider in Admin Dashboard](../../../assets/screenshot-add-oauth-provider.png)
 
 The admin dashboard supports:
+
 - Auto-discovery from OpenID Discovery URLs
 - Manual endpoint configuration for non-standard providers
 - Provider testing before enabling
@@ -154,15 +180,15 @@ FLUXBASE_AUTH_OAUTH_PROVIDERS_2_CLIENT_SECRET=your-keycloak-secret
 
 ## Endpoints
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/v1/auth/oauth/providers` | GET | List available OAuth providers (public) |
-| `/api/v1/auth/oauth/:provider/authorize` | GET | Initiate OAuth flow (redirects to provider) |
-| `/api/v1/auth/oauth/:provider/callback` | GET | OAuth callback handler |
-| `/api/v1/admin/oauth/providers` | GET | List all providers (admin) |
-| `/api/v1/admin/oauth/providers` | POST | Create new provider (admin) |
-| `/api/v1/admin/oauth/providers/:id` | PATCH | Update provider (admin) |
-| `/api/v1/admin/oauth/providers/:id` | DELETE | Delete provider (admin) |
+| Endpoint                                 | Method | Description                                 |
+| ---------------------------------------- | ------ | ------------------------------------------- |
+| `/api/v1/auth/oauth/providers`           | GET    | List available OAuth providers (public)     |
+| `/api/v1/auth/oauth/:provider/authorize` | GET    | Initiate OAuth flow (redirects to provider) |
+| `/api/v1/auth/oauth/:provider/callback`  | GET    | OAuth callback handler                      |
+| `/api/v1/admin/oauth/providers`          | GET    | List all providers (admin)                  |
+| `/api/v1/admin/oauth/providers`          | POST   | Create new provider (admin)                 |
+| `/api/v1/admin/oauth/providers/:id`      | PATCH  | Update provider (admin)                     |
+| `/api/v1/admin/oauth/providers/:id`      | DELETE | Delete provider (admin)                     |
 
 ## Setup Guide
 
@@ -189,6 +215,7 @@ https://your-domain.com/api/v1/auth/oauth/{provider}/callback
 ```
 
 For example:
+
 - Google: `https://your-domain.com/api/v1/auth/oauth/google/callback`
 - GitHub: `https://your-domain.com/api/v1/auth/oauth/github/callback`
 
@@ -265,7 +292,7 @@ auth:
     - name: apple
       enabled: true
       client_id: "com.yourapp.service"
-      client_secret: "YOUR_APPLE_SECRET"  # Generated JWT
+      client_secret: "YOUR_APPLE_SECRET" # Generated JWT
       scopes: [openid, email, name]
 ```
 
@@ -322,40 +349,40 @@ auth:
 **Initiate OAuth flow:**
 
 ```typescript
-import { FluxbaseClient } from '@fluxbase/sdk'
+import { FluxbaseClient } from "@fluxbase/sdk";
 
-const client = new FluxbaseClient({ url: 'https://api.example.com' })
+const client = new FluxbaseClient({ url: "https://api.example.com" });
 
 // Get available OAuth providers
-const { data: providers } = await client.auth.getOAuthProviders()
+const { data: providers } = await client.auth.getOAuthProviders();
 // [{ name: 'google', display_name: 'Google' }, ...]
 
 // Get OAuth authorization URL
 const { data } = await client.auth.signInWithOAuth({
-  provider: 'google',
+  provider: "google",
   options: {
     redirectTo: `${window.location.origin}/auth/callback`,
   },
-})
+});
 
 // Redirect to provider
-window.location.href = data.url
+window.location.href = data.url;
 ```
 
 **Handle callback:**
 
 ```typescript
 // In your /auth/callback route
-const code = searchParams.get('code')
-const state = searchParams.get('state')
+const code = searchParams.get("code");
+const state = searchParams.get("state");
 
 const { user, session } = await client.auth.exchangeCodeForSession({
   code,
   state,
-})
+});
 
 // User is now authenticated
-console.log('Logged in as:', user.email)
+console.log("Logged in as:", user.email);
 ```
 
 ### React SDK
@@ -364,30 +391,32 @@ console.log('Logged in as:', user.email)
 import {
   useOAuthProviders,
   useSignInWithOAuth,
-  useSession
-} from '@fluxbase/sdk-react'
+  useSession,
+} from "@fluxbase/sdk-react";
 
 function OAuthLoginButtons() {
-  const { data: providers, isLoading } = useOAuthProviders()
-  const signIn = useSignInWithOAuth()
+  const { data: providers, isLoading } = useOAuthProviders();
+  const signIn = useSignInWithOAuth();
 
-  if (isLoading) return <div>Loading...</div>
+  if (isLoading) return <div>Loading...</div>;
 
   return (
     <div>
-      {providers?.map(provider => (
+      {providers?.map((provider) => (
         <button
           key={provider.name}
-          onClick={() => signIn.mutate({
-            provider: provider.name,
-            redirectTo: '/dashboard'
-          })}
+          onClick={() =>
+            signIn.mutate({
+              provider: provider.name,
+              redirectTo: "/dashboard",
+            })
+          }
         >
           Sign in with {provider.display_name || provider.name}
         </button>
       ))}
     </div>
-  )
+  );
 }
 ```
 
@@ -395,21 +424,21 @@ function OAuthLoginButtons() {
 
 ```tsx
 // pages/auth/callback.tsx
-import { useEffect } from 'react'
-import { useSession } from '@fluxbase/sdk-react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect } from "react";
+import { useSession } from "@fluxbase/sdk-react";
+import { useNavigate } from "react-router-dom";
 
 function OAuthCallback() {
-  const { data: session, isLoading } = useSession()
-  const navigate = useNavigate()
+  const { data: session, isLoading } = useSession();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!isLoading && session) {
-      navigate('/dashboard')
+      navigate("/dashboard");
     }
-  }, [session, isLoading])
+  }, [session, isLoading]);
 
-  return <div>Completing sign in...</div>
+  return <div>Completing sign in...</div>;
 }
 ```
 
@@ -422,6 +451,7 @@ GET /api/v1/auth/oauth/providers
 ```
 
 Response:
+
 ```json
 {
   "providers": [
@@ -455,6 +485,7 @@ Authorization: Bearer <admin-token>
 ```
 
 Response:
+
 ```json
 {
   "providers": [
@@ -537,15 +568,15 @@ Fluxbase automatically generates and validates state tokens to prevent CSRF atta
 
 ### Best Practices
 
-| Practice | Description |
-|----------|-------------|
-| **Use HTTPS in production** | OAuth requires secure connections |
-| **Protect client secrets** | Store in environment variables, never in code |
-| **Use PKCE** | Fluxbase supports PKCE for enhanced security |
-| **Limit scopes** | Only request necessary permissions |
-| **Rotate secrets** | Periodically rotate client secrets |
-| **Monitor OAuth usage** | Watch for unusual patterns and failed attempts |
-| **Validate redirect URIs** | Use exact match, avoid wildcards |
+| Practice                    | Description                                    |
+| --------------------------- | ---------------------------------------------- |
+| **Use HTTPS in production** | OAuth requires secure connections              |
+| **Protect client secrets**  | Store in environment variables, never in code  |
+| **Use PKCE**                | Fluxbase supports PKCE for enhanced security   |
+| **Limit scopes**            | Only request necessary permissions             |
+| **Rotate secrets**          | Periodically rotate client secrets             |
+| **Monitor OAuth usage**     | Watch for unusual patterns and failed attempts |
+| **Validate redirect URIs**  | Use exact match, avoid wildcards               |
 
 ## Role-Based Access Control (RBAC)
 
@@ -568,7 +599,7 @@ auth:
       # RBAC configuration
       required_claims:
         roles:
-          - "admin"           # User must have at least ONE of these role values
+          - "admin" # User must have at least ONE of these role values
           - "editor"
         department:
           - "IT"
@@ -576,7 +607,7 @@ auth:
 
       denied_claims:
         status:
-          - "suspended"       # Reject users with ANY of these status values
+          - "suspended" # Reject users with ANY of these status values
           - "inactive"
 ```
 
@@ -584,10 +615,10 @@ auth:
 
 Two types of claim validation rules:
 
-| Rule | Logic | Example Use Case |
-| --- | --- | --- |
-| `required_claims` | User must have at least ONE matching value per claim | Require admin OR editor role |
-| `denied_claims` | Reject if ANY value matches | Block suspended or inactive users |
+| Rule              | Logic                                                | Example Use Case                  |
+| ----------------- | ---------------------------------------------------- | --------------------------------- |
+| `required_claims` | User must have at least ONE matching value per claim | Require admin OR editor role      |
+| `denied_claims`   | Reject if ANY value matches                          | Block suspended or inactive users |
 
 **Execution order**: Denied claims are checked first (highest priority), then required claims.
 
@@ -597,9 +628,9 @@ OAuth claims can be strings or arrays. The validation handles both:
 
 ```json
 {
-  "roles": "admin",           // Single string value
+  "roles": "admin", // Single string value
   "groups": ["admins", "IT"], // Array of strings
-  "level": 5                  // Number (converted to string)
+  "level": 5 // Number (converted to string)
 }
 ```
 
@@ -620,7 +651,7 @@ auth:
       allow_dashboard_login: true
       allow_app_login: false
       required_claims:
-        hd: ["company.com"]  # Google Workspace domain
+        hd: ["company.com"] # Google Workspace domain
         role: ["admin", "superuser"]
 ```
 
@@ -639,7 +670,7 @@ auth:
       allow_dashboard_login: true
       required_claims:
         groups:
-          - "FluxbaseAdmins"       # Azure AD group name
+          - "FluxbaseAdmins" # Azure AD group name
           - "ApplicationAdmins"
       denied_claims:
         groups:
@@ -704,6 +735,7 @@ When claim validation fails, users see clear error messages:
 Fluxbase validates claims from the OAuth ID token (JWT). The ID token is returned during the token exchange and contains user identity and claims.
 
 For custom claims:
+
 1. Configure your IdP to include claims in ID token (not just userinfo endpoint)
 2. Request appropriate scopes to receive the claims
 3. Some providers require custom scopes for custom claims
@@ -754,6 +786,7 @@ function(user, context, callback) {
 **"Claim values are case-sensitive"**
 
 Claim values are matched exactly:
+
 - `"Admin"` ≠ `"admin"`
 - `"IT-Team"` ≠ `"IT Team"`
 
@@ -795,6 +828,7 @@ Once SSO is configured for dashboard login:
 3. Save settings
 
 When enabled:
+
 - Login page shows only SSO buttons
 - Password form is hidden
 - Backend rejects password attempts
@@ -827,28 +861,131 @@ This temporarily re-enables password login.
 
 ```typescript
 // User must be authenticated
-const { url } = await client.auth.linkIdentity({ provider: 'github' })
-window.location.href = url
+const { url } = await client.auth.linkIdentity({ provider: "github" });
+window.location.href = url;
 ```
 
 ### Unlink OAuth Provider
 
 ```typescript
-await client.auth.unlinkIdentity({ provider: 'github' })
+await client.auth.unlinkIdentity({ provider: "github" });
 ```
 
 ## Troubleshooting
 
-| Issue | Solution |
-|-------|----------|
-| **Redirect URI mismatch** | Ensure redirect URI in Fluxbase config exactly matches provider registration (include protocol, no trailing slashes) |
-| **Invalid state parameter** | Enable cookies (state stored in cookie), verify cross-site cookie settings |
-| **Client secret invalid** | Verify secret hasn't expired, regenerate if needed |
-| **Users can't sign in** | Check provider returns email, verify scopes include necessary permissions |
-| **Custom provider not working** | Verify `issuer_url` is accessible, check OIDC discovery endpoint |
-| **Token encryption errors** | Ensure `FLUXBASE_ENCRYPTION_KEY` is exactly 32 bytes |
-| **CORS errors** | Configure allowed origins in Fluxbase CORS settings |
-| **Dev vs prod URLs** | Use environment variables for redirect URLs |
+| Issue                           | Solution                                                                                                             |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Redirect URI mismatch**       | Ensure redirect URI in Fluxbase config exactly matches provider registration (include protocol, no trailing slashes) |
+| **Invalid state parameter**     | Enable cookies (state stored in cookie), verify cross-site cookie settings                                           |
+| **Client secret invalid**       | Verify secret hasn't expired, regenerate if needed                                                                   |
+| **Users can't sign in**         | Check provider returns email, verify scopes include necessary permissions                                            |
+| **Custom provider not working** | Verify `issuer_url` is accessible, check OIDC discovery endpoint                                                     |
+| **Token encryption errors**     | Ensure `FLUXBASE_ENCRYPTION_KEY` is exactly 32 bytes                                                                 |
+| **CORS errors**                 | Configure allowed origins in Fluxbase CORS settings                                                                  |
+| **Dev vs prod URLs**            | Use environment variables for redirect URLs                                                                          |
+
+### Refresh Token Issues
+
+If users need to re-authenticate frequently or sessions don't persist, check provider-specific requirements:
+
+#### Google
+
+- **Mechanism**: `access_type=offline` parameter + `prompt=consent`
+- **Automatic**: Fluxbase adds both parameters automatically
+- **Scopes**: `[openid, email, profile]` - **NO** `offline_access`
+
+```yaml
+scopes: [openid, email, profile] # ✅ Correct
+```
+
+#### Microsoft & GitLab
+
+- **Mechanism**: Standard OIDC with `offline_access` scope
+- **Scopes**: `[openid, email, profile, offline_access]`
+
+```yaml
+scopes: [openid, email, profile, offline_access] # ✅ Correct
+```
+
+#### GitHub
+
+- **Mechanism**: Not OIDC-compliant; uses GitHub App tokens
+- **Note**: Standard OAuth may not provide refresh tokens; consider GitHub Apps
+- **Scopes**: `[read:user, user:email]` - **NO** `offline_access`
+
+```yaml
+scopes: [read:user, user:email] # ✅ Correct
+```
+
+#### Twitter (X)
+
+- **Mechanism**: OAuth 2.0 PKCE flow
+- **Important**: Uses **dot** not underscore!
+- **Scopes**: `[tweet.read, users.read, offline.access]`
+
+```yaml
+scopes: [tweet.read, users.read, offline.access] # ✅ Note the dot!
+```
+
+#### LinkedIn
+
+- **Mechanism**: Standard OAuth 2.0
+- **Note**: Issues refresh tokens automatically
+- **Scopes**: `[r_liteprofile, r_emailaddress]`
+
+```yaml
+scopes: [r_liteprofile, r_emailaddress] # ✅ Correct
+```
+
+#### Bitbucket
+
+- **Mechanism**: OAuth 2.0 with rotating refresh tokens
+- **Scopes**: `[account, email]`
+
+```yaml
+scopes: [account, email] # ✅ Correct
+```
+
+#### Apple
+
+- **Mechanism**: Short-lived tokens only
+- **Note**: Users must re-authenticate periodically (Apple design)
+- **Scopes**: `[email, name]` - No refresh tokens
+
+```yaml
+scopes: [email, name] # ✅ Correct (no refresh token support)
+```
+
+#### Facebook
+
+- **Mechanism**: Long-lived tokens via separate API exchange
+- **Note**: Standard OAuth does not provide refresh tokens
+- **Scopes**: `[email, public_profile]`
+
+```yaml
+scopes: [email, public_profile] # ✅ Standard (no refresh tokens)
+```
+
+#### Custom OIDC (Keycloak, Auth0, Authelia, etc.)
+
+- **Mechanism**: Standard OIDC authorization code flow
+- **Scopes**: `[openid, email, profile, offline_access]`
+
+```yaml
+scopes: [openid, email, profile, offline_access] # ✅ Correct
+```
+
+**Why refresh tokens matter:**
+
+- Enable long-lived sessions without requiring re-authentication
+- Allow automatic token refresh in the background
+- Essential for production applications with persistent login
+
+**How Fluxbase handles it:**
+
+- Automatically adds `access_type=offline` for all providers
+- Adds `prompt=consent` for Google (ensures refresh tokens on repeat logins)
+- Stores refresh tokens securely in the database (encrypted if key configured)
 
 ### Debug Logging
 
@@ -859,6 +996,7 @@ debug: true
 ```
 
 Check logs for:
+
 - OAuth request/response details
 - Token exchange errors
 - User info extraction

--- a/docs/src/content/docs/sdk/oauth.md
+++ b/docs/src/content/docs/sdk/oauth.md
@@ -87,14 +87,72 @@ console.log('Provider created:', result.id)
 #### Built-in Provider Names
 
 Supported built-in providers:
-- `github`
 - `google`
+- `github`
 - `gitlab`
 - `microsoft`
-- `discord`
-- `slack`
+- `apple`
 - `facebook`
 - `twitter`
+- `linkedin`
+- `bitbucket`
+
+#### Important: Provider-Specific Configuration
+
+Different OAuth providers handle refresh tokens differently. Configure scopes correctly for each provider:
+
+**Google** (uses parameter, not scope):
+```typescript
+{
+  provider_name: 'google',
+  scopes: ['openid', 'email', 'profile'],
+  // Fluxbase automatically adds access_type=offline + prompt=consent
+}
+```
+
+**Microsoft, GitLab, and OIDC providers** (use `offline_access` scope):
+```typescript
+{
+  provider_name: 'microsoft', // or 'gitlab', 'keycloak', 'auth0', etc.
+  scopes: ['openid', 'email', 'profile', 'offline_access'],
+}
+```
+
+**GitHub** (not OIDC-compliant):
+```typescript
+{
+  provider_name: 'github',
+  scopes: ['read:user', 'user:email'],
+  // Note: May require GitHub Apps for refresh tokens
+}
+```
+
+**Twitter/X** (note the **dot** in scope name):
+```typescript
+{
+  provider_name: 'twitter',
+  scopes: ['tweet.read', 'users.read', 'offline.access'], // Note: offline.access
+}
+```
+
+**Apple** (short-lived tokens only):
+```typescript
+{
+  provider_name: 'apple',
+  scopes: ['email', 'name'],
+  // Note: Apple tokens are short-lived; users must re-authenticate
+}
+```
+
+**LinkedIn, Bitbucket** (standard OAuth):
+```typescript
+{
+  provider_name: 'linkedin',
+  scopes: ['r_liteprofile', 'r_emailaddress'],
+}
+```
+
+Without proper refresh token configuration, users will need to re-authenticate when their access token expires.
 
 ### Create Custom OAuth2 Provider
 
@@ -108,7 +166,7 @@ await client.admin.oauth.providers.createProvider({
   client_id: 'your-client-id',
   client_secret: 'your-client-secret',
   redirect_url: 'https://yourapp.com/auth/callback',
-  scopes: ['openid', 'profile', 'email'],
+  scopes: ['openid', 'profile', 'email', 'offline_access'],
   is_custom: true,
   authorization_url: 'https://sso.example.com/oauth/authorize',
   token_url: 'https://sso.example.com/oauth/token',
@@ -278,19 +336,19 @@ for (const config of providers) {
 Configure custom OAuth2 provider for enterprise single sign-on:
 
 ```typescript
-await client.admin.oauth.providers.createProvider({
-  provider_name: 'okta_sso',
-  display_name: 'Okta SSO',
-  enabled: true,
-  client_id: process.env.OKTA_CLIENT_ID!,
-  client_secret: process.env.OKTA_CLIENT_SECRET!,
-  redirect_url: 'https://yourapp.com/auth/callback/okta',
-  scopes: ['openid', 'profile', 'email', 'groups'],
-  is_custom: true,
-  authorization_url: 'https://your-org.okta.com/oauth2/v1/authorize',
-  token_url: 'https://your-org.okta.com/oauth2/v1/token',
-  user_info_url: 'https://your-org.okta.com/oauth2/v1/userinfo'
-})
+  await client.admin.oauth.providers.createProvider({
+    provider_name: 'okta_sso',
+    display_name: 'Okta SSO',
+    enabled: true,
+    client_id: process.env.OKTA_CLIENT_ID!,
+    client_secret: process.env.OKTA_CLIENT_SECRET!,
+    redirect_url: 'https://yourapp.com/auth/callback/okta',
+    scopes: ['openid', 'profile', 'email', 'groups', 'offline_access'],
+    is_custom: true,
+    authorization_url: 'https://your-org.okta.com/oauth2/v1/authorize',
+    token_url: 'https://your-org.okta.com/oauth2/v1/token',
+    user_info_url: 'https://your-org.okta.com/oauth2/v1/userinfo'
+  })
 
 console.log('Enterprise SSO configured')
 ```

--- a/internal/api/dashboard_auth_handler.go
+++ b/internal/api/dashboard_auth_handler.go
@@ -889,8 +889,16 @@ func (h *DashboardAuthHandler) InitiateOAuthLogin(c fiber.Ctx) error {
 	h.oauthConfigs[state] = config
 	h.oauthConfigsMu.Unlock()
 
+	// Build auth URL options
+	authURLOpts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
+
+	// Add prompt=consent for Google to ensure refresh tokens on subsequent logins
+	if strings.ToLower(providerName) == "google" {
+		authURLOpts = append(authURLOpts, oauth2.SetAuthURLParam("prompt", "consent"))
+	}
+
 	// Redirect to OAuth provider
-	authorizeURL := config.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	authorizeURL := config.AuthCodeURL(state, authURLOpts...)
 
 	log.Debug().
 		Str("state", state).
@@ -942,7 +950,7 @@ func (h *DashboardAuthHandler) buildOAuthConfig(provider, clientID, clientSecret
 				TokenURL: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
 			}
 			if len(scopes) == 0 {
-				scopes = []string{"openid", "email", "profile"}
+				scopes = []string{"openid", "email", "profile", "offline_access"}
 			}
 		case "gitlab":
 			endpoint = oauth2.Endpoint{
@@ -950,7 +958,7 @@ func (h *DashboardAuthHandler) buildOAuthConfig(provider, clientID, clientSecret
 				TokenURL: "https://gitlab.com/oauth/token",
 			}
 			if len(scopes) == 0 {
-				scopes = []string{"read_user", "openid", "email"}
+				scopes = []string{"read_user", "openid", "email", "offline_access"}
 			}
 		default:
 			return nil

--- a/internal/api/oauth_handler.go
+++ b/internal/api/oauth_handler.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -159,8 +160,16 @@ func (h *OAuthHandler) Authorize(c fiber.Ctx) error {
 		})
 	}
 
+	// Build auth URL options
+	authURLOpts := []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
+
+	// Add prompt=consent for Google to ensure refresh tokens on subsequent logins
+	if strings.ToLower(providerName) == "google" {
+		authURLOpts = append(authURLOpts, oauth2.SetAuthURLParam("prompt", "consent"))
+	}
+
 	// Generate authorization URL
-	authURL := oauthConfig.AuthCodeURL(state, oauth2.AccessTypeOffline)
+	authURL := oauthConfig.AuthCodeURL(state, authURLOpts...)
 
 	log.Info().
 		Str("provider", providerName).

--- a/sdk/src/oauth.ts
+++ b/sdk/src/oauth.ts
@@ -1,4 +1,4 @@
-import type { FluxbaseFetch } from './fetch'
+import type { FluxbaseFetch } from "./fetch";
 import type {
   OAuthProvider,
   CreateOAuthProviderRequest,
@@ -9,7 +9,7 @@ import type {
   AuthSettings,
   UpdateAuthSettingsRequest,
   UpdateAuthSettingsResponse,
-} from './types'
+} from "./types";
 
 /**
  * OAuth Provider Manager
@@ -66,8 +66,10 @@ export class OAuthProviderManager {
    * ```
    */
   async listProviders(): Promise<OAuthProvider[]> {
-    const providers = await this.fetch.get<OAuthProvider[]>('/api/v1/admin/oauth/providers')
-    return Array.isArray(providers) ? providers : []
+    const providers = await this.fetch.get<OAuthProvider[]>(
+      "/api/v1/admin/oauth/providers",
+    );
+    return Array.isArray(providers) ? providers : [];
   }
 
   /**
@@ -89,7 +91,9 @@ export class OAuthProviderManager {
    * ```
    */
   async getProvider(providerId: string): Promise<OAuthProvider> {
-    return await this.fetch.get<OAuthProvider>(`/api/v1/admin/oauth/providers/${providerId}`)
+    return await this.fetch.get<OAuthProvider>(
+      `/api/v1/admin/oauth/providers/${providerId}`,
+    );
   }
 
   /**
@@ -129,7 +133,7 @@ export class OAuthProviderManager {
    *   client_id: 'client-id',
    *   client_secret: 'client-secret',
    *   redirect_url: 'https://yourapp.com/auth/callback',
-   *   scopes: ['openid', 'profile', 'email'],
+   *   scopes: ['openid', 'profile', 'email', 'offline_access'],
    *   is_custom: true,
    *   authorization_url: 'https://sso.example.com/oauth/authorize',
    *   token_url: 'https://sso.example.com/oauth/token',
@@ -137,8 +141,13 @@ export class OAuthProviderManager {
    * })
    * ```
    */
-  async createProvider(request: CreateOAuthProviderRequest): Promise<CreateOAuthProviderResponse> {
-    return await this.fetch.post<CreateOAuthProviderResponse>('/api/v1/admin/oauth/providers', request)
+  async createProvider(
+    request: CreateOAuthProviderRequest,
+  ): Promise<CreateOAuthProviderResponse> {
+    return await this.fetch.post<CreateOAuthProviderResponse>(
+      "/api/v1/admin/oauth/providers",
+      request,
+    );
   }
 
   /**
@@ -179,12 +188,12 @@ export class OAuthProviderManager {
    */
   async updateProvider(
     providerId: string,
-    request: UpdateOAuthProviderRequest
+    request: UpdateOAuthProviderRequest,
   ): Promise<UpdateOAuthProviderResponse> {
     return await this.fetch.put<UpdateOAuthProviderResponse>(
       `/api/v1/admin/oauth/providers/${providerId}`,
-      request
-    )
+      request,
+    );
   }
 
   /**
@@ -213,10 +222,12 @@ export class OAuthProviderManager {
    * }
    * ```
    */
-  async deleteProvider(providerId: string): Promise<DeleteOAuthProviderResponse> {
+  async deleteProvider(
+    providerId: string,
+  ): Promise<DeleteOAuthProviderResponse> {
     return await this.fetch.delete<DeleteOAuthProviderResponse>(
-      `/api/v1/admin/oauth/providers/${providerId}`
-    )
+      `/api/v1/admin/oauth/providers/${providerId}`,
+    );
   }
 
   /**
@@ -232,8 +243,10 @@ export class OAuthProviderManager {
    * await client.admin.oauth.enableProvider('provider-id')
    * ```
    */
-  async enableProvider(providerId: string): Promise<UpdateOAuthProviderResponse> {
-    return await this.updateProvider(providerId, { enabled: true })
+  async enableProvider(
+    providerId: string,
+  ): Promise<UpdateOAuthProviderResponse> {
+    return await this.updateProvider(providerId, { enabled: true });
   }
 
   /**
@@ -249,8 +262,10 @@ export class OAuthProviderManager {
    * await client.admin.oauth.disableProvider('provider-id')
    * ```
    */
-  async disableProvider(providerId: string): Promise<UpdateOAuthProviderResponse> {
-    return await this.updateProvider(providerId, { enabled: false })
+  async disableProvider(
+    providerId: string,
+  ): Promise<UpdateOAuthProviderResponse> {
+    return await this.updateProvider(providerId, { enabled: false });
   }
 }
 
@@ -295,7 +310,7 @@ export class AuthSettingsManager {
    * ```
    */
   async get(): Promise<AuthSettings> {
-    return await this.fetch.get<AuthSettings>('/api/v1/admin/auth/settings')
+    return await this.fetch.get<AuthSettings>("/api/v1/admin/auth/settings");
   }
 
   /**
@@ -336,8 +351,13 @@ export class AuthSettingsManager {
    * })
    * ```
    */
-  async update(request: UpdateAuthSettingsRequest): Promise<UpdateAuthSettingsResponse> {
-    return await this.fetch.put<UpdateAuthSettingsResponse>('/api/v1/admin/auth/settings', request)
+  async update(
+    request: UpdateAuthSettingsRequest,
+  ): Promise<UpdateAuthSettingsResponse> {
+    return await this.fetch.put<UpdateAuthSettingsResponse>(
+      "/api/v1/admin/auth/settings",
+      request,
+    );
   }
 }
 
@@ -358,11 +378,11 @@ export class AuthSettingsManager {
  * ```
  */
 export class FluxbaseOAuth {
-  public providers: OAuthProviderManager
-  public authSettings: AuthSettingsManager
+  public providers: OAuthProviderManager;
+  public authSettings: AuthSettingsManager;
 
   constructor(fetch: FluxbaseFetch) {
-    this.providers = new OAuthProviderManager(fetch)
-    this.authSettings = new AuthSettingsManager(fetch)
+    this.providers = new OAuthProviderManager(fetch);
+    this.authSettings = new AuthSettingsManager(fetch);
   }
 }


### PR DESCRIPTION
- Add prompt=consent parameter for Google OAuth to ensure refresh tokens on subsequent logins
- Update documentation with comprehensive provider-specific refresh token requirements
- Document that Google uses access_type=offline parameter, not offline_access scope
- Document provider-specific requirements for troubleshooting section
- Update SDK documentation with provider-specific examples

Key findings from research:
- Google: Uses access_type=offline parameter + prompt=consent (not offline_access scope)
- GitHub: Limited OIDC compliance; uses different mechanism
- Microsoft/GitLab: Require offline_access scope
- Twitter: Uses offline.access scope (note the dot)
- Apple/Facebook: No refresh tokens (short-lived tokens only)
- LinkedIn/Bitbucket: Auto-issued refresh tokens

Fixes refresh token issues reported by users when using Google OAuth.