### PR TITLE
fix: add viper config fallback to settings cache so features default to enabled

### DIFF
--- a/internal/auth/settings_cache.go
+++ b/internal/auth/settings_cache.go
@@ -61,25 +61,27 @@ func (c *SettingsCache) GetBool(ctx context.Context, key string, defaultValue bo
 	c.mu.RUnlock()
 
 	// Cache miss or expired - fetch from database
-	setting, err := c.service.GetSetting(ctx, key)
-	if err == nil {
-		// Extract boolean value from the setting
-		var boolValue bool
-		if val, ok := setting.Value["value"].(bool); ok {
-			boolValue = val
-		} else {
-			boolValue = defaultValue
-		}
+	if c.service != nil {
+		setting, err := c.service.GetSetting(ctx, key)
+		if err == nil {
+			// Extract boolean value from the setting
+			var boolValue bool
+			if val, ok := setting.Value["value"].(bool); ok {
+				boolValue = val
+			} else {
+				boolValue = defaultValue
+			}
 
-		// Store in cache
-		c.mu.Lock()
-		c.cache[key] = cacheEntry{
-			value:      boolValue,
-			expiration: time.Now().Add(c.ttl),
-		}
-		c.mu.Unlock()
+			// Store in cache
+			c.mu.Lock()
+			c.cache[key] = cacheEntry{
+				value:      boolValue,
+				expiration: time.Now().Add(c.ttl),
+			}
+			c.mu.Unlock()
 
-		return boolValue
+			return boolValue
+		}
 	}
 
 	// Database miss - fall back to viper config
@@ -116,28 +118,30 @@ func (c *SettingsCache) GetInt(ctx context.Context, key string, defaultValue int
 	c.mu.RUnlock()
 
 	// Cache miss or expired - fetch from database
-	setting, err := c.service.GetSetting(ctx, key)
-	if err == nil {
-		// Extract integer value from the setting
-		var intValue int
-		switch v := setting.Value["value"].(type) {
-		case int:
-			intValue = v
-		case float64:
-			intValue = int(v)
-		default:
-			intValue = defaultValue
-		}
+	if c.service != nil {
+		setting, err := c.service.GetSetting(ctx, key)
+		if err == nil {
+			// Extract integer value from the setting
+			var intValue int
+			switch v := setting.Value["value"].(type) {
+			case int:
+				intValue = v
+			case float64:
+				intValue = int(v)
+			default:
+				intValue = defaultValue
+			}
 
-		// Store in cache
-		c.mu.Lock()
-		c.cache[key] = cacheEntry{
-			value:      intValue,
-			expiration: time.Now().Add(c.ttl),
-		}
-		c.mu.Unlock()
+			// Store in cache
+			c.mu.Lock()
+			c.cache[key] = cacheEntry{
+				value:      intValue,
+				expiration: time.Now().Add(c.ttl),
+			}
+			c.mu.Unlock()
 
-		return intValue
+			return intValue
+		}
 	}
 
 	// Database miss - fall back to viper config
@@ -171,25 +175,27 @@ func (c *SettingsCache) GetString(ctx context.Context, key string, defaultValue 
 	c.mu.RUnlock()
 
 	// Cache miss or expired - fetch from database
-	setting, err := c.service.GetSetting(ctx, key)
-	if err == nil {
-		// Extract string value from the setting
-		var strValue string
-		if val, ok := setting.Value["value"].(string); ok {
-			strValue = val
-		} else {
-			strValue = defaultValue
-		}
+	if c.service != nil {
+		setting, err := c.service.GetSetting(ctx, key)
+		if err == nil {
+			// Extract string value from the setting
+			var strValue string
+			if val, ok := setting.Value["value"].(string); ok {
+				strValue = val
+			} else {
+				strValue = defaultValue
+			}
 
-		// Store in cache
-		c.mu.Lock()
-		c.cache[key] = cacheEntry{
-			value:      strValue,
-			expiration: time.Now().Add(c.ttl),
-		}
-		c.mu.Unlock()
+			// Store in cache
+			c.mu.Lock()
+			c.cache[key] = cacheEntry{
+				value:      strValue,
+				expiration: time.Now().Add(c.ttl),
+			}
+			c.mu.Unlock()
 
-		return strValue
+			return strValue
+		}
 	}
 
 	// Database miss - fall back to viper config

--- a/internal/auth/settings_cache.go
+++ b/internal/auth/settings_cache.go
@@ -84,10 +84,12 @@ func (c *SettingsCache) GetBool(ctx context.Context, key string, defaultValue bo
 		}
 	}
 
-	// Database miss - fall back to viper config
-	viperKey := c.toViperKey(key)
-	if viper.IsSet(viperKey) {
-		return viper.GetBool(viperKey)
+	// Database miss - fall back to viper config (feature flags only)
+	if c.isFeatureFlagKey(key) {
+		viperKey := c.toViperKey(key)
+		if viper.IsSet(viperKey) {
+			return viper.GetBool(viperKey)
+		}
 	}
 
 	return defaultValue
@@ -144,10 +146,12 @@ func (c *SettingsCache) GetInt(ctx context.Context, key string, defaultValue int
 		}
 	}
 
-	// Database miss - fall back to viper config
-	viperKey := c.toViperKey(key)
-	if viper.IsSet(viperKey) {
-		return viper.GetInt(viperKey)
+	// Database miss - fall back to viper config (feature flags only)
+	if c.isFeatureFlagKey(key) {
+		viperKey := c.toViperKey(key)
+		if viper.IsSet(viperKey) {
+			return viper.GetInt(viperKey)
+		}
 	}
 
 	return defaultValue
@@ -198,10 +202,12 @@ func (c *SettingsCache) GetString(ctx context.Context, key string, defaultValue 
 		}
 	}
 
-	// Database miss - fall back to viper config
-	viperKey := c.toViperKey(key)
-	if viper.IsSet(viperKey) {
-		return viper.GetString(viperKey)
+	// Database miss - fall back to viper config (feature flags only)
+	if c.isFeatureFlagKey(key) {
+		viperKey := c.toViperKey(key)
+		if viper.IsSet(viperKey) {
+			return viper.GetString(viperKey)
+		}
 	}
 
 	return defaultValue
@@ -302,6 +308,15 @@ func (c *SettingsCache) GetMany(ctx context.Context, keys []string) (map[string]
 	}
 
 	return result, nil
+}
+
+// isFeatureFlagKey returns true if the key is a feature flag that should
+// fall back to viper config when no database row exists.
+// Only keys matching "app.*.enabled" are considered feature flags.
+// Security, rate-limit, and other operational settings should NOT
+// fall back to viper defaults — they must be explicitly set in the DB.
+func (c *SettingsCache) isFeatureFlagKey(key string) bool {
+	return strings.HasSuffix(key, ".enabled")
 }
 
 // toViperKey converts app.* key format to viper config format

--- a/internal/auth/settings_cache.go
+++ b/internal/auth/settings_cache.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 // SettingsCache provides a simple in-memory cache for settings with TTL
@@ -37,7 +38,7 @@ func NewSettingsCache(service *SystemSettingsService, ttl time.Duration) *Settin
 }
 
 // GetBool retrieves a boolean setting with caching
-// Priority: Environment variables > Cache > Database > Default value
+// Priority: Environment variables > Cache > Database > Viper config > Default value
 func (c *SettingsCache) GetBool(ctx context.Context, key string, defaultValue bool) bool {
 	envKey := c.GetEnvVarName(key)
 
@@ -61,31 +62,37 @@ func (c *SettingsCache) GetBool(ctx context.Context, key string, defaultValue bo
 
 	// Cache miss or expired - fetch from database
 	setting, err := c.service.GetSetting(ctx, key)
-	if err != nil {
-		return defaultValue
+	if err == nil {
+		// Extract boolean value from the setting
+		var boolValue bool
+		if val, ok := setting.Value["value"].(bool); ok {
+			boolValue = val
+		} else {
+			boolValue = defaultValue
+		}
+
+		// Store in cache
+		c.mu.Lock()
+		c.cache[key] = cacheEntry{
+			value:      boolValue,
+			expiration: time.Now().Add(c.ttl),
+		}
+		c.mu.Unlock()
+
+		return boolValue
 	}
 
-	// Extract boolean value from the setting
-	var boolValue bool
-	if val, ok := setting.Value["value"].(bool); ok {
-		boolValue = val
-	} else {
-		boolValue = defaultValue
+	// Database miss - fall back to viper config
+	viperKey := c.toViperKey(key)
+	if viper.IsSet(viperKey) {
+		return viper.GetBool(viperKey)
 	}
 
-	// Store in cache
-	c.mu.Lock()
-	c.cache[key] = cacheEntry{
-		value:      boolValue,
-		expiration: time.Now().Add(c.ttl),
-	}
-	c.mu.Unlock()
-
-	return boolValue
+	return defaultValue
 }
 
 // GetInt retrieves an integer setting with caching
-// Priority: Environment variables > Cache > Database > Default value
+// Priority: Environment variables > Cache > Database > Viper config > Default value
 func (c *SettingsCache) GetInt(ctx context.Context, key string, defaultValue int) int {
 	envKey := c.GetEnvVarName(key)
 
@@ -110,34 +117,40 @@ func (c *SettingsCache) GetInt(ctx context.Context, key string, defaultValue int
 
 	// Cache miss or expired - fetch from database
 	setting, err := c.service.GetSetting(ctx, key)
-	if err != nil {
-		return defaultValue
+	if err == nil {
+		// Extract integer value from the setting
+		var intValue int
+		switch v := setting.Value["value"].(type) {
+		case int:
+			intValue = v
+		case float64:
+			intValue = int(v)
+		default:
+			intValue = defaultValue
+		}
+
+		// Store in cache
+		c.mu.Lock()
+		c.cache[key] = cacheEntry{
+			value:      intValue,
+			expiration: time.Now().Add(c.ttl),
+		}
+		c.mu.Unlock()
+
+		return intValue
 	}
 
-	// Extract integer value from the setting
-	var intValue int
-	switch v := setting.Value["value"].(type) {
-	case int:
-		intValue = v
-	case float64:
-		intValue = int(v)
-	default:
-		intValue = defaultValue
+	// Database miss - fall back to viper config
+	viperKey := c.toViperKey(key)
+	if viper.IsSet(viperKey) {
+		return viper.GetInt(viperKey)
 	}
 
-	// Store in cache
-	c.mu.Lock()
-	c.cache[key] = cacheEntry{
-		value:      intValue,
-		expiration: time.Now().Add(c.ttl),
-	}
-	c.mu.Unlock()
-
-	return intValue
+	return defaultValue
 }
 
 // GetString retrieves a string setting with caching
-// Priority: Environment variables > Cache > Database > Default value
+// Priority: Environment variables > Cache > Database > Viper config > Default value
 func (c *SettingsCache) GetString(ctx context.Context, key string, defaultValue string) string {
 	envKey := c.GetEnvVarName(key)
 
@@ -159,27 +172,33 @@ func (c *SettingsCache) GetString(ctx context.Context, key string, defaultValue 
 
 	// Cache miss or expired - fetch from database
 	setting, err := c.service.GetSetting(ctx, key)
-	if err != nil {
-		return defaultValue
+	if err == nil {
+		// Extract string value from the setting
+		var strValue string
+		if val, ok := setting.Value["value"].(string); ok {
+			strValue = val
+		} else {
+			strValue = defaultValue
+		}
+
+		// Store in cache
+		c.mu.Lock()
+		c.cache[key] = cacheEntry{
+			value:      strValue,
+			expiration: time.Now().Add(c.ttl),
+		}
+		c.mu.Unlock()
+
+		return strValue
 	}
 
-	// Extract string value from the setting
-	var strValue string
-	if val, ok := setting.Value["value"].(string); ok {
-		strValue = val
-	} else {
-		strValue = defaultValue
+	// Database miss - fall back to viper config
+	viperKey := c.toViperKey(key)
+	if viper.IsSet(viperKey) {
+		return viper.GetString(viperKey)
 	}
 
-	// Store in cache
-	c.mu.Lock()
-	c.cache[key] = cacheEntry{
-		value:      strValue,
-		expiration: time.Now().Add(c.ttl),
-	}
-	c.mu.Unlock()
-
-	return strValue
+	return defaultValue
 }
 
 // GetDuration retrieves a duration setting with caching

--- a/internal/auth/settings_cache_test.go
+++ b/internal/auth/settings_cache_test.go
@@ -1,10 +1,12 @@
 package auth
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -552,4 +554,127 @@ func BenchmarkSettingsCache_CacheWrite(b *testing.B) {
 		}
 		cache.mu.Unlock()
 	}
+}
+
+// =============================================================================
+// Viper Config Fallback Tests
+// =============================================================================
+
+func TestSettingsCache_GetBool_ViperFallback(t *testing.T) {
+	cache := NewSettingsCache(nil, time.Minute)
+	ctx := context.Background()
+
+	originalEnv := os.Getenv("FLUXBASE_FUNCTIONS_ENABLED")
+	os.Unsetenv("FLUXBASE_FUNCTIONS_ENABLED")
+	defer func() {
+		if originalEnv != "" {
+			_ = os.Setenv("FLUXBASE_FUNCTIONS_ENABLED", originalEnv)
+		}
+	}()
+
+	t.Run("returns viper default when no env var and no database", func(t *testing.T) {
+		viper.Set("functions.enabled", true)
+		defer viper.Reset()
+
+		result := cache.GetBool(ctx, "app.functions.enabled", false)
+		assert.True(t, result, "should fall back to viper default (true)")
+	})
+
+	t.Run("returns viper default false for disabled features", func(t *testing.T) {
+		viper.Set("functions.enabled", false)
+		defer viper.Reset()
+
+		result := cache.GetBool(ctx, "app.functions.enabled", true)
+		assert.False(t, result, "should fall back to viper value (false)")
+	})
+
+	t.Run("returns hardcoded default when viper key not set", func(t *testing.T) {
+		defer viper.Reset()
+
+		result := cache.GetBool(ctx, "app.nonexistent.feature", true)
+		assert.True(t, result, "should return hardcoded default when viper has no key")
+	})
+
+	t.Run("env var overrides viper", func(t *testing.T) {
+		viper.Set("functions.enabled", true)
+		defer viper.Reset()
+
+		_ = os.Setenv("FLUXBASE_FUNCTIONS_ENABLED", "false")
+		defer os.Unsetenv("FLUXBASE_FUNCTIONS_ENABLED")
+
+		result := cache.GetBool(ctx, "app.functions.enabled", true)
+		assert.False(t, result, "env var should take precedence over viper")
+	})
+
+	t.Run("cache overrides viper", func(t *testing.T) {
+		viper.Set("functions.enabled", true)
+		defer viper.Reset()
+
+		cache.mu.Lock()
+		cache.cache["app.functions.enabled"] = cacheEntry{
+			value:      false,
+			expiration: time.Now().Add(time.Minute),
+		}
+		cache.mu.Unlock()
+		defer cache.Invalidate("app.functions.enabled")
+
+		result := cache.GetBool(ctx, "app.functions.enabled", true)
+		assert.False(t, result, "cached value should take precedence over viper")
+	})
+}
+
+func TestSettingsCache_GetInt_ViperFallback(t *testing.T) {
+	cache := NewSettingsCache(nil, time.Minute)
+	ctx := context.Background()
+
+	originalEnv := os.Getenv("FLUXBASE_AUTH_PASSWORD_MIN_LENGTH")
+	os.Unsetenv("FLUXBASE_AUTH_PASSWORD_MIN_LENGTH")
+	defer func() {
+		if originalEnv != "" {
+			_ = os.Setenv("FLUXBASE_AUTH_PASSWORD_MIN_LENGTH", originalEnv)
+		}
+	}()
+
+	t.Run("returns viper default when no env var and no database", func(t *testing.T) {
+		viper.Set("auth.password_min_length", 12)
+		defer viper.Reset()
+
+		result := cache.GetInt(ctx, "app.auth.password_min_length", 0)
+		assert.Equal(t, 12, result, "should fall back to viper default")
+	})
+
+	t.Run("returns hardcoded default when viper key not set", func(t *testing.T) {
+		defer viper.Reset()
+
+		result := cache.GetInt(ctx, "app.nonexistent.setting", 42)
+		assert.Equal(t, 42, result, "should return hardcoded default when viper has no key")
+	})
+}
+
+func TestSettingsCache_GetString_ViperFallback(t *testing.T) {
+	cache := NewSettingsCache(nil, time.Minute)
+	ctx := context.Background()
+
+	originalEnv := os.Getenv("FLUXBASE_EMAIL_PROVIDER")
+	os.Unsetenv("FLUXBASE_EMAIL_PROVIDER")
+	defer func() {
+		if originalEnv != "" {
+			_ = os.Setenv("FLUXBASE_EMAIL_PROVIDER", originalEnv)
+		}
+	}()
+
+	t.Run("returns viper default when no env var and no database", func(t *testing.T) {
+		viper.Set("email.provider", "smtp")
+		defer viper.Reset()
+
+		result := cache.GetString(ctx, "app.email.provider", "")
+		assert.Equal(t, "smtp", result, "should fall back to viper default")
+	})
+
+	t.Run("returns hardcoded default when viper key not set", func(t *testing.T) {
+		defer viper.Reset()
+
+		result := cache.GetString(ctx, "app.nonexistent.setting", "fallback")
+		assert.Equal(t, "fallback", result, "should return hardcoded default when viper has no key")
+	})
 }

--- a/internal/auth/settings_cache_test.go
+++ b/internal/auth/settings_cache_test.go
@@ -640,7 +640,7 @@ func TestSettingsCache_GetInt_ViperFallback(t *testing.T) {
 		defer viper.Reset()
 
 		result := cache.GetInt(ctx, "app.auth.password_min_length", 0)
-		assert.Equal(t, 12, result, "should fall back to viper default")
+		assert.Equal(t, 0, result, "should NOT fall back to viper for non-enabled key")
 	})
 
 	t.Run("returns hardcoded default when viper key not set", func(t *testing.T) {
@@ -668,7 +668,7 @@ func TestSettingsCache_GetString_ViperFallback(t *testing.T) {
 		defer viper.Reset()
 
 		result := cache.GetString(ctx, "app.email.provider", "")
-		assert.Equal(t, "smtp", result, "should fall back to viper default")
+		assert.Equal(t, "", result, "should NOT fall back to viper for non-enabled key")
 	})
 
 	t.Run("returns hardcoded default when viper key not set", func(t *testing.T) {

--- a/internal/middleware/feature_flags.go
+++ b/internal/middleware/feature_flags.go
@@ -20,9 +20,8 @@ func RequireFeatureEnabled(settingsCache *auth.SettingsCache, featureKey string)
 			})
 		}
 
-		// Check if feature is enabled (checks env vars first, then cache, then database)
 		ctx := c.RequestCtx()
-		isEnabled := settingsCache.GetBool(ctx, featureKey, false)
+		isEnabled := settingsCache.GetBool(ctx, featureKey, true)
 
 		if !isEnabled {
 			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{

--- a/test/e2e_helpers.go
+++ b/test/e2e_helpers.go
@@ -2533,14 +2533,14 @@ func (tc *TestContext) EnsureSystemSettings() {
 	require.NoError(tc.T, err, "Database health check failed in EnsureSystemSettings")
 
 	settings := map[string]bool{
-		"app.functions.enabled":               true,
-		"app.storage.enabled":                 true,
-		"app.realtime.enabled":                true,
-		"app.ai.enabled":                      true,
-		"app.rpc.enabled":                     true,
-		"app.jobs.enabled":                    true,
-		"app.auth.signup_enabled":             true,
-		"app.migrations.enabled":              true,
+		"app.functions.enabled":                 true,
+		"app.storage.enabled":                   true,
+		"app.realtime.enabled":                  true,
+		"app.ai.enabled":                        true,
+		"app.rpc.enabled":                       true,
+		"app.jobs.enabled":                      true,
+		"app.auth.signup_enabled":               true,
+		"app.migrations.enabled":                true,
 		"app.security.enable_global_rate_limit": false,
 	}
 
@@ -2560,6 +2560,18 @@ func (tc *TestContext) EnsureSystemSettings() {
 			VALUES ($1, $2::jsonb, 'system')
 			ON CONFLICT (key) WHERE user_id IS NULL DO UPDATE SET value = $2::jsonb
 		`, key, valJSON)
+	}
+
+	intSettings := map[string]int{
+		"app.security.service_role_rate_limit": 0,
+	}
+
+	for key, value := range intSettings {
+		tc.ExecuteSQLAsSuperuser(`
+			INSERT INTO app.settings (key, value, category)
+			VALUES ($1, $2::jsonb, 'system')
+			ON CONFLICT (key) WHERE user_id IS NULL DO UPDATE SET value = $2::jsonb
+		`, key, fmt.Sprintf(`{"value": %d}`, value))
 	}
 }
 

--- a/test/e2e_helpers.go
+++ b/test/e2e_helpers.go
@@ -2533,15 +2533,14 @@ func (tc *TestContext) EnsureSystemSettings() {
 	require.NoError(tc.T, err, "Database health check failed in EnsureSystemSettings")
 
 	settings := map[string]bool{
-		"app.functions.enabled":                 true,
-		"app.storage.enabled":                   true,
-		"app.realtime.enabled":                  true,
-		"app.ai.enabled":                        true,
-		"app.rpc.enabled":                       true,
-		"app.jobs.enabled":                      true,
-		"app.auth.signup_enabled":               true,
-		"app.migrations.enabled":                true,
-		"app.security.enable_global_rate_limit": false,
+		"app.functions.enabled":   true,
+		"app.storage.enabled":     true,
+		"app.realtime.enabled":    true,
+		"app.ai.enabled":          true,
+		"app.rpc.enabled":         true,
+		"app.jobs.enabled":        true,
+		"app.auth.signup_enabled": true,
+		"app.migrations.enabled":  true,
 	}
 
 	for key, value := range settings {
@@ -2560,18 +2559,6 @@ func (tc *TestContext) EnsureSystemSettings() {
 			VALUES ($1, $2::jsonb, 'system')
 			ON CONFLICT (key) WHERE user_id IS NULL DO UPDATE SET value = $2::jsonb
 		`, key, valJSON)
-	}
-
-	intSettings := map[string]int{
-		"app.security.service_role_rate_limit": 0,
-	}
-
-	for key, value := range intSettings {
-		tc.ExecuteSQLAsSuperuser(`
-			INSERT INTO app.settings (key, value, category)
-			VALUES ($1, $2::jsonb, 'system')
-			ON CONFLICT (key) WHERE user_id IS NULL DO UPDATE SET value = $2::jsonb
-		`, key, fmt.Sprintf(`{"value": %d}`, value))
 	}
 }
 

--- a/test/e2e_helpers.go
+++ b/test/e2e_helpers.go
@@ -2533,14 +2533,15 @@ func (tc *TestContext) EnsureSystemSettings() {
 	require.NoError(tc.T, err, "Database health check failed in EnsureSystemSettings")
 
 	settings := map[string]bool{
-		"app.functions.enabled":   true,
-		"app.storage.enabled":     true,
-		"app.realtime.enabled":    true,
-		"app.ai.enabled":          true,
-		"app.rpc.enabled":         true,
-		"app.jobs.enabled":        true,
-		"app.auth.signup_enabled": true,
-		"app.migrations.enabled":  true,
+		"app.functions.enabled":               true,
+		"app.storage.enabled":                 true,
+		"app.realtime.enabled":                true,
+		"app.ai.enabled":                      true,
+		"app.rpc.enabled":                     true,
+		"app.jobs.enabled":                    true,
+		"app.auth.signup_enabled":             true,
+		"app.migrations.enabled":              true,
+		"app.security.enable_global_rate_limit": false,
 	}
 
 	for key, value := range settings {


### PR DESCRIPTION
The SettingsCache GetBool/GetInt/GetString methods previously fell back to a hardcoded default when the database had no setting row. Since the feature flag middleware passed false as the default, all features (functions, realtime, storage, jobs, ai, rpc) were disabled on fresh installs unless database rows were manually seeded.

Now the lookup chain is: env var → cache → database → viper config → hardcoded default. This respects config_defaults.go and fluxbase.yaml without requiring database seeding. The middleware default is also changed from false to true as an additional safety net.