### PR TITLE
fix: Reorder jobs routes and fix RPC executions infinite loop

### DIFF
--- a/admin/src/routes/_authenticated/rpc/index.tsx
+++ b/admin/src/routes/_authenticated/rpc/index.tsx
@@ -97,7 +97,7 @@ function RPCContent() {
 
   const [executions, setExecutions] = useState<RPCExecution[]>([]);
   const [executionsLoading, setExecutionsLoading] = useState(false);
-  const [executionsOffset, setExecutionsOffset] = useState(0);
+  const executionsOffsetRef = useRef(0);
   const [hasMoreExecutions, setHasMoreExecutions] = useState(true);
   const [loadingMoreExecutions, setLoadingMoreExecutions] = useState(false);
   const [totalExecutions, setTotalExecutions] = useState(0);
@@ -148,13 +148,13 @@ function RPCContent() {
 
       if (isReset) {
         setExecutionsLoading(true);
-        setExecutionsOffset(0);
+        executionsOffsetRef.current = 0;
       } else {
         setLoadingMoreExecutions(true);
       }
 
       try {
-        const offset = isReset ? 0 : executionsOffset;
+        const offset = isReset ? 0 : executionsOffsetRef.current;
         const result = await rpcApi.listExecutions({
           namespace:
             selectedNamespace !== "all" ? selectedNamespace : undefined,
@@ -180,10 +180,10 @@ function RPCContent() {
         const execList = result.executions || [];
         if (isReset) {
           setExecutions(execList);
-          setExecutionsOffset(RPC_PAGE_SIZE);
+          executionsOffsetRef.current = RPC_PAGE_SIZE;
         } else {
           setExecutions((prev) => [...prev, ...execList]);
-          setExecutionsOffset((prev) => prev + RPC_PAGE_SIZE);
+          executionsOffsetRef.current += RPC_PAGE_SIZE;
         }
 
         setTotalExecutions(result.total || 0);
@@ -199,7 +199,7 @@ function RPCContent() {
         }
       }
     },
-    [selectedNamespace, searchQuery, statusFilter, executionsOffset],
+    [selectedNamespace, searchQuery, statusFilter],
   );
 
   const openExecutionDetails = (exec: RPCExecution) => {

--- a/internal/api/routes/jobs_admin.go
+++ b/internal/api/routes/jobs_admin.go
@@ -47,20 +47,19 @@ func BuildJobsAdminRoutes(deps *JobsAdminDeps) *RouteGroup {
 			{Method: "POST", Path: "/jobs/sync", Handler: deps.SyncJobs, Summary: "Sync jobs"},
 
 			// Job queue (tenant_admin can access - override roles)
+			// Literal /queue paths MUST come before parameterized /:id to avoid "queue" matching :id
 			{Method: "GET", Path: "/jobs", Handler: deps.ListAllJobs, Summary: "List all jobs", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
-			{Method: "GET", Path: "/jobs/:id", Handler: deps.GetJobAdmin, Summary: "Get job (admin)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
-			{Method: "POST", Path: "/jobs/:id/terminate", Handler: deps.TerminateJob, Summary: "Terminate job", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
-			{Method: "POST", Path: "/jobs/:id/cancel", Handler: deps.CancelJobAdmin, Summary: "Cancel job (admin)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
-			{Method: "POST", Path: "/jobs/:id/retry", Handler: deps.RetryJobAdmin, Summary: "Retry job (admin)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
-			{Method: "POST", Path: "/jobs/:id/resubmit", Handler: deps.ResubmitJobAdmin, Summary: "Resubmit job", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
-
-			// Job queue route aliases (frontend compatibility, tenant_admin can access)
 			{Method: "GET", Path: "/jobs/queue", Handler: deps.ListAllJobs, Summary: "List all jobs (queue alias)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
 			{Method: "GET", Path: "/jobs/queue/:id", Handler: deps.GetJobAdmin, Summary: "Get job (queue alias)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
 			{Method: "POST", Path: "/jobs/queue/:id/cancel", Handler: deps.CancelJobAdmin, Summary: "Cancel job (queue alias)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
 			{Method: "POST", Path: "/jobs/queue/:id/terminate", Handler: deps.TerminateJob, Summary: "Terminate job (queue alias)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
 			{Method: "POST", Path: "/jobs/queue/:id/retry", Handler: deps.RetryJobAdmin, Summary: "Retry job (queue alias)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
 			{Method: "POST", Path: "/jobs/queue/:id/resubmit", Handler: deps.ResubmitJobAdmin, Summary: "Resubmit job (queue alias)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
+			{Method: "GET", Path: "/jobs/:id", Handler: deps.GetJobAdmin, Summary: "Get job (admin)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
+			{Method: "POST", Path: "/jobs/:id/terminate", Handler: deps.TerminateJob, Summary: "Terminate job", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
+			{Method: "POST", Path: "/jobs/:id/cancel", Handler: deps.CancelJobAdmin, Summary: "Cancel job (admin)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
+			{Method: "POST", Path: "/jobs/:id/retry", Handler: deps.RetryJobAdmin, Summary: "Retry job (admin)", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
+			{Method: "POST", Path: "/jobs/:id/resubmit", Handler: deps.ResubmitJobAdmin, Summary: "Resubmit job", Roles: []string{"admin", "instance_admin", "tenant_admin"}},
 		},
 	}
 }


### PR DESCRIPTION
Move literal /jobs/queue routes before parameterized /jobs/:id to prevent Fiber from matching "queue" as a job ID. Use a ref instead of state for the executions offset in the RPC page to break an infinite re-render loop that kept the spinner stuck.