### PR TITLE
fix: Wire settings cache to fix email provider switcher not persisting

### DIFF
--- a/internal/api/email_settings_handler.go
+++ b/internal/api/email_settings_handler.go
@@ -283,6 +283,11 @@ func (h *EmailSettingsHandler) UpdateSettings(c fiber.Ctx) error {
 			}
 		}
 
+		// Invalidate settings cache so GetSettings reflects the change
+		if h.settingsCache != nil {
+			h.settingsCache.Invalidate(key)
+		}
+
 		updatedKeys = append(updatedKeys, key)
 		return nil
 	}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -293,6 +293,7 @@ func NewServer(cfg *config.Config, db *database.Connection, version string) *Ser
 	}
 	dashboardAuthService := auth.NewDashboardAuthService(db, dashboardJWTManager, cfg.Auth.TOTPIssuer)
 	systemSettingsService := auth.NewSystemSettingsService(db)
+	systemSettingsService.SetCache(authService.GetSettingsCache())
 	adminAuthHandler := NewAdminAuthHandler(authService, auth.NewUserRepository(db), dashboardAuthService, systemSettingsService, cfg)
 	// Note: dashboardAuthHandler is initialized later after samlService is created
 	clientKeyHandler := NewClientKeyHandler(clientKeyService)


### PR DESCRIPTION
The systemSettingsService in server.go was created without a cache reference, so SetSetting() silently skipped cache invalidation. The email settings handler then read from a stale cache on subsequent GETs, causing provider changes to revert immediately.