### PR TITLE
feat: add getProviderToken endpoint for retrieving OAuth provider tokens

### DIFF
--- a/internal/api/oauth_handler.go
+++ b/internal/api/oauth_handler.go
@@ -927,4 +927,246 @@ func (h *OAuthHandler) GetAndValidateState(state string) (*auth.StateMetadata, b
 	return h.stateStore.GetAndValidate(context.Background(), state)
 }
 
+// ProviderTokenResponse represents the response for getting provider tokens
+type ProviderTokenResponse struct {
+	Provider     string   `json:"provider"`
+	AccessToken  string   `json:"access_token"`
+	RefreshToken string   `json:"refresh_token,omitempty"`
+	TokenExpiry  string   `json:"token_expiry"`
+	ExpiresIn    int      `json:"expires_in"`
+	IDToken      string   `json:"id_token,omitempty"`
+	Scopes       []string `json:"scopes,omitempty"`
+	TokenType    string   `json:"token_type"`
+}
+
+// GetProviderToken retrieves the OAuth provider tokens for the authenticated user
+// This endpoint allows users to retrieve their stored OAuth tokens to make API calls
+// to the provider (e.g., Google Drive API).
+// GET /api/v1/auth/oauth/:provider/token
+func (h *OAuthHandler) GetProviderToken(c fiber.Ctx) error {
+	ctx := c.RequestCtx()
+	providerName := c.Params("provider")
+
+	userID := c.Locals("user_id")
+	if userID == nil || userID.(string) == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Authentication required",
+		})
+	}
+	userIDStr := userID.(string)
+
+	if h.db == nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Database connection not initialized",
+		})
+	}
+
+	oauthConfig, err := h.getProviderConfigForToken(ctx, providerName)
+	if err != nil {
+		log.Error().Err(err).Str("provider", providerName).Msg("Failed to get OAuth provider config for token retrieval")
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": fmt.Sprintf("OAuth provider '%s' not configured or disabled", providerName),
+		})
+	}
+
+	storedToken, err := h.logoutService.GetUserOAuthToken(ctx, userIDStr, providerName)
+	if err != nil {
+		if errors.Is(err, auth.ErrOAuthTokenNotFound) {
+			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+				"error":         "No OAuth token found for this provider",
+				"error_code":    "oauth_token_not_found",
+				"error_hint":    "You need to sign in with this provider first",
+				"provider":      providerName,
+				"authorize_url": fmt.Sprintf("%s/api/v1/auth/oauth/%s/authorize", h.baseURL, providerName),
+			})
+		}
+		log.Error().Err(err).Str("provider", providerName).Str("user_id", userIDStr).Msg("Failed to get stored OAuth token")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to retrieve OAuth token",
+		})
+	}
+
+	accessToken := storedToken.AccessToken
+	refreshToken := storedToken.RefreshToken
+	idToken := storedToken.IDToken
+
+	if h.encryptionKey != "" {
+		if accessToken != "" {
+			decrypted, decErr := crypto.Decrypt(accessToken, h.encryptionKey)
+			if decErr == nil {
+				accessToken = decrypted
+			} else {
+				log.Warn().Err(decErr).Str("provider", providerName).Msg("Failed to decrypt access token")
+			}
+		}
+		if refreshToken != "" {
+			decrypted, decErr := crypto.Decrypt(refreshToken, h.encryptionKey)
+			if decErr == nil {
+				refreshToken = decrypted
+			}
+		}
+		if idToken != "" {
+			decrypted, decErr := crypto.Decrypt(idToken, h.encryptionKey)
+			if decErr == nil {
+				idToken = decrypted
+			}
+		}
+	}
+
+	tokenExpiry := storedToken.TokenExpiry
+	needsRefresh := !tokenExpiry.IsZero() && time.Now().After(tokenExpiry.Add(-5*time.Minute))
+
+	if needsRefresh && refreshToken != "" {
+		log.Info().Str("provider", providerName).Str("user_id", userIDStr).Msg("OAuth token expired or expiring soon, attempting refresh")
+
+		token := &oauth2.Token{
+			AccessToken:  accessToken,
+			RefreshToken: refreshToken,
+			Expiry:       tokenExpiry,
+		}
+		if idToken != "" {
+			token = token.WithExtra(map[string]interface{}{"id_token": idToken})
+		}
+
+		newToken, refreshErr := oauthConfig.TokenSource(ctx, token).Token()
+		if refreshErr != nil {
+			log.Warn().Err(refreshErr).Str("provider", providerName).Str("user_id", userIDStr).Msg("Failed to refresh OAuth token, returning existing token")
+		} else {
+			accessToken = newToken.AccessToken
+			refreshToken = newToken.RefreshToken
+			tokenExpiry = newToken.Expiry
+			if rawIDToken, ok := newToken.Extra("id_token").(string); ok {
+				idToken = rawIDToken
+			}
+
+			go func() {
+				refreshCtx := context.Background()
+				accessTokenToStore := newToken.AccessToken
+				refreshTokenToStore := newToken.RefreshToken
+				idTokenToStore := idToken
+
+				if h.encryptionKey != "" {
+					var encErr error
+					accessTokenToStore, encErr = crypto.EncryptIfNotEmpty(newToken.AccessToken, h.encryptionKey)
+					if encErr != nil {
+						log.Warn().Err(encErr).Str("provider", providerName).Msg("Failed to encrypt refreshed access token")
+						return
+					}
+					refreshTokenToStore, encErr = crypto.EncryptIfNotEmpty(newToken.RefreshToken, h.encryptionKey)
+					if encErr != nil {
+						log.Warn().Err(encErr).Str("provider", providerName).Msg("Failed to encrypt refreshed refresh token")
+						return
+					}
+					idTokenToStore, encErr = crypto.EncryptIfNotEmpty(idTokenToStore, h.encryptionKey)
+					if encErr != nil {
+						log.Warn().Err(encErr).Str("provider", providerName).Msg("Failed to encrypt refreshed id token")
+						return
+					}
+				}
+
+				_, err := h.db.Exec(refreshCtx, `
+					UPDATE auth.oauth_tokens
+					SET access_token = $1, refresh_token = $2, id_token = $3, token_expiry = $4, updated_at = CURRENT_TIMESTAMP
+					WHERE user_id = $5 AND provider = $6
+				`, accessTokenToStore, refreshTokenToStore, idTokenToStore, newToken.Expiry, userIDStr, providerName)
+				if err != nil {
+					log.Warn().Err(err).Str("provider", providerName).Str("user_id", userIDStr).Msg("Failed to update refreshed OAuth token in database")
+				} else {
+					log.Info().Str("provider", providerName).Str("user_id", userIDStr).Msg("OAuth token refreshed and updated in database")
+				}
+			}()
+		}
+	}
+
+	expiresIn := 0
+	if !tokenExpiry.IsZero() {
+		expiresIn = int(time.Until(tokenExpiry).Seconds())
+		if expiresIn < 0 {
+			expiresIn = 0
+		}
+	}
+
+	var scopes []string
+	if oauthConfig.Scopes != nil {
+		scopes = oauthConfig.Scopes
+	}
+
+	response := ProviderTokenResponse{
+		Provider:     providerName,
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenExpiry:  tokenExpiry.UTC().Format(time.RFC3339),
+		ExpiresIn:    expiresIn,
+		IDToken:      idToken,
+		Scopes:       scopes,
+		TokenType:    "Bearer",
+	}
+
+	log.Info().
+		Str("provider", providerName).
+		Str("user_id", userIDStr).
+		Bool("was_refreshed", needsRefresh).
+		Msg("OAuth provider token retrieved")
+
+	return c.JSON(response)
+}
+
+// getProviderConfigForToken retrieves OAuth configuration for token operations
+// Unlike getProviderConfig, this doesn't require allow_app_login to be true
+// since the user already has a stored token from a previous OAuth flow
+func (h *OAuthHandler) getProviderConfigForToken(ctx context.Context, providerName string) (*oauth2.Config, error) {
+	query := `
+		SELECT client_id, client_secret, redirect_url, scopes,
+		       authorization_url, token_url, is_custom,
+		       COALESCE(is_encrypted, false) AS is_encrypted
+		FROM dashboard.oauth_providers
+		WHERE provider_name = $1 AND enabled = TRUE
+	`
+
+	var clientID, clientSecret, redirectURL string
+	var scopes []string
+	var authURL, tokenURL *string
+	var isCustom bool
+	var isEncrypted bool
+
+	err := h.db.QueryRow(ctx, query, providerName).Scan(
+		&clientID, &clientSecret, &redirectURL, &scopes,
+		&authURL, &tokenURL, &isCustom, &isEncrypted,
+	)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("OAuth provider '%s' not found or disabled", providerName)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query OAuth provider: %w", err)
+	}
+
+	if isEncrypted && clientSecret != "" {
+		decryptedSecret, decErr := crypto.Decrypt(clientSecret, h.encryptionKey)
+		if decErr != nil {
+			log.Error().Err(decErr).Str("provider", providerName).Msg("Failed to decrypt client secret")
+			return nil, fmt.Errorf("failed to decrypt client secret for provider '%s'", providerName)
+		}
+		clientSecret = decryptedSecret
+	}
+
+	config := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		Scopes:       scopes,
+	}
+
+	if isCustom && authURL != nil && tokenURL != nil {
+		config.Endpoint = oauth2.Endpoint{
+			AuthURL:  *authURL,
+			TokenURL: *tokenURL,
+		}
+	} else {
+		config.Endpoint = h.getStandardEndpoint(providerName)
+	}
+
+	return config, nil
+}
+
 // fiber:context-methods migrated

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2044,6 +2044,13 @@ func (s *Server) setupAuthRoutes(router fiber.Router) {
 	router.Get("/oauth/:provider/authorize", s.oauthHandler.Authorize)
 	router.Get("/oauth/:provider/callback", s.oauthHandler.Callback)
 
+	// OAuth token retrieval - allows users to get their stored provider tokens
+	// Requires authentication (user must be logged in with Fluxbase JWT)
+	router.Get("/oauth/:provider/token",
+		middleware.RequireAuthOrServiceKey(s.authHandler.authService, s.clientKeyService, s.db.Pool(), s.dashboardAuthHandler.jwtManager),
+		s.oauthHandler.GetProviderToken,
+	)
+
 	// OAuth Single Logout routes
 	// Logout requires authentication, callback is public (validates via state parameter)
 	router.Post("/oauth/:provider/logout",

--- a/sdk/src/auth.test.ts
+++ b/sdk/src/auth.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { FluxbaseAuth } from "./auth";
 import type { FluxbaseFetch } from "./fetch";
-import type { AuthResponse } from "./types";
+import type { AuthResponse, ProviderTokenResponse } from "./types";
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -2524,6 +2524,172 @@ describe("FluxbaseAuth", () => {
       expect(data?.requires_redirect).toBe(false);
 
       global.window = originalWindow;
+    });
+  });
+
+  describe("getProviderToken()", () => {
+    it("should throw error when not authenticated", async () => {
+      // Clear session
+      vi.mocked(mockFetch.get).mockClear();
+
+      const { data, error } = await auth.getProviderToken("google");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+      expect(error?.message).toBe("Not authenticated");
+    });
+
+    it("should return provider tokens when authenticated", async () => {
+      // First sign in
+      const authResponse: AuthResponse = {
+        access_token: "fluxbase-token",
+        refresh_token: "fluxbase-refresh",
+        expires_in: 3600,
+        token_type: "Bearer",
+        user: {
+          id: "user-1",
+          email: "user@example.com",
+          created_at: new Date().toISOString(),
+        },
+      };
+      vi.mocked(mockFetch.post).mockResolvedValue(authResponse);
+      await auth.signIn({ email: "user@example.com", password: "password" });
+
+      // Mock getProviderToken response
+      const providerTokenResponse: ProviderTokenResponse = {
+        provider: "google",
+        access_token: "ya29.a0...",
+        refresh_token: "1//...",
+        token_expiry: new Date(Date.now() + 3600 * 1000).toISOString(),
+        expires_in: 3600,
+        scopes: ["openid", "email", "https://www.googleapis.com/auth/drive.readonly"],
+        token_type: "Bearer",
+      };
+      vi.mocked(mockFetch.get).mockResolvedValue(providerTokenResponse);
+
+      const { data, error } = await auth.getProviderToken("google");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/auth/oauth/google/token",
+      );
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data?.provider).toBe("google");
+      expect(data?.access_token).toBe("ya29.a0...");
+      expect(data?.refresh_token).toBe("1//...");
+      expect(data?.expires_in).toBe(3600);
+      expect(data?.token_type).toBe("Bearer");
+      expect(data?.scopes).toContain("https://www.googleapis.com/auth/drive.readonly");
+    });
+
+    it("should return error when provider token not found", async () => {
+      // First sign in
+      const authResponse: AuthResponse = {
+        access_token: "fluxbase-token",
+        refresh_token: "fluxbase-refresh",
+        expires_in: 3600,
+        token_type: "Bearer",
+        user: {
+          id: "user-1",
+          email: "user@example.com",
+          created_at: new Date().toISOString(),
+        },
+      };
+      vi.mocked(mockFetch.post).mockResolvedValue(authResponse);
+      await auth.signIn({ email: "user@example.com", password: "password" });
+
+      // Mock not found error
+      const notFoundError = {
+        error: "No OAuth token found for this provider",
+        error_code: "oauth_token_not_found",
+        error_hint: "You need to sign in with this provider first",
+        provider: "google",
+        authorize_url: "http://localhost:8080/api/v1/auth/oauth/google/authorize",
+      };
+      vi.mocked(mockFetch.get).mockRejectedValue({
+        status: 404,
+        json: () => Promise.resolve(notFoundError),
+      });
+
+      const { data, error } = await auth.getProviderToken("google");
+
+      expect(data).toBeNull();
+      expect(error).toBeDefined();
+    });
+
+    it("should handle auto-refreshed tokens", async () => {
+      // First sign in
+      const authResponse: AuthResponse = {
+        access_token: "fluxbase-token",
+        refresh_token: "fluxbase-refresh",
+        expires_in: 3600,
+        token_type: "Bearer",
+        user: {
+          id: "user-1",
+          email: "user@example.com",
+          created_at: new Date().toISOString(),
+        },
+      };
+      vi.mocked(mockFetch.post).mockResolvedValue(authResponse);
+      await auth.signIn({ email: "user@example.com", password: "password" });
+
+      // Mock refreshed token response
+      const refreshedTokenResponse: ProviderTokenResponse = {
+        provider: "google",
+        access_token: "ya29.refreshed...",
+        refresh_token: "1//new...",
+        token_expiry: new Date(Date.now() + 3600 * 1000).toISOString(),
+        expires_in: 3600,
+        id_token: "eyJ...",
+        scopes: ["openid", "email", "https://www.googleapis.com/auth/drive.readonly"],
+        token_type: "Bearer",
+      };
+      vi.mocked(mockFetch.get).mockResolvedValue(refreshedTokenResponse);
+
+      const { data, error } = await auth.getProviderToken("google");
+
+      expect(error).toBeNull();
+      expect(data).toBeDefined();
+      expect(data?.access_token).toBe("ya29.refreshed...");
+      expect(data?.id_token).toBe("eyJ...");
+    });
+
+    it("should work with different providers", async () => {
+      // First sign in
+      const authResponse: AuthResponse = {
+        access_token: "fluxbase-token",
+        refresh_token: "fluxbase-refresh",
+        expires_in: 3600,
+        token_type: "Bearer",
+        user: {
+          id: "user-1",
+          email: "user@example.com",
+          created_at: new Date().toISOString(),
+        },
+      };
+      vi.mocked(mockFetch.post).mockResolvedValue(authResponse);
+      await auth.signIn({ email: "user@example.com", password: "password" });
+
+      // Mock GitHub token response
+      const githubTokenResponse: ProviderTokenResponse = {
+        provider: "github",
+        access_token: "gho_...",
+        token_expiry: new Date(Date.now() + 3600 * 1000).toISOString(),
+        expires_in: 3600,
+        scopes: ["user:email", "read:user"],
+        token_type: "Bearer",
+      };
+      vi.mocked(mockFetch.get).mockResolvedValue(githubTokenResponse);
+
+      const { data, error } = await auth.getProviderToken("github");
+
+      expect(mockFetch.get).toHaveBeenCalledWith(
+        "/api/v1/auth/oauth/github/token",
+      );
+      expect(error).toBeNull();
+      expect(data?.provider).toBe("github");
+      expect(data?.access_token).toBe("gho_...");
+      expect(data?.scopes).toContain("user:email");
     });
   });
 });

--- a/sdk/src/auth.ts
+++ b/sdk/src/auth.ts
@@ -29,6 +29,7 @@ import type {
   OAuthUrlResponse,
   OAuthLogoutOptions,
   OAuthLogoutResponse,
+  ProviderTokenResponse,
   AuthChangeEvent,
   AuthStateChangeCallback,
   AuthSubscription,
@@ -1077,6 +1078,67 @@ export class FluxbaseAuth {
       }
 
       return result.data;
+    });
+  }
+
+  /**
+   * Get provider OAuth tokens for calling external APIs
+   *
+   * Retrieves the stored OAuth tokens for a provider (e.g., Google, GitHub) that
+   * the user has previously authenticated with. Use these tokens to call provider
+   * APIs directly (e.g., Google Drive API).
+   *
+   * The access_token is automatically refreshed if it has expired or is about to expire.
+   *
+   * @param provider - OAuth provider name (e.g., 'google', 'github')
+   * @returns Promise with provider tokens (access_token, refresh_token, etc.)
+   *
+   * @example
+   * ```typescript
+   * // Get Google tokens to call Google Drive API
+   * const { data, error } = await client.auth.getProviderToken('google')
+   *
+   * if (error) {
+   *   if (error.error_code === 'oauth_token_not_found') {
+   *     // User needs to sign in with Google first
+   *     window.location.href = error.authorize_url
+   *   }
+   *   return
+   * }
+   *
+   * // Use the access token to call Google Drive API
+   * const response = await fetch('https://www.googleapis.com/drive/v3/files', {
+   *   headers: {
+   *     'Authorization': `Bearer ${data.access_token}`
+   *   }
+   * })
+   * const files = await response.json()
+   * ```
+   *
+   * @example
+   * ```typescript
+   * // Check token expiry before making API calls
+   * const { data } = await client.auth.getProviderToken('google')
+   *
+   * if (data.expires_in < 60) {
+   *   console.warn('Token expires soon, consider caching and refreshing')
+   * }
+   *
+   * // Token expiry is also available as ISO timestamp
+   * console.log('Token expires at:', data.token_expiry)
+   * ```
+   */
+  async getProviderToken(
+    provider: string,
+  ): Promise<DataResponse<ProviderTokenResponse>> {
+    return wrapAsync(async () => {
+      if (!this.session) {
+        throw new Error("Not authenticated");
+      }
+
+      return await this.fetch.get<ProviderTokenResponse>(
+        `/api/v1/auth/oauth/${provider}/token`,
+      );
     });
   }
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -424,6 +424,11 @@ export type {
   // OAuth Logout types
   OAuthLogoutOptions,
   OAuthLogoutResponse,
+
+  // Provider Token types
+  ProviderTokenResponse,
+  ProviderTokenNotFoundError,
+
   AuthSettings,
   UpdateAuthSettingsRequest,
   UpdateAuthSettingsResponse,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -870,6 +870,46 @@ export interface OAuthLogoutResponse {
   warning?: string;
 }
 
+// Provider Token Types
+/**
+ * Response from the provider token endpoint
+ * Contains OAuth tokens that can be used to call provider APIs (e.g., Google Drive)
+ */
+export interface ProviderTokenResponse {
+  /** OAuth provider name (e.g., 'google', 'github') */
+  provider: string;
+  /** Provider access token - use this to call provider APIs */
+  access_token: string;
+  /** Provider refresh token (may be empty for some providers) */
+  refresh_token?: string;
+  /** Token expiry timestamp in RFC3339 format */
+  token_expiry: string;
+  /** Seconds until token expires (0 if already expired) */
+  expires_in: number;
+  /** OpenID Connect ID token (if available) */
+  id_token?: string;
+  /** OAuth scopes granted for this token */
+  scopes?: string[];
+  /** Token type (always 'Bearer') */
+  token_type: string;
+}
+
+/**
+ * Error response when provider token is not found
+ */
+export interface ProviderTokenNotFoundError {
+  /** Error message */
+  error: string;
+  /** Error code for programmatic handling */
+  error_code: "oauth_token_not_found";
+  /** Hint for resolving the error */
+  error_hint: string;
+  /** Provider name */
+  provider: string;
+  /** URL to initiate OAuth flow for this provider */
+  authorize_url: string;
+}
+
 // SAML SSO Types
 /**
  * SAML Identity Provider configuration


### PR DESCRIPTION
Adds a new endpoint GET /api/v1/auth/oauth/:provider/token that allows authenticated users to retrieve their stored OAuth tokens (e.g., Google, GitHub) to make API calls directly to those providers.

Features:
- Automatic token refresh when expired or expiring within 5 minutes
- Returns access_token, refresh_token, id_token, scopes, and expiry info
- Provides helpful authorize_url when token not found

SDK changes:
- Add getProviderToken() method to FluxbaseAuth
- Add ProviderTokenResponse and ProviderTokenNotFoundError types
- Add comprehensive test coverage