### PR TITLE
fix(tenancy): harden FDW schema import against transient connection failures

### DIFF
--- a/admin/src/components/layout/data/sidebar-data.ts
+++ b/admin/src/components/layout/data/sidebar-data.ts
@@ -191,6 +191,7 @@ export const sidebarData: SidebarDataWithVisibility = {
           url: "/users",
           icon: Users,
           visibility: "all",
+          requiresTenant: false,
         },
         {
           title: "Authentication",

--- a/admin/src/features/dashboard/index.tsx
+++ b/admin/src/features/dashboard/index.tsx
@@ -2,7 +2,6 @@ import { LayoutDashboard } from 'lucide-react'
 import { Main } from '@/components/layout/main'
 import { HealthIndicators } from './components/health-indicators'
 import { MetricsCards } from './components/metrics-cards'
-import { ActivityFeed } from './components/activity-feed'
 import { FluxbaseStats } from './components/fluxbase-stats'
 import { SecuritySummary } from './components/security-summary'
 
@@ -35,9 +34,6 @@ export function Dashboard() {
 
         {/* Security Summary */}
         <SecuritySummary />
-
-        {/* Activity Feed - moved to bottom */}
-        <ActivityFeed />
       </div>
     </Main>
   )

--- a/admin/src/features/users/components/users-columns.tsx
+++ b/admin/src/features/users/components/users-columns.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { type ColumnDef } from "@tanstack/react-table";
-import { Lock, Building2 } from "lucide-react";
+import { Lock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -10,16 +10,12 @@ import { LongText } from "@/components/long-text";
 import { providerColors, providerLabels, roles } from "../data/data";
 import { type User } from "../data/schema";
 import { DataTableRowActions } from "./data-table-row-actions";
-import { useTenantStore } from "@/stores/tenant-store";
 
 /**
  * Hook that returns user table columns with conditional tenants column.
  * The tenants column is only shown when no tenant is selected (instance admin mode).
  */
 export function useUsersColumns(): ColumnDef<User>[] {
-  const currentTenant = useTenantStore((state) => state.currentTenant);
-  const showTenantsColumn = currentTenant === null;
-
   return useMemo(() => {
     const columns: ColumnDef<User>[] = [
       {
@@ -123,42 +119,6 @@ export function useUsersColumns(): ColumnDef<User>[] {
       },
     ];
 
-    // Only include tenants column when in instance admin mode (no tenant selected)
-    if (showTenantsColumn) {
-      columns.push({
-        id: "tenant_assignments",
-        accessorFn: (row) => row.tenant_assignments || [],
-        header: ({ column }) => (
-          <DataTableColumnHeader column={column} title="Tenants" />
-        ),
-        cell: ({ row }) => {
-          const assignments = row.original.tenant_assignments;
-          if (!assignments || assignments.length === 0) {
-            return <span className="text-muted-foreground">-</span>;
-          }
-          if (assignments.length === 1) {
-            return (
-              <div className="flex items-center gap-1">
-                <Building2 className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="text-sm">{assignments[0].tenant_name}</span>
-              </div>
-            );
-          }
-          return (
-            <div className="flex items-center gap-1">
-              <Building2 className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="text-sm">{assignments[0].tenant_name}</span>
-              <Badge variant="secondary" className="ml-1 px-1.5 py-0 text-xs">
-                +{assignments.length - 1}
-              </Badge>
-            </div>
-          );
-        },
-        enableSorting: false,
-      });
-    }
-
-    // Add remaining columns
     columns.push(
       {
         accessorKey: "email_verified",
@@ -222,197 +182,5 @@ export function useUsersColumns(): ColumnDef<User>[] {
     );
 
     return columns;
-  }, [showTenantsColumn]);
+  }, []);
 }
-
-// Keep the static export for backward compatibility (used by tests, etc.)
-// This always shows the tenants column
-export const usersColumns: ColumnDef<User>[] = [
-  {
-    id: "select",
-    header: ({ table }) => (
-      <Checkbox
-        checked={
-          table.getIsAllPageRowsSelected() ||
-          (table.getIsSomePageRowsSelected() && "indeterminate")
-        }
-        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
-        className="translate-y-[2px]"
-      />
-    ),
-    meta: {
-      className: cn("max-md:sticky start-0 z-10 rounded-tl-[inherit]"),
-    },
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
-        className="translate-y-[2px]"
-      />
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "email",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Email" />
-    ),
-    cell: ({ row }) => (
-      <div className="flex items-center gap-2 ps-3">
-        <LongText className="max-w-48">{row.getValue("email")}</LongText>
-        {row.original.is_locked && (
-          <Lock className="h-3.5 w-3.5 text-orange-500" />
-        )}
-      </div>
-    ),
-    meta: {
-      className: cn(
-        "drop-shadow-[0_1px_2px_rgb(0_0_0_/_0.1)] dark:drop-shadow-[0_1px_2px_rgb(255_255_255_/_0.1)]",
-        "ps-0.5 max-md:sticky start-6 @4xl/content:table-cell @4xl/content:drop-shadow-none",
-      ),
-    },
-    enableHiding: false,
-  },
-  {
-    accessorKey: "provider",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Provider" />
-    ),
-    cell: ({ row }) => {
-      const { provider } = row.original;
-      const badgeColor = providerColors.get(provider);
-      return (
-        <div className="flex space-x-2">
-          <Badge variant="outline" className={cn("capitalize", badgeColor)}>
-            {providerLabels[provider]}
-          </Badge>
-        </div>
-      );
-    },
-    filterFn: (row, id, value) => {
-      return value.includes(row.getValue(id));
-    },
-    enableSorting: false,
-  },
-  {
-    accessorKey: "role",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Role" />
-    ),
-    cell: ({ row }) => {
-      const { role } = row.original;
-      const userType = roles.find(({ value }) => value === role);
-
-      if (!userType) {
-        return <span className="text-sm capitalize">{role}</span>;
-      }
-
-      return (
-        <div className="flex items-center gap-x-2">
-          {userType.icon && (
-            <userType.icon size={16} className="text-muted-foreground" />
-          )}
-          <span className="text-sm capitalize">{role}</span>
-        </div>
-      );
-    },
-    filterFn: (row, id, value) => {
-      return value.includes(row.getValue(id));
-    },
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    id: "tenant_assignments",
-    accessorFn: (row) => row.tenant_assignments || [],
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Tenants" />
-    ),
-    cell: ({ row }) => {
-      const assignments = row.original.tenant_assignments;
-      if (!assignments || assignments.length === 0) {
-        return <span className="text-muted-foreground">-</span>;
-      }
-      if (assignments.length === 1) {
-        return (
-          <div className="flex items-center gap-1">
-            <Building2 className="h-3.5 w-3.5 text-muted-foreground" />
-            <span className="text-sm">{assignments[0].tenant_name}</span>
-          </div>
-        );
-      }
-      return (
-        <div className="flex items-center gap-1">
-          <Building2 className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-sm">{assignments[0].tenant_name}</span>
-          <Badge variant="secondary" className="ml-1 px-1.5 py-0 text-xs">
-            +{assignments.length - 1}
-          </Badge>
-        </div>
-      );
-    },
-    enableSorting: false,
-  },
-  {
-    accessorKey: "email_verified",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Verified" />
-    ),
-    cell: ({ row }) => {
-      const verified = row.getValue("email_verified") as boolean;
-      return (
-        <Badge variant={verified ? "default" : "outline"}>
-          {verified ? "Yes" : "No"}
-        </Badge>
-      );
-    },
-    enableSorting: false,
-  },
-  {
-    accessorKey: "active_sessions",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Sessions" />
-    ),
-    cell: ({ row }) => (
-      <div className="text-center">{row.getValue("active_sessions")}</div>
-    ),
-  },
-  {
-    accessorKey: "last_sign_in",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Last Sign In" />
-    ),
-    cell: ({ row }) => {
-      const lastSignIn = row.getValue("last_sign_in") as Date | null;
-      if (!lastSignIn) {
-        return <span className="text-muted-foreground">Never</span>;
-      }
-      return (
-        <span className="text-nowrap">
-          {formatDistanceToNow(lastSignIn, { addSuffix: true })}
-        </span>
-      );
-    },
-  },
-  {
-    accessorKey: "created_at",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Created" />
-    ),
-    cell: ({ row }) => {
-      const createdAt = row.getValue("created_at") as Date;
-      return (
-        <span className="text-nowrap">
-          {formatDistanceToNow(createdAt, { addSuffix: true })}
-        </span>
-      );
-    },
-  },
-  {
-    id: "actions",
-    cell: DataTableRowActions,
-  },
-];

--- a/admin/src/hooks/use-activity-logs.ts
+++ b/admin/src/hooks/use-activity-logs.ts
@@ -138,8 +138,8 @@ export function useActivityLogs({
         hide_static_assets: true,
       });
 
-      // Filter to only show relevant activity categories
-      setLogs(data.entries.filter(isActivityLog));
+      const filtered = (data.entries ?? []).filter(isActivityLog);
+      setLogs(filtered);
     } catch (err) {
       setError(err as Error);
     } finally {

--- a/admin/src/routes/_authenticated/users/index.tsx
+++ b/admin/src/routes/_authenticated/users/index.tsx
@@ -2,12 +2,11 @@ import { useState } from "react";
 import { z } from "zod";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { Users, UserPlus, UserCheck, Clock, Shield } from "lucide-react";
+import { Users, UserPlus, UserCheck, Clock } from "lucide-react";
 import { userManagementApi } from "@/lib/api";
 import { useTenantStore } from "@/stores/tenant-store";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UsersDialogs } from "@/features/users/components/users-dialogs";
 import { UsersInviteDialog } from "@/features/users/components/users-invite-dialog";
 import { UsersProvider } from "@/features/users/components/users-provider";
@@ -19,7 +18,6 @@ const usersSearchSchema = z.object({
   email: z.string().optional(),
   provider: z.array(z.string()).optional(),
   role: z.array(z.string()).optional(),
-  tab: z.enum(["app", "dashboard"]).optional(),
 });
 
 export const Route = createFileRoute("/_authenticated/users/")({
@@ -28,23 +26,16 @@ export const Route = createFileRoute("/_authenticated/users/")({
 });
 
 function UsersPage() {
-  const navigate = Route.useNavigate();
-  const search = Route.useSearch();
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
-  const activeTab = search.tab || "app";
   const { currentTenant } = useTenantStore();
 
-  // Fetch users from API based on active tab
-  // Include tenant ID in query key to trigger refetch when tenant changes
   const { data: usersResponse, isLoading } = useQuery({
-    queryKey: ["users", activeTab, currentTenant?.id],
-    queryFn: () => userManagementApi.listUsers(activeTab),
+    queryKey: ["users", "app", currentTenant?.id],
+    queryFn: () => userManagementApi.listUsers("app"),
   });
 
-  // Extract users array from response (backend returns {users: [], total: number})
   const rawUsers = usersResponse?.users || [];
 
-  // Convert API response to match frontend schema (date strings to Date objects)
   const users = rawUsers.map((user) => ({
     ...user,
     last_sign_in: user.last_sign_in ? new Date(user.last_sign_in) : null,
@@ -52,7 +43,6 @@ function UsersPage() {
     updated_at: new Date(user.updated_at),
   }));
 
-  // Calculate stats
   const totalUsers = users.length;
   const verifiedUsers = users.filter((u) => u.email_verified).length;
   const activeToday = users.filter((u) => {
@@ -78,7 +68,7 @@ function UsersPage() {
   }
 
   return (
-    <UsersProvider userType={activeTab}>
+    <UsersProvider userType="app">
       <div className="flex h-full flex-col">
         {/* Header */}
         <div className="bg-background flex items-center justify-between border-b px-6 py-4">
@@ -89,9 +79,7 @@ function UsersPage() {
             <div>
               <h1 className="text-xl font-semibold">Users</h1>
               <p className="text-muted-foreground text-sm">
-                {activeTab === "app"
-                  ? "Manage application users who access your app through the REST API"
-                  : "Manage Fluxbase dashboard administrators and operators"}
+                Manage application users
               </p>
             </div>
           </div>
@@ -101,99 +89,75 @@ function UsersPage() {
           </Button>
         </div>
 
-        {/* Tabs for User Types */}
         <div className="flex-1 overflow-auto p-6">
-          <Tabs
-            value={activeTab}
-            onValueChange={(value) => {
-              navigate({
-                search: { ...search, tab: value as "app" | "dashboard" },
-              });
-            }}
-          >
-            <TabsList>
-              <TabsTrigger value="app" className="flex items-center gap-2">
-                <Users className="h-4 w-4" />
-                Application Users
-              </TabsTrigger>
-              <TabsTrigger
-                value="dashboard"
-                className="flex items-center gap-2"
-              >
-                <Shield className="h-4 w-4" />
-                Fluxbase Users
-              </TabsTrigger>
-            </TabsList>
+          <div className="space-y-6">
+            {/* Stats Cards */}
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    Total Users
+                  </CardTitle>
+                  <Users className="text-muted-foreground h-4 w-4" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{totalUsers}</div>
+                  <p className="text-muted-foreground text-xs">
+                    {verifiedUsers} verified
+                  </p>
+                </CardContent>
+              </Card>
 
-            <TabsContent value={activeTab} className="mt-6 space-y-4">
-              {/* Stats Cards */}
-              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">
-                      Total Users
-                    </CardTitle>
-                    <Users className="text-muted-foreground h-4 w-4" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">{totalUsers}</div>
-                    <p className="text-muted-foreground text-xs">
-                      {verifiedUsers} verified
-                    </p>
-                  </CardContent>
-                </Card>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    Active Today
+                  </CardTitle>
+                  <Clock className="text-muted-foreground h-4 w-4" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{activeToday}</div>
+                  <p className="text-muted-foreground text-xs">
+                    Users signed in today
+                  </p>
+                </CardContent>
+              </Card>
 
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">
-                      Active Today
-                    </CardTitle>
-                    <Clock className="text-muted-foreground h-4 w-4" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">{activeToday}</div>
-                    <p className="text-muted-foreground text-xs">
-                      Users signed in today
-                    </p>
-                  </CardContent>
-                </Card>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    Pending Invites
+                  </CardTitle>
+                  <UserPlus className="text-muted-foreground h-4 w-4" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{pendingInvites}</div>
+                  <p className="text-muted-foreground text-xs">
+                    Awaiting first sign in
+                  </p>
+                </CardContent>
+              </Card>
 
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">
-                      Pending Invites
-                    </CardTitle>
-                    <UserPlus className="text-muted-foreground h-4 w-4" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">{pendingInvites}</div>
-                    <p className="text-muted-foreground text-xs">
-                      Awaiting first sign in
-                    </p>
-                  </CardContent>
-                </Card>
+              <Card>
+                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                  <CardTitle className="text-sm font-medium">
+                    Verified Users
+                  </CardTitle>
+                  <UserCheck className="text-muted-foreground h-4 w-4" />
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold">{verifiedUsers}</div>
+                  <p className="text-muted-foreground text-xs">
+                    {Math.round((verifiedUsers / totalUsers) * 100) || 0}% of
+                    total
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
 
-                <Card>
-                  <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                    <CardTitle className="text-sm font-medium">
-                      Verified Users
-                    </CardTitle>
-                    <UserCheck className="text-muted-foreground h-4 w-4" />
-                  </CardHeader>
-                  <CardContent>
-                    <div className="text-2xl font-bold">{verifiedUsers}</div>
-                    <p className="text-muted-foreground text-xs">
-                      {Math.round((verifiedUsers / totalUsers) * 100) || 0}% of
-                      total
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-
-              {/* Users Table */}
-              <UsersTable data={users} />
-            </TabsContent>
-          </Tabs>
+            {/* Users Table */}
+            <UsersTable data={users} />
+          </div>
         </div>
 
         {/* Invite Dialog */}

--- a/admin/src/routes/_authenticated/users/index.tsx
+++ b/admin/src/routes/_authenticated/users/index.tsx
@@ -2,11 +2,12 @@ import { useState } from "react";
 import { z } from "zod";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { Users, UserPlus, UserCheck, Clock } from "lucide-react";
+import { Users, UserPlus, UserCheck, Clock, Shield } from "lucide-react";
 import { userManagementApi } from "@/lib/api";
 import { useTenantStore } from "@/stores/tenant-store";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UsersDialogs } from "@/features/users/components/users-dialogs";
 import { UsersInviteDialog } from "@/features/users/components/users-invite-dialog";
 import { UsersProvider } from "@/features/users/components/users-provider";
@@ -18,6 +19,7 @@ const usersSearchSchema = z.object({
   email: z.string().optional(),
   provider: z.array(z.string()).optional(),
   role: z.array(z.string()).optional(),
+  tab: z.enum(["app", "dashboard"]).optional(),
 });
 
 export const Route = createFileRoute("/_authenticated/users/")({
@@ -26,12 +28,17 @@ export const Route = createFileRoute("/_authenticated/users/")({
 });
 
 function UsersPage() {
+  const navigate = Route.useNavigate();
+  const search = Route.useSearch();
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
   const { currentTenant } = useTenantStore();
 
+  const isInstanceScope = currentTenant === null;
+  const activeTab = isInstanceScope ? (search.tab || "app") : "app";
+
   const { data: usersResponse, isLoading } = useQuery({
-    queryKey: ["users", "app", currentTenant?.id],
-    queryFn: () => userManagementApi.listUsers("app"),
+    queryKey: ["users", activeTab, currentTenant?.id],
+    queryFn: () => userManagementApi.listUsers(activeTab),
   });
 
   const rawUsers = usersResponse?.users || [];
@@ -67,10 +74,78 @@ function UsersPage() {
     );
   }
 
+  const content = (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">
+              Total Users
+            </CardTitle>
+            <Users className="text-muted-foreground h-4 w-4" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{totalUsers}</div>
+            <p className="text-muted-foreground text-xs">
+              {verifiedUsers} verified
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">
+              Active Today
+            </CardTitle>
+            <Clock className="text-muted-foreground h-4 w-4" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{activeToday}</div>
+            <p className="text-muted-foreground text-xs">
+              Users signed in today
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">
+              Pending Invites
+            </CardTitle>
+            <UserPlus className="text-muted-foreground h-4 w-4" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{pendingInvites}</div>
+            <p className="text-muted-foreground text-xs">
+              Awaiting first sign in
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">
+              Verified Users
+            </CardTitle>
+            <UserCheck className="text-muted-foreground h-4 w-4" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{verifiedUsers}</div>
+            <p className="text-muted-foreground text-xs">
+              {Math.round((verifiedUsers / totalUsers) * 100) || 0}% of
+              total
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <UsersTable data={users} />
+    </div>
+  );
+
   return (
-    <UsersProvider userType="app">
+    <UsersProvider userType={activeTab}>
       <div className="flex h-full flex-col">
-        {/* Header */}
         <div className="bg-background flex items-center justify-between border-b px-6 py-4">
           <div className="flex items-center gap-3">
             <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
@@ -79,95 +154,55 @@ function UsersPage() {
             <div>
               <h1 className="text-xl font-semibold">Users</h1>
               <p className="text-muted-foreground text-sm">
-                Manage application users
+                {activeTab === "dashboard"
+                  ? "Manage Fluxbase dashboard administrators"
+                  : "Manage application users"}
               </p>
             </div>
           </div>
-          <Button onClick={() => setInviteDialogOpen(true)}>
-            <UserPlus className="mr-2 h-4 w-4" />
-            Invite User
-          </Button>
+          {activeTab === "app" && (
+            <Button onClick={() => setInviteDialogOpen(true)}>
+              <UserPlus className="mr-2 h-4 w-4" />
+              Invite User
+            </Button>
+          )}
         </div>
 
         <div className="flex-1 overflow-auto p-6">
-          <div className="space-y-6">
-            {/* Stats Cards */}
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    Total Users
-                  </CardTitle>
-                  <Users className="text-muted-foreground h-4 w-4" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{totalUsers}</div>
-                  <p className="text-muted-foreground text-xs">
-                    {verifiedUsers} verified
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    Active Today
-                  </CardTitle>
-                  <Clock className="text-muted-foreground h-4 w-4" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{activeToday}</div>
-                  <p className="text-muted-foreground text-xs">
-                    Users signed in today
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    Pending Invites
-                  </CardTitle>
-                  <UserPlus className="text-muted-foreground h-4 w-4" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{pendingInvites}</div>
-                  <p className="text-muted-foreground text-xs">
-                    Awaiting first sign in
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    Verified Users
-                  </CardTitle>
-                  <UserCheck className="text-muted-foreground h-4 w-4" />
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold">{verifiedUsers}</div>
-                  <p className="text-muted-foreground text-xs">
-                    {Math.round((verifiedUsers / totalUsers) * 100) || 0}% of
-                    total
-                  </p>
-                </CardContent>
-              </Card>
-            </div>
-
-            {/* Users Table */}
-            <UsersTable data={users} />
-          </div>
+          {isInstanceScope ? (
+            <Tabs
+              value={activeTab}
+              onValueChange={(value) => {
+                navigate({
+                  search: { ...search, tab: value as "app" | "dashboard" },
+                });
+              }}
+            >
+              <TabsList>
+                <TabsTrigger value="app" className="flex items-center gap-2">
+                  <Users className="h-4 w-4" />
+                  Application Users
+                </TabsTrigger>
+                <TabsTrigger value="dashboard" className="flex items-center gap-2">
+                  <Shield className="h-4 w-4" />
+                  Fluxbase Users
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value={activeTab} className="mt-6">
+                {content}
+              </TabsContent>
+            </Tabs>
+          ) : (
+            content
+          )}
         </div>
 
-        {/* Invite Dialog */}
         <UsersInviteDialog
           open={inviteDialogOpen}
           onOpenChange={setInviteDialogOpen}
         />
       </div>
 
-      {/* Dialogs for edit/delete actions */}
       <UsersDialogs />
     </UsersProvider>
   );

--- a/cmd/fluxbase/main.go
+++ b/cmd/fluxbase/main.go
@@ -827,12 +827,14 @@ func backfillTenantIDToDefault(pool *pgxpool.Pool) error {
 	//   - platform.enabled_extensions (NULL = instance-level extensions)
 	//   - auth.service_keys (NULL = global_service keys)
 	//   - auth.saml_providers (NULL = shared SAML providers, like OAuth)
-	tenantIDDedupTables := map[string]string{
-		"mcp.custom_tools":         "name, namespace",
-		"mcp.custom_resources":     "uri, namespace",
-		"branching.branches":       "name",
-		"branching.github_config":  "repository",
-		"platform.oauth_providers": "provider_name",
+	tenantIDDedupTables := map[string][]string{
+		"auth.users":               {"email"},
+		"functions.edge_functions": {"name, namespace"},
+		"storage.buckets":          {"name"},
+		"branching.branches":       {"name", "slug"},
+		"branching.github_config":  {"repository"},
+		"mcp.custom_tools":         {"name, namespace"},
+		"mcp.custom_resources":     {"uri, namespace"},
 	}
 
 	tables := []string{
@@ -918,15 +920,27 @@ func backfillTenantIDToDefault(pool *pgxpool.Pool) error {
 
 	var totalBackfilled int
 	for _, table := range tables {
-		if dedupCols, needsDedup := tenantIDDedupTables[table]; needsDedup {
-			dedupQuery := fmt.Sprintf(
-				"DELETE FROM %s WHERE id IN (SELECT id FROM (SELECT id, row_number() OVER (PARTITION BY %s ORDER BY created_at DESC) AS rn FROM %s WHERE tenant_id IS NULL) sub WHERE rn > 1)",
-				table, dedupCols, table,
-			)
-			if dedupResult, err := pool.Exec(ctx, dedupQuery); err != nil {
-				log.Warn().Err(err).Str("table", table).Msg("Failed to dedup NULL-tenant rows before backfill")
-			} else if n := dedupResult.RowsAffected(); n > 0 {
-				log.Info().Str("table", table).Int64("duplicates_removed", n).Msg("Removed duplicate NULL-tenant rows before backfill")
+		if dedupSets, needsDedup := tenantIDDedupTables[table]; needsDedup {
+			for _, dedupCols := range dedupSets {
+				dedupQuery := fmt.Sprintf(
+					"DELETE FROM %s WHERE id IN (SELECT id FROM (SELECT id, row_number() OVER (PARTITION BY %s ORDER BY created_at DESC) AS rn FROM %s WHERE tenant_id IS NULL) sub WHERE rn > 1)",
+					table, dedupCols, table,
+				)
+				if dedupResult, err := pool.Exec(ctx, dedupQuery); err != nil {
+					log.Warn().Err(err).Str("table", table).Str("cols", dedupCols).Msg("Failed to dedup NULL-tenant rows before backfill")
+				} else if n := dedupResult.RowsAffected(); n > 0 {
+					log.Info().Str("table", table).Str("cols", dedupCols).Int64("duplicates_removed", n).Msg("Removed duplicate NULL-tenant rows before backfill")
+				}
+
+				conflictQuery := fmt.Sprintf(
+					"DELETE FROM %s WHERE id IN (SELECT n.id FROM %s n WHERE n.tenant_id IS NULL AND EXISTS (SELECT 1 FROM %s e WHERE e.tenant_id = $1 AND (%s)))",
+					table, table, table, buildJoinCondition(dedupCols, "n", "e"),
+				)
+				if conflictResult, err := pool.Exec(ctx, conflictQuery, defaultTenantID); err != nil {
+					log.Warn().Err(err).Str("table", table).Str("cols", dedupCols).Msg("Failed to remove NULL-tenant rows conflicting with existing tenant rows")
+				} else if n := conflictResult.RowsAffected(); n > 0 {
+					log.Info().Str("table", table).Str("cols", dedupCols).Int64("conflicts_removed", n).Msg("Removed NULL-tenant rows that would conflict with existing tenant rows")
+				}
 			}
 		}
 
@@ -951,4 +965,14 @@ func backfillTenantIDToDefault(pool *pgxpool.Pool) error {
 	}
 
 	return nil
+}
+
+func buildJoinCondition(cols, leftAlias, rightAlias string) string {
+	parts := strings.Split(cols, ",")
+	conditions := make([]string, len(parts))
+	for i, col := range parts {
+		col = strings.TrimSpace(col)
+		conditions[i] = fmt.Sprintf("%s.%s = %s.%s", leftAlias, col, rightAlias, col)
+	}
+	return strings.Join(conditions, " AND ")
 }

--- a/internal/api/server_init.go
+++ b/internal/api/server_init.go
@@ -333,6 +333,7 @@ func (s *Server) initTenancy() {
 				log.Info().Msg("FDW enabled for tenant databases")
 
 				go func() {
+					time.Sleep(5 * time.Second)
 					ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 					defer cancel()
 					tenantManager.UpgradeAllTenantsFDW(ctx)

--- a/internal/api/user_management_handler.go
+++ b/internal/api/user_management_handler.go
@@ -43,8 +43,9 @@ func (h *UserManagementHandler) ListUsers(c fiber.Ctx) error {
 	tenantID := middleware.GetTenantID(c)
 	tenantSource, _ := c.Locals("tenant_source").(string)
 	isInstanceAdmin, _ := c.Locals("is_instance_admin").(bool)
+	isDefaultTenant, _ := c.Locals("is_default_tenant").(bool)
 
-	if isInstanceAdmin && tenantSource == "default" {
+	if isInstanceAdmin && (tenantSource == "default" || isDefaultTenant) {
 		tenantID = ""
 	}
 

--- a/internal/migrations/declarative.go
+++ b/internal/migrations/declarative.go
@@ -690,6 +690,17 @@ func (s *DeclarativeService) applyPlanDirectly(ctx context.Context, schema strin
 			}
 		}
 
+		// Skip ALTER TABLE ... DROP CONSTRAINT on partition tables.
+		// Partition tables inherit constraints from their parent and PostgreSQL
+		// rejects direct drops with "cannot drop inherited constraint" (SQLSTATE 42P16).
+		if strings.HasPrefix(sqlUpper, "ALTER TABLE") && strings.Contains(sqlUpper, "DROP CONSTRAINT") {
+			constraintTable := extractAlterTableName(change.SQL)
+			if partitions[constraintTable] {
+				log.Debug().Str("schema", schema).Str("table", constraintTable).Msg("Skipping DROP CONSTRAINT on partition table (inherited from parent)")
+				continue
+			}
+		}
+
 		// Substitute {{APP_USER}} placeholder with the runtime user
 		sql, subErr := bootstrap.SubstituteAppUser(change.SQL, s.appUser)
 		if subErr != nil {

--- a/internal/tenantdb/fdw.go
+++ b/internal/tenantdb/fdw.go
@@ -272,15 +272,27 @@ func setupFDWAllSchemas(ctx context.Context, tenantPool *pgxpool.Pool, cfg FDWCo
 		return fmt.Errorf("failed to create postgres_fdw extension: %w", err)
 	}
 
-	// 2. Create foreign server pointing at main database
+	// 2. Create or update foreign server pointing at main database.
+	// Tenant databases always live on the same PostgreSQL instance as the
+	// main database, so the FDW connection is a loopback. Use "localhost"
+	// instead of the external hostname (which may be a Docker service name
+	// that doesn't resolve from within the PostgreSQL process).
+	fdwHost := "localhost"
 	_, err = tenantPool.Exec(ctx, fmt.Sprintf(
 		`CREATE SERVER IF NOT EXISTS %s FOREIGN DATA WRAPPER postgres_fdw
 		  OPTIONS (host '%s', port '%s', dbname '%s')`,
-		quoteIdent(fdwServerName), cfg.Host, cfg.Port, cfg.DBName,
+		quoteIdent(fdwServerName), fdwHost, cfg.Port, cfg.DBName,
 	))
 	if err != nil {
 		return fmt.Errorf("failed to create foreign server: %w", err)
 	}
+
+	// Ensure options are current (CREATE SERVER IF NOT EXISTS skips if server
+	// already exists, leaving stale options from previous runs).
+	_, _ = tenantPool.Exec(ctx, fmt.Sprintf(
+		`ALTER SERVER %s OPTIONS (SET host '%s', SET port '%s', SET dbname '%s')`,
+		quoteIdent(fdwServerName), fdwHost, cfg.Port, cfg.DBName,
+	))
 
 	// 3. Create user mapping using admin credentials
 	// This will be replaced by the per-tenant role mapping in CreateTenantDatabase
@@ -497,8 +509,8 @@ func setupFDWLegacy(ctx context.Context, tenantPool *pgxpool.Pool, cfg FDWConfig
 	// 1. Create foreign server
 	_, err := tenantPool.Exec(ctx, fmt.Sprintf(
 		`CREATE SERVER IF NOT EXISTS %s FOREIGN DATA WRAPPER postgres_fdw
-		  OPTIONS (host '%s', port '%s', dbname '%s')`,
-		quoteIdent(fdwServerName), cfg.Host, cfg.Port, cfg.DBName,
+		  OPTIONS (host 'localhost', port '%s', dbname '%s')`,
+		quoteIdent(fdwServerName), cfg.Port, cfg.DBName,
 	))
 	if err != nil {
 		return fmt.Errorf("failed to create foreign server: %w", err)

--- a/internal/tenantdb/fdw.go
+++ b/internal/tenantdb/fdw.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
 )
@@ -51,6 +54,20 @@ var fdwExcludeTables = map[string][]string{
 		"webhook_monitored_tables", "saml_assertion_ids",
 		"nonces", "oauth_states",
 	},
+}
+
+// fdwImportRetryDelays defines the backoff delays for retrying transient FDW
+// connection errors (SQLSTATE 08001) during schema import.
+var fdwImportRetryDelays = []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second}
+
+// isFDWConnectionError returns true if the error is a transient FDW connection
+// failure (SQLSTATE 08001 — sqlclient_unable_to_establish_sqlconnection).
+func isFDWConnectionError(err error) bool {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "08001"
+	}
+	return false
 }
 
 // ParseFDWConfig extracts FDW connection details from a database URL.
@@ -282,26 +299,40 @@ func setupFDWAllSchemas(ctx context.Context, tenantPool *pgxpool.Pool, cfg FDWCo
 	}
 
 	// 4. Import tables from each FDW schema
+	var failedSchemas []string
 	for _, schema := range fdwSchemas {
 		if err := importSchemaFDW(ctx, tenantPool, schema); err != nil {
 			log.Warn().Err(err).Str("schema", schema).Msg("Failed to import schema via FDW")
-			// Continue with other schemas — not all schemas may have tables
+			failedSchemas = append(failedSchemas, schema)
 		}
 	}
 
-	log.Info().
-		Strs("schemas", fdwSchemas).
-		Str("main_db", cfg.DBName).
-		Msg("Set up FDW for tenant database (all schemas)")
+	if len(failedSchemas) == 0 {
+		log.Info().
+			Strs("schemas", fdwSchemas).
+			Str("main_db", cfg.DBName).
+			Msg("Set up FDW for tenant database (all schemas)")
+	} else {
+		log.Warn().
+			Strs("succeeded", filterSlice(fdwSchemas, failedSchemas)).
+			Strs("failed", failedSchemas).
+			Str("main_db", cfg.DBName).
+			Msg("Set up FDW for tenant database with partial failures")
+	}
 
 	return nil
 }
 
-// importSchemaFDW drops local tables and imports foreign tables for a single schema.
+// importSchemaFDW drops local and foreign tables and imports foreign tables
+// for a single schema. Transient FDW connection errors are retried with backoff.
 func importSchemaFDW(ctx context.Context, tenantPool *pgxpool.Pool, schema string) error {
 	excluded := fdwExcludeTables[schema]
 
-	// Get list of local tables in this schema to drop
+	excludeSet := make(map[string]bool, len(excluded))
+	for _, ex := range excluded {
+		excludeSet[ex] = true
+	}
+
 	rows, err := tenantPool.Query(ctx, `
 		SELECT tablename FROM pg_tables WHERE schemaname = $1
 	`, schema)
@@ -309,29 +340,20 @@ func importSchemaFDW(ctx context.Context, tenantPool *pgxpool.Pool, schema strin
 		return fmt.Errorf("failed to list tables in schema %s: %w", schema, err)
 	}
 
-	var localTables []string
+	var tablesToDrop []string
 	for rows.Next() {
 		var name string
 		if err := rows.Scan(&name); err != nil {
 			rows.Close()
 			return fmt.Errorf("failed to scan table name: %w", err)
 		}
-		// Skip excluded tables
-		skip := false
-		for _, ex := range excluded {
-			if name == ex {
-				skip = true
-				break
-			}
-		}
-		if !skip {
-			localTables = append(localTables, name)
+		if !excludeSet[name] {
+			tablesToDrop = append(tablesToDrop, name)
 		}
 	}
 	rows.Close()
 
-	// Drop local tables that will be replaced by foreign tables
-	for _, table := range localTables {
+	for _, table := range tablesToDrop {
 		_, err := tenantPool.Exec(ctx, fmt.Sprintf(
 			`DROP TABLE IF EXISTS %s.%s CASCADE`,
 			quoteIdent(schema), quoteIdent(table),
@@ -340,17 +362,38 @@ func importSchemaFDW(ctx context.Context, tenantPool *pgxpool.Pool, schema strin
 			log.Warn().Err(err).Str("schema", schema).Str("table", table).
 				Msg("Failed to drop local table before FDW import")
 		}
-		// Also drop existing foreign tables for idempotency
+	}
+
+	foreignRows, err := tenantPool.Query(ctx, `
+		SELECT ft.relname FROM pg_foreign_table f
+		JOIN pg_class ft ON f.ftrelid = ft.oid
+		JOIN pg_namespace n ON ft.relnamespace = n.oid
+		WHERE n.nspname = $1
+	`, schema)
+	if err != nil {
+		return fmt.Errorf("failed to list foreign tables in schema %s: %w", schema, err)
+	}
+
+	var foreignTables []string
+	for foreignRows.Next() {
+		var name string
+		if err := foreignRows.Scan(&name); err != nil {
+			foreignRows.Close()
+			return fmt.Errorf("failed to scan foreign table name: %w", err)
+		}
+		if !excludeSet[name] {
+			foreignTables = append(foreignTables, name)
+		}
+	}
+	foreignRows.Close()
+
+	for _, table := range foreignTables {
 		_, _ = tenantPool.Exec(ctx, fmt.Sprintf(
 			`DROP FOREIGN TABLE IF EXISTS %s.%s CASCADE`,
 			quoteIdent(schema), quoteIdent(table),
 		))
 	}
 
-	// Drop stale foreign tables for excluded names. These may exist from earlier
-	// versions that imported them before they were added to fdwExcludeTables.
-	// Without this, CREATE TABLE IF NOT EXISTS in bootstrap finds the foreign
-	// table and skips, leaving associated sequences uncreated.
 	for _, ex := range excluded {
 		_, _ = tenantPool.Exec(ctx, fmt.Sprintf(
 			`DROP FOREIGN TABLE IF EXISTS %s.%s CASCADE`,
@@ -358,13 +401,11 @@ func importSchemaFDW(ctx context.Context, tenantPool *pgxpool.Pool, schema strin
 		))
 	}
 
-	// Build IMPORT FOREIGN SCHEMA statement
 	importSQL := fmt.Sprintf(
 		`IMPORT FOREIGN SCHEMA %s FROM SERVER %s INTO %s`,
 		quoteIdent(schema), quoteIdent(fdwServerName), quoteIdent(schema),
 	)
 
-	// Add EXCEPT clause for excluded tables
 	if len(excluded) > 0 {
 		excludedList := make([]string, len(excluded))
 		for i, t := range excluded {
@@ -377,14 +418,32 @@ func importSchemaFDW(ctx context.Context, tenantPool *pgxpool.Pool, schema strin
 		)
 	}
 
-	_, err = tenantPool.Exec(ctx, importSQL)
-	if err != nil {
-		return fmt.Errorf("failed to import foreign schema %s: %w", schema, err)
+	var lastErr error
+	attempts := 1 + len(fdwImportRetryDelays)
+	for attempt := range attempts {
+		_, err = tenantPool.Exec(ctx, importSQL)
+		if err == nil {
+			break
+		}
+		lastErr = err
+		if isFDWConnectionError(err) && attempt < len(fdwImportRetryDelays) {
+			delay := fdwImportRetryDelays[attempt]
+			log.Warn().Err(err).Str("schema", schema).
+				Dur("retry_after", delay).Int("attempt", attempt+1).
+				Msg("FDW connection error, retrying schema import")
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+			continue
+		}
+		break
+	}
+	if lastErr != nil {
+		return fmt.Errorf("failed to import foreign schema %s: %w", schema, lastErr)
 	}
 
-	// Grant permissions on imported foreign tables to tenant_service and service_role.
-	// The IMPORT FOREIGN SCHEMA creates new table objects that don't inherit GRANTs
-	// from the local tables that were dropped during FDW setup.
 	for _, role := range []string{"tenant_service", "service_role"} {
 		_, err = tenantPool.Exec(ctx, fmt.Sprintf(
 			`GRANT ALL ON ALL TABLES IN SCHEMA %s TO %s`,
@@ -396,8 +455,9 @@ func importSchemaFDW(ctx context.Context, tenantPool *pgxpool.Pool, schema strin
 		}
 	}
 
-	if len(localTables) > 0 {
-		log.Debug().Str("schema", schema).Int("tables", len(localTables)).
+	importedCount := len(tablesToDrop) + len(foreignTables)
+	if importedCount > 0 {
+		log.Debug().Str("schema", schema).Int("tables", importedCount).
 			Msg("Imported schema tables via FDW")
 	}
 
@@ -545,4 +605,19 @@ func quoteIdent(name string) string {
 // escapeSQLString escapes a string for use in SQL single-quoted literals.
 func escapeSQLString(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
+}
+
+// filterSlice returns elements from slice that are not in exclude.
+func filterSlice(slice, exclude []string) []string {
+	excludeSet := make(map[string]bool, len(exclude))
+	for _, s := range exclude {
+		excludeSet[s] = true
+	}
+	var result []string
+	for _, s := range slice {
+		if !excludeSet[s] {
+			result = append(result, s)
+		}
+	}
+	return result
 }

--- a/internal/tenantdb/fdw_test.go
+++ b/internal/tenantdb/fdw_test.go
@@ -1,8 +1,10 @@
 package tenantdb
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,4 +132,54 @@ func TestTeardownFDW_NilPool(t *testing.T) {
 	err := TeardownFDW(nil, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "tenant pool is nil")
+}
+
+func TestIsFDWConnectionError(t *testing.T) {
+	t.Run("detects SQLSTATE 08001", func(t *testing.T) {
+		err := &pgconn.PgError{Code: "08001", Message: "could not connect to server"}
+		assert.True(t, isFDWConnectionError(err))
+	})
+
+	t.Run("detects wrapped SQLSTATE 08001", func(t *testing.T) {
+		pgErr := &pgconn.PgError{Code: "08001", Message: "could not connect to server"}
+		wrapped := fmt.Errorf("import failed: %w", pgErr)
+		assert.True(t, isFDWConnectionError(wrapped))
+	})
+
+	t.Run("non-connection error code", func(t *testing.T) {
+		err := &pgconn.PgError{Code: "42P01", Message: "relation not found"}
+		assert.False(t, isFDWConnectionError(err))
+	})
+
+	t.Run("non-PgError", func(t *testing.T) {
+		err := fmt.Errorf("some other error")
+		assert.False(t, isFDWConnectionError(err))
+	})
+}
+
+func TestFilterSlice(t *testing.T) {
+	t.Run("filters excluded elements", func(t *testing.T) {
+		all := []string{"a", "b", "c", "d"}
+		exclude := []string{"b", "d"}
+		result := filterSlice(all, exclude)
+		assert.Equal(t, []string{"a", "c"}, result)
+	})
+
+	t.Run("no exclusions", func(t *testing.T) {
+		all := []string{"a", "b", "c"}
+		result := filterSlice(all, nil)
+		assert.Equal(t, []string{"a", "b", "c"}, result)
+	})
+
+	t.Run("exclude all", func(t *testing.T) {
+		all := []string{"a", "b"}
+		exclude := []string{"a", "b"}
+		result := filterSlice(all, exclude)
+		assert.Empty(t, result)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		result := filterSlice(nil, []string{"a"})
+		assert.Empty(t, result)
+	})
 }


### PR DESCRIPTION
During startup, UpgradeAllTenantsFDW runs concurrently with other initialization, causing FDW loopback connections to fail (SQLSTATE 08001) for later schemas due to connection contention. On existing tenants this was silently masked — the old foreign tables remained and the failure was logged as a success.

- Add retry with exponential backoff (2s/4s/8s) for SQLSTATE 08001 errors during IMPORT FOREIGN SCHEMA
- Query pg_foreign_table to find and drop existing foreign tables before re-importing (previously only pg_tables was queried, which misses foreign tables from a previous FDW setup)
- Track failed schemas and log Warn with succeeded/failed lists instead of unconditional Info success message
- Add 5-second delay before UpgradeAllTenantsFDW goroutine to reduce startup connection contention
- Add unit tests for isFDWConnectionError and filterSlice