### PR TITLE
fix: propagate tenant context in WebSocket handlers and async goroutines

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -107,7 +107,7 @@
     },
     "sdk": {
       "name": "@nimbleflux/fluxbase-sdk",
-      "version": "2026.5.3",
+      "version": "2026.5.4-rc.17",
       "dependencies": {
         "cross-fetch": "^4.1.0",
       },
@@ -135,7 +135,7 @@
     },
     "sdk-react": {
       "name": "@nimbleflux/fluxbase-sdk-react",
-      "version": "2026.5.3",
+      "version": "2026.5.4-rc.17",
       "devDependencies": {
         "@nimbleflux/fluxbase-sdk": "workspace:*",
         "@tanstack/react-query": "^5.96.2",
@@ -153,7 +153,7 @@
         "vitest": "^4.1.3",
       },
       "peerDependencies": {
-        "@nimbleflux/fluxbase-sdk": "^2026.5.3",
+        "@nimbleflux/fluxbase-sdk": "^2026.5.4-rc.17",
         "@tanstack/react-query": "^5.96.2",
         "react": "^18.0.0 || ^19.0.0",
       },

--- a/deploy/helm/fluxbase/Chart.yaml
+++ b/deploy/helm/fluxbase/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 # Chart version - should be bumped on chart changes
 version: 2026.01.1
 # App version - matches Fluxbase version (automatically updated by release workflow)
-appVersion: "2026.5.3"
+appVersion: "2026.5.4-rc.17"
 keywords:
   - backend
   - baas

--- a/docs/src/content/docs/cli/installation.md
+++ b/docs/src/content/docs/cli/installation.md
@@ -22,7 +22,7 @@ The easiest way to install the Fluxbase CLI:
 curl -fsSL https://raw.githubusercontent.com/nimbleflux/fluxbase/main/install-cli.sh | bash
 
 # Install specific version
-curl -fsSL https://raw.githubusercontent.com/nimbleflux/fluxbase/main/install-cli.sh | bash -s -- v2026.5.3
+curl -fsSL https://raw.githubusercontent.com/nimbleflux/fluxbase/main/install-cli.sh | bash -s -- v2026.5.4-rc.17
 ```
 
 The script automatically detects your OS and architecture, downloads the appropriate binary, and installs it to `/usr/local/bin`.

--- a/internal/ai/chat_handler.go
+++ b/internal/ai/chat_handler.go
@@ -192,6 +192,10 @@ func (h *ChatHandler) handleConnection(c *websocket.Conn) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if tenantID := extractStringDefault(c.Locals("tenant_id"), ""); tenantID != "" {
+		ctx = database.ContextWithTenant(ctx, tenantID)
+	}
+
 	// Extract auth context from locals (set by auth middleware)
 	userID := extractString(c.Locals("user_id"))
 	role := extractStringDefault(c.Locals("rls_role"), "anon")

--- a/internal/functions/handler_execute.go
+++ b/internal/functions/handler_execute.go
@@ -10,11 +10,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
+	"github.com/nimbleflux/fluxbase/internal/database"
+	apperrors "github.com/nimbleflux/fluxbase/internal/errors"
 	"github.com/nimbleflux/fluxbase/internal/middleware"
 	"github.com/nimbleflux/fluxbase/internal/ratelimit"
 	"github.com/nimbleflux/fluxbase/internal/runtime"
-
-	apperrors "github.com/nimbleflux/fluxbase/internal/errors"
 	"github.com/nimbleflux/fluxbase/internal/util"
 )
 
@@ -272,9 +272,9 @@ func (h *Handler) InvokeFunction(c fiber.Ctx) error {
 	// Update execution record asynchronously (don't block response)
 	// Skip if execution logs are disabled for this function
 	if !fn.DisableExecutionLogs {
+		asyncTenantCtx := database.ContextWithTenant(context.Background(), database.TenantFromContext(middleware.CtxWithTenant(c)))
 		go func() {
-			ctx := context.Background()
-			if updateErr := h.storage.CompleteExecution(ctx, executionID, status, &result.Status, &durationMs, resultBody, &result.Logs, errorMessage); updateErr != nil {
+			if updateErr := h.storage.CompleteExecution(asyncTenantCtx, executionID, status, &result.Status, &durationMs, resultBody, &result.Logs, errorMessage); updateErr != nil {
 				log.Error().Err(updateErr).Str("execution_id", executionID.String()).Msg("Failed to complete execution record")
 			}
 		}()

--- a/internal/functions/scheduler.go
+++ b/internal/functions/scheduler.go
@@ -107,9 +107,13 @@ func (s *Scheduler) ScheduleFunction(fn EdgeFunctionSummary) error {
 
 	funcName := fn.Name
 	funcNamespace := fn.Namespace
+	var funcTenantID *string
+	if fn.TenantID != nil {
+		funcTenantID = fn.TenantID
+	}
 
 	entryID, err := s.inner.AddFunc(fn.Name, *fn.CronSchedule, func() {
-		s.executeScheduledFunction(funcName, funcNamespace)
+		s.executeScheduledFunction(funcName, funcNamespace, funcTenantID)
 	})
 	if err != nil {
 		log.Error().
@@ -144,13 +148,16 @@ func (s *Scheduler) RescheduleFunction(fn EdgeFunctionSummary) error {
 	return nil
 }
 
-func (s *Scheduler) executeScheduledFunction(funcName, funcNamespace string) {
+func (s *Scheduler) executeScheduledFunction(funcName, funcNamespace string, tenantID *string) {
 	if !s.inner.Guard.Acquire(funcName) {
 		return
 	}
 	defer s.inner.Guard.Release()
 
 	ctx := s.inner.Context()
+	if tenantID != nil && *tenantID != "" {
+		ctx = database.ContextWithTenant(ctx, *tenantID)
+	}
 
 	fn, err := s.storage.GetFunctionByNamespace(ctx, funcName, funcNamespace)
 	if err != nil {
@@ -257,6 +264,7 @@ func (s *Scheduler) executeScheduledFunction(funcName, funcNamespace string) {
 	}
 
 	if !fn.DisableExecutionLogs {
+		asyncCtx := database.ContextWithTenant(context.Background(), database.TenantFromContext(ctx))
 		go func() {
 			defer func() {
 				if rec := recover(); rec != nil {
@@ -267,7 +275,7 @@ func (s *Scheduler) executeScheduledFunction(funcName, funcNamespace string) {
 						Msg("Panic in scheduled function execution record completion - recovered")
 				}
 			}()
-			if updateErr := s.storage.CompleteExecution(context.Background(), executionID, status, &result.Status, &durationMs, resultStr, &result.Logs, errorMessage); updateErr != nil {
+			if updateErr := s.storage.CompleteExecution(asyncCtx, executionID, status, &result.Status, &durationMs, resultStr, &result.Logs, errorMessage); updateErr != nil {
 				log.Error().
 					Err(updateErr).
 					Str("function", fn.Name).

--- a/internal/functions/storage.go
+++ b/internal/functions/storage.go
@@ -94,7 +94,8 @@ type EdgeFunctionSummary struct {
 	CreatedAt            time.Time  `json:"created_at"`
 	UpdatedAt            time.Time  `json:"updated_at"`
 	CreatedBy            *uuid.UUID `json:"created_by"`
-	Source               string     `json:"source"` // "filesystem" or "api"
+	Source               string     `json:"source"`    // "filesystem" or "api"
+	TenantID             *string    `json:"tenant_id"` // Tenant owner (nil = default tenant)
 }
 
 // EdgeFunctionExecution represents a function execution log
@@ -255,7 +256,7 @@ func (s *Storage) ListFunctionsForSync(ctx context.Context, tenantID string) ([]
 		       timeout_seconds, memory_limit_mb, allow_net, allow_env, allow_read, allow_write, allow_unauthenticated, is_public, disable_execution_logs,
 		       cors_origins, cors_methods, cors_headers, cors_credentials, cors_max_age,
 		       rate_limit_per_minute, rate_limit_per_hour, rate_limit_per_day,
-		       created_at, updated_at, created_by, source
+		       created_at, updated_at, created_by, source, tenant_id
 		FROM functions.edge_functions
 		WHERE is_public = true
 		  AND (tenant_id = $1 OR tenant_id IS NULL)
@@ -278,7 +279,7 @@ func (s *Storage) ListFunctionsForSync(ctx context.Context, tenantID string) ([]
 				&fn.TimeoutSeconds, &fn.MemoryLimitMB, &fn.AllowNet, &fn.AllowEnv, &fn.AllowRead, &fn.AllowWrite, &fn.AllowUnauthenticated, &fn.IsPublic, &fn.DisableExecutionLogs,
 				&fn.CorsOrigins, &fn.CorsMethods, &fn.CorsHeaders, &fn.CorsCredentials, &fn.CorsMaxAge,
 				&fn.RateLimitPerMinute, &fn.RateLimitPerHour, &fn.RateLimitPerDay,
-				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source,
+				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source, &fn.TenantID,
 			)
 			if err != nil {
 				return err
@@ -336,7 +337,7 @@ func (s *Storage) ListFunctions(ctx context.Context) ([]EdgeFunctionSummary, err
 		       timeout_seconds, memory_limit_mb, allow_net, allow_env, allow_read, allow_write, allow_unauthenticated, is_public, disable_execution_logs,
 		       cors_origins, cors_methods, cors_headers, cors_credentials, cors_max_age,
 		       rate_limit_per_minute, rate_limit_per_hour, rate_limit_per_day,
-		       created_at, updated_at, created_by, source
+		       created_at, updated_at, created_by, source, tenant_id
 		FROM functions.edge_functions
 		WHERE is_public = true
 		  AND (tenant_id = $1 OR ($1 IS NULL AND tenant_id IS NULL))
@@ -359,7 +360,7 @@ func (s *Storage) ListFunctions(ctx context.Context) ([]EdgeFunctionSummary, err
 				&fn.TimeoutSeconds, &fn.MemoryLimitMB, &fn.AllowNet, &fn.AllowEnv, &fn.AllowRead, &fn.AllowWrite, &fn.AllowUnauthenticated, &fn.IsPublic, &fn.DisableExecutionLogs,
 				&fn.CorsOrigins, &fn.CorsMethods, &fn.CorsHeaders, &fn.CorsCredentials, &fn.CorsMaxAge,
 				&fn.RateLimitPerMinute, &fn.RateLimitPerHour, &fn.RateLimitPerDay,
-				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source,
+				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source, &fn.TenantID,
 			)
 			if err != nil {
 				return err
@@ -384,7 +385,7 @@ func (s *Storage) ListFunctionsByNamespaceForSync(ctx context.Context, namespace
 		       timeout_seconds, memory_limit_mb, allow_net, allow_env, allow_read, allow_write, allow_unauthenticated, is_public, disable_execution_logs,
 		       cors_origins, cors_methods, cors_headers, cors_credentials, cors_max_age,
 		       rate_limit_per_minute, rate_limit_per_hour, rate_limit_per_day,
-		       created_at, updated_at, created_by, source
+		       created_at, updated_at, created_by, source, tenant_id
 		FROM functions.edge_functions
 		WHERE namespace = $1
 		  AND (tenant_id = $2 OR tenant_id IS NULL)
@@ -407,7 +408,7 @@ func (s *Storage) ListFunctionsByNamespaceForSync(ctx context.Context, namespace
 				&fn.TimeoutSeconds, &fn.MemoryLimitMB, &fn.AllowNet, &fn.AllowEnv, &fn.AllowRead, &fn.AllowWrite, &fn.AllowUnauthenticated, &fn.IsPublic, &fn.DisableExecutionLogs,
 				&fn.CorsOrigins, &fn.CorsMethods, &fn.CorsHeaders, &fn.CorsCredentials, &fn.CorsMaxAge,
 				&fn.RateLimitPerMinute, &fn.RateLimitPerHour, &fn.RateLimitPerDay,
-				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source,
+				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source, &fn.TenantID,
 			)
 			if err != nil {
 				return err
@@ -432,7 +433,7 @@ func (s *Storage) ListAllFunctions(ctx context.Context) ([]EdgeFunctionSummary, 
 		       timeout_seconds, memory_limit_mb, allow_net, allow_env, allow_read, allow_write, allow_unauthenticated, is_public, disable_execution_logs,
 		       cors_origins, cors_methods, cors_headers, cors_credentials, cors_max_age,
 		       rate_limit_per_minute, rate_limit_per_hour, rate_limit_per_day,
-		       created_at, updated_at, created_by, source
+		       created_at, updated_at, created_by, source, tenant_id
 		FROM functions.edge_functions
 		WHERE (tenant_id = $1 OR ($1 IS NULL AND tenant_id IS NULL))
 		ORDER BY namespace, name
@@ -454,7 +455,7 @@ func (s *Storage) ListAllFunctions(ctx context.Context) ([]EdgeFunctionSummary, 
 				&fn.TimeoutSeconds, &fn.MemoryLimitMB, &fn.AllowNet, &fn.AllowEnv, &fn.AllowRead, &fn.AllowWrite, &fn.AllowUnauthenticated, &fn.IsPublic, &fn.DisableExecutionLogs,
 				&fn.CorsOrigins, &fn.CorsMethods, &fn.CorsHeaders, &fn.CorsCredentials, &fn.CorsMaxAge,
 				&fn.RateLimitPerMinute, &fn.RateLimitPerHour, &fn.RateLimitPerDay,
-				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source,
+				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source, &fn.TenantID,
 			)
 			if err != nil {
 				return err
@@ -509,7 +510,7 @@ func (s *Storage) ListFunctionsByNamespace(ctx context.Context, namespace string
 		       timeout_seconds, memory_limit_mb, allow_net, allow_env, allow_read, allow_write, allow_unauthenticated, is_public, disable_execution_logs,
 		       cors_origins, cors_methods, cors_headers, cors_credentials, cors_max_age,
 		       rate_limit_per_minute, rate_limit_per_hour, rate_limit_per_day,
-		       created_at, updated_at, created_by, source
+		       created_at, updated_at, created_by, source, tenant_id
 		FROM functions.edge_functions
 		WHERE namespace = $1
 		  AND (tenant_id = $2 OR ($2 IS NULL AND tenant_id IS NULL))
@@ -532,7 +533,7 @@ func (s *Storage) ListFunctionsByNamespace(ctx context.Context, namespace string
 				&fn.TimeoutSeconds, &fn.MemoryLimitMB, &fn.AllowNet, &fn.AllowEnv, &fn.AllowRead, &fn.AllowWrite, &fn.AllowUnauthenticated, &fn.IsPublic, &fn.DisableExecutionLogs,
 				&fn.CorsOrigins, &fn.CorsMethods, &fn.CorsHeaders, &fn.CorsCredentials, &fn.CorsMaxAge,
 				&fn.RateLimitPerMinute, &fn.RateLimitPerHour, &fn.RateLimitPerDay,
-				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source,
+				&fn.CreatedAt, &fn.UpdatedAt, &fn.CreatedBy, &fn.Source, &fn.TenantID,
 			)
 			if err != nil {
 				return err

--- a/internal/realtime/connection.go
+++ b/internal/realtime/connection.go
@@ -37,6 +37,7 @@ type Connection struct {
 	UserID          *string                // Authenticated user ID (nil if anonymous)
 	Role            string                 // User role (e.g., "authenticated", "anon", "instance_admin")
 	Claims          map[string]interface{} // Full JWT claims for RLS (includes custom claims like meeting_id, player_id)
+	TenantID        string                 // Tenant ID for multi-tenancy (empty = default tenant)
 	ConnectedAt     time.Time              // Connection timestamp
 	mu              sync.RWMutex
 	slowClientCount atomic.Int32 // Count of slow client warnings
@@ -59,16 +60,16 @@ type Connection struct {
 
 // NewConnection creates a new WebSocket connection with async message queue.
 // If parentCtx is nil, context.Background() is used.
-func NewConnection(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, parentCtx context.Context) *Connection {
+func NewConnection(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, tenantID string, parentCtx context.Context) *Connection {
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
-	return NewConnectionWithQueueSize(id, conn, userID, role, claims, DefaultMessageQueueSize, parentCtx)
+	return NewConnectionWithQueueSize(id, conn, userID, role, claims, tenantID, DefaultMessageQueueSize, parentCtx)
 }
 
 // NewConnectionWithQueueSize creates a new WebSocket connection with custom queue size.
 // If parentCtx is nil, context.Background() is used.
-func NewConnectionWithQueueSize(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, queueSize int, parentCtx context.Context) *Connection {
+func NewConnectionWithQueueSize(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, tenantID string, queueSize int, parentCtx context.Context) *Connection {
 	if queueSize <= 0 {
 		queueSize = DefaultMessageQueueSize
 	}
@@ -85,6 +86,7 @@ func NewConnectionWithQueueSize(id string, conn *websocket.Conn, userID *string,
 		UserID:        userID,
 		Role:          role,
 		Claims:        claims,
+		TenantID:      tenantID,
 		ConnectedAt:   time.Now(),
 		sendCh:        make(chan interface{}, queueSize),
 		ctx:           ctx,

--- a/internal/realtime/connection_test.go
+++ b/internal/realtime/connection_test.go
@@ -49,7 +49,7 @@ func TestNewConnection(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
 	userID := "user123"
 
-	connection := NewConnection("conn1", conn, &userID, "authenticated", nil, nil)
+	connection := NewConnection("conn1", conn, &userID, "authenticated", nil, "", nil)
 
 	assert.NotNil(t, connection)
 	assert.Equal(t, "conn1", connection.ID)
@@ -61,7 +61,7 @@ func TestNewConnection(t *testing.T) {
 
 func TestConnection_Subscribe(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe to a channel
 	connection.Subscribe("table:public.products")
@@ -72,7 +72,7 @@ func TestConnection_Subscribe(t *testing.T) {
 
 func TestConnection_SubscribeMultiple(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe to multiple channels
 	connection.Subscribe("table:public.products")
@@ -87,7 +87,7 @@ func TestConnection_SubscribeMultiple(t *testing.T) {
 
 func TestConnection_SubscribeDuplicate(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe to same channel twice
 	connection.Subscribe("table:public.products")
@@ -99,7 +99,7 @@ func TestConnection_SubscribeDuplicate(t *testing.T) {
 
 func TestConnection_Unsubscribe(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe then unsubscribe
 	connection.Subscribe("table:public.products")
@@ -112,7 +112,7 @@ func TestConnection_Unsubscribe(t *testing.T) {
 
 func TestConnection_UnsubscribeNonExistent(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Unsubscribe from channel we never subscribed to
 	connection.Unsubscribe("table:public.products")
@@ -123,7 +123,7 @@ func TestConnection_UnsubscribeNonExistent(t *testing.T) {
 
 func TestConnection_IsSubscribed(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Initially not subscribed
 	assert.False(t, connection.IsSubscribed("table:public.products"))
@@ -139,7 +139,7 @@ func TestConnection_IsSubscribed(t *testing.T) {
 
 func TestConnection_ConcurrentSubscribe(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	var wg sync.WaitGroup
 	numGoroutines := 100
@@ -162,7 +162,7 @@ func TestConnection_ConcurrentSubscribe(t *testing.T) {
 
 func TestConnection_ConcurrentUnsubscribe(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe to multiple channels first
 	numChannels := 100
@@ -193,7 +193,7 @@ func TestConnection_ConcurrentUnsubscribe(t *testing.T) {
 
 func TestConnection_ConcurrentIsSubscribed(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	connection.Subscribe("table:public.products")
 
@@ -218,7 +218,7 @@ func TestConnection_ConcurrentIsSubscribed(t *testing.T) {
 
 func TestConnection_MixedConcurrentOperations(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 	defer func() { _ = connection.Close() }()
 
 	var wg sync.WaitGroup
@@ -264,7 +264,7 @@ func TestConnection_MixedConcurrentOperations(t *testing.T) {
 
 func TestNewConnectionWithQueueSize(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, 128, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", 128, nil)
 	defer func() { _ = connection.Close() }()
 
 	assert.NotNil(t, connection)
@@ -273,7 +273,7 @@ func TestNewConnectionWithQueueSize(t *testing.T) {
 
 func TestNewConnectionWithQueueSize_DefaultOnZero(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, 0, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", 0, nil)
 	defer func() { _ = connection.Close() }()
 
 	assert.Equal(t, DefaultMessageQueueSize, cap(connection.sendCh))
@@ -281,7 +281,7 @@ func TestNewConnectionWithQueueSize_DefaultOnZero(t *testing.T) {
 
 func TestNewConnectionWithQueueSize_DefaultOnNegative(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, -10, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", -10, nil)
 	defer func() { _ = connection.Close() }()
 
 	assert.Equal(t, DefaultMessageQueueSize, cap(connection.sendCh))
@@ -298,7 +298,7 @@ func TestNewConnectionSync(t *testing.T) {
 
 func TestConnection_SendMessage_ToClosedConnection(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Close the connection first
 	_ = connection.Close()
@@ -310,7 +310,7 @@ func TestConnection_SendMessage_ToClosedConnection(t *testing.T) {
 
 func TestConnection_GetQueueStats(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, 100, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", 100, nil)
 	defer func() { _ = connection.Close() }()
 
 	stats := connection.GetQueueStats()
@@ -324,7 +324,7 @@ func TestConnection_GetQueueStats(t *testing.T) {
 }
 
 func TestConnection_Close_MultipleTimes(t *testing.T) {
-	connection := NewConnection("conn1", nil, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", nil, nil, "anon", nil, "", nil)
 
 	// First close should succeed
 	err := connection.Close()
@@ -337,7 +337,7 @@ func TestConnection_Close_MultipleTimes(t *testing.T) {
 
 func TestConnection_IsSlowClient_Initial(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 	defer func() { _ = connection.Close() }()
 
 	assert.False(t, connection.IsSlowClient())
@@ -345,7 +345,7 @@ func TestConnection_IsSlowClient_Initial(t *testing.T) {
 
 func TestConnection_IsSlowClient_AfterWarnings(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 	defer func() { _ = connection.Close() }()
 
 	// Manually increment slow client count
@@ -376,7 +376,7 @@ func TestConnectionQueueStats_Struct(t *testing.T) {
 
 func TestConnection_SendMessage_WithSlowClientMarked(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 	defer func() { _ = connection.Close() }()
 
 	// Mark as slow client
@@ -415,7 +415,7 @@ func BenchmarkConnection_IsSubscribed(b *testing.B) {
 
 func BenchmarkConnection_GetQueueStats(b *testing.B) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, 256, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", 256, nil)
 	defer func() { _ = connection.Close() }()
 
 	b.ResetTimer()

--- a/internal/realtime/handler.go
+++ b/internal/realtime/handler.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+
+	"github.com/nimbleflux/fluxbase/internal/database"
 )
 
 // MessageType represents the type of WebSocket message
@@ -163,10 +165,11 @@ func (h *RealtimeHandler) HandleWebSocket(c fiber.Ctx) error {
 		}
 	}
 
-	// Store user ID, role and claims in Fiber locals so handleConnection can access them
+	// Store user ID, role, tenant and claims in Fiber locals so handleConnection can access them
 	c.Locals("user_id", userID)
 	c.Locals("user_role", role)
 	c.Locals("claims", rawClaims)
+	// Preserve tenant_id from TenantMiddleware (already in Locals from middleware chain)
 
 	// Upgrade to WebSocket
 	return websocket.New(h.handleConnection)(c)
@@ -208,8 +211,16 @@ func (h *RealtimeHandler) handleConnection(c *websocket.Conn) {
 		}
 	}
 
+	// Get tenant ID from Fiber locals (set by TenantMiddleware)
+	var tenantID string
+	if tid := c.Locals("tenant_id"); tid != nil {
+		if id, ok := tid.(string); ok {
+			tenantID = id
+		}
+	}
+
 	// Add connection to manager (checks connection limit)
-	connection, err := h.manager.AddConnection(connectionID, c, userID, role, claims)
+	connection, err := h.manager.AddConnection(connectionID, c, userID, role, claims, tenantID)
 	if err != nil {
 		// Connection limit reached - send error and close
 		_ = c.WriteJSON(ServerMessage{
@@ -915,8 +926,12 @@ func (h *RealtimeHandler) handleSubscribeLogs(conn *Connection, msg ClientMessag
 			return
 		}
 
+		ctx := context.Background()
+		if conn.TenantID != "" {
+			ctx = database.ContextWithTenant(ctx, conn.TenantID)
+		}
 		isOwner, exists, err := h.subManager.CheckExecutionOwnership(
-			context.Background(), executionID, *conn.UserID, executionType,
+			ctx, executionID, *conn.UserID, executionType,
 		)
 		if err != nil {
 			log.Error().Err(err).Str("execution_id", executionID).Msg("Failed to check execution ownership")

--- a/internal/realtime/manager.go
+++ b/internal/realtime/manager.go
@@ -241,7 +241,7 @@ func (m *Manager) BroadcastGlobal(channel string, message ServerMessage) error {
 // Returns nil and ErrMaxConnectionsReached if the connection limit is exceeded
 // Returns nil and ErrMaxUserConnectionsReached if the per-user limit is exceeded
 // Returns nil and ErrMaxIPConnectionsReached if the per-IP limit is exceeded (for anonymous)
-func (m *Manager) AddConnection(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}) (*Connection, error) {
+func (m *Manager) AddConnection(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, tenantID string) (*Connection, error) {
 	// Get remote IP for tracking
 	remoteIP := ""
 	if conn != nil {
@@ -252,12 +252,12 @@ func (m *Manager) AddConnection(id string, conn *websocket.Conn, userID *string,
 		}
 	}
 
-	return m.AddConnectionWithIP(id, conn, userID, role, claims, remoteIP)
+	return m.AddConnectionWithIP(id, conn, userID, role, claims, tenantID, remoteIP)
 }
 
 // AddConnectionWithIP adds a new WebSocket connection with explicit IP address
 // This is useful when the IP is already known (e.g., from X-Forwarded-For header)
-func (m *Manager) AddConnectionWithIP(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, remoteIP string) (*Connection, error) {
+func (m *Manager) AddConnectionWithIP(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, tenantID string, remoteIP string) (*Connection, error) {
 	m.mu.Lock()
 
 	// Check global connection limit before adding
@@ -313,9 +313,9 @@ func (m *Manager) AddConnectionWithIP(id string, conn *websocket.Conn, userID *s
 	// Create and track the connection with configured queue size
 	var connection *Connection
 	if m.clientMessageQueueSize > 0 {
-		connection = NewConnectionWithQueueSize(id, conn, userID, role, claims, m.clientMessageQueueSize, m.ctx)
+		connection = NewConnectionWithQueueSize(id, conn, userID, role, claims, tenantID, m.clientMessageQueueSize, m.ctx)
 	} else {
-		connection = NewConnection(id, conn, userID, role, claims, m.ctx)
+		connection = NewConnection(id, conn, userID, role, claims, tenantID, m.ctx)
 	}
 	m.connections[id] = connection
 

--- a/internal/realtime/manager_test.go
+++ b/internal/realtime/manager_test.go
@@ -78,7 +78,7 @@ func TestManager_AddConnection(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(ctx)
 
-	connection, err := manager.AddConnection("conn1", nil, nil, "anon", nil)
+	connection, err := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, connection)
@@ -90,9 +90,9 @@ func TestManager_AddMultipleConnections(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(ctx)
 
-	manager.AddConnection("conn1", nil, nil, "anon", nil)
-	manager.AddConnection("conn2", nil, nil, "anon", nil)
-	manager.AddConnection("conn3", nil, nil, "anon", nil)
+	manager.AddConnection("conn1", nil, nil, "anon", nil, "")
+	manager.AddConnection("conn2", nil, nil, "anon", nil, "")
+	manager.AddConnection("conn3", nil, nil, "anon", nil, "")
 
 	assert.Equal(t, 3, manager.GetConnectionCount())
 }
@@ -102,7 +102,7 @@ func TestManager_AddConnectionWithUserID(t *testing.T) {
 	manager := NewManager(ctx)
 	userID := "user123"
 
-	connection, err := manager.AddConnection("conn1", nil, &userID, "authenticated", nil)
+	connection, err := manager.AddConnection("conn1", nil, &userID, "authenticated", nil, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, connection.UserID)
@@ -113,7 +113,7 @@ func TestManager_RemoveConnection(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(ctx)
 
-	manager.AddConnection("conn1", nil, nil, "anon", nil)
+	manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 	assert.Equal(t, 1, manager.GetConnectionCount())
 
 	manager.RemoveConnection("conn1")
@@ -135,10 +135,10 @@ func TestManager_GetConnectionCount(t *testing.T) {
 
 	assert.Equal(t, 0, manager.GetConnectionCount())
 
-	manager.AddConnection("conn1", nil, nil, "anon", nil)
+	manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 	assert.Equal(t, 1, manager.GetConnectionCount())
 
-	manager.AddConnection("conn2", nil, nil, "anon", nil)
+	manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 	assert.Equal(t, 2, manager.GetConnectionCount())
 
 	manager.RemoveConnection("conn1")
@@ -159,7 +159,7 @@ func TestManager_ConcurrentAddConnection(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			manager.AddConnection("conn"+string(rune(n)), nil, nil, "anon", nil)
+			manager.AddConnection("conn"+string(rune(n)), nil, nil, "anon", nil, "")
 		}(i)
 	}
 
@@ -175,7 +175,7 @@ func TestManager_ConcurrentRemoveConnection(t *testing.T) {
 	// Add connections first
 	numConnections := 100
 	for i := 0; i < numConnections; i++ {
-		manager.AddConnection("conn"+string(rune(i)), nil, nil, "anon", nil)
+		manager.AddConnection("conn"+string(rune(i)), nil, nil, "anon", nil, "")
 	}
 
 	assert.Equal(t, numConnections, manager.GetConnectionCount())
@@ -199,8 +199,8 @@ func TestManager_Shutdown(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(ctx)
 
-	manager.AddConnection("conn1", nil, nil, "anon", nil)
-	manager.AddConnection("conn2", nil, nil, "anon", nil)
+	manager.AddConnection("conn1", nil, nil, "anon", nil, "")
+	manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 
 	manager.Shutdown()
 
@@ -224,7 +224,7 @@ func TestManager_MixedConcurrentOperations(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			manager.AddConnection("conn"+string(rune(n%20)), nil, nil, "anon", nil)
+			manager.AddConnection("conn"+string(rune(n%20)), nil, nil, "anon", nil, "")
 		}(i)
 
 		// Remove connection
@@ -252,16 +252,16 @@ func TestManager_PerUserConnectionLimit(t *testing.T) {
 	userID := "user123"
 
 	// First two connections should succeed
-	conn1, err := manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "192.168.1.1")
+	conn1, err := manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.NoError(t, err)
 	assert.NotNil(t, conn1)
 
-	conn2, err := manager.AddConnectionWithIP("conn2", nil, &userID, "authenticated", nil, "192.168.1.1")
+	conn2, err := manager.AddConnectionWithIP("conn2", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.NoError(t, err)
 	assert.NotNil(t, conn2)
 
 	// Third connection should fail
-	conn3, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "192.168.1.1")
+	conn3, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.Error(t, err)
 	assert.Equal(t, ErrMaxUserConnectionsReached, err)
 	assert.Nil(t, conn3)
@@ -281,18 +281,18 @@ func TestManager_PerUserConnectionLimit_DifferentUsers(t *testing.T) {
 	user2 := "user2"
 
 	// User1 can have 2 connections
-	manager.AddConnectionWithIP("conn1", nil, &user1, "authenticated", nil, "192.168.1.1")
-	manager.AddConnectionWithIP("conn2", nil, &user1, "authenticated", nil, "192.168.1.1")
+	manager.AddConnectionWithIP("conn1", nil, &user1, "authenticated", nil, "", "192.168.1.1")
+	manager.AddConnectionWithIP("conn2", nil, &user1, "authenticated", nil, "", "192.168.1.1")
 
 	// User2 can also have 2 connections
-	manager.AddConnectionWithIP("conn3", nil, &user2, "authenticated", nil, "192.168.1.2")
-	manager.AddConnectionWithIP("conn4", nil, &user2, "authenticated", nil, "192.168.1.2")
+	manager.AddConnectionWithIP("conn3", nil, &user2, "authenticated", nil, "", "192.168.1.2")
+	manager.AddConnectionWithIP("conn4", nil, &user2, "authenticated", nil, "", "192.168.1.2")
 
 	// Both users should be at their limits
-	_, err1 := manager.AddConnectionWithIP("conn5", nil, &user1, "authenticated", nil, "192.168.1.1")
+	_, err1 := manager.AddConnectionWithIP("conn5", nil, &user1, "authenticated", nil, "", "192.168.1.1")
 	assert.Equal(t, ErrMaxUserConnectionsReached, err1)
 
-	_, err2 := manager.AddConnectionWithIP("conn6", nil, &user2, "authenticated", nil, "192.168.1.2")
+	_, err2 := manager.AddConnectionWithIP("conn6", nil, &user2, "authenticated", nil, "", "192.168.1.2")
 	assert.Equal(t, ErrMaxUserConnectionsReached, err2)
 
 	assert.Equal(t, 4, manager.GetConnectionCount())
@@ -307,20 +307,20 @@ func TestManager_PerIPConnectionLimit(t *testing.T) {
 	ip := "192.168.1.100"
 
 	// First three anonymous connections from same IP should succeed
-	conn1, err := manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, ip)
+	conn1, err := manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, "", ip)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn1)
 
-	conn2, err := manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, ip)
+	conn2, err := manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, "", ip)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn2)
 
-	conn3, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, ip)
+	conn3, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, "", ip)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn3)
 
 	// Fourth connection should fail
-	conn4, err := manager.AddConnectionWithIP("conn4", nil, nil, "anon", nil, ip)
+	conn4, err := manager.AddConnectionWithIP("conn4", nil, nil, "anon", nil, "", ip)
 	assert.Error(t, err)
 	assert.Equal(t, ErrMaxIPConnectionsReached, err)
 	assert.Nil(t, conn4)
@@ -340,12 +340,12 @@ func TestManager_PerIPConnectionLimit_DifferentIPs(t *testing.T) {
 	ip2 := "192.168.1.2"
 
 	// IP1 can have 2 connections
-	manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, ip1)
-	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, ip1)
+	manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, "", ip1)
+	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, "", ip1)
 
 	// IP2 can also have 2 connections
-	manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, ip2)
-	manager.AddConnectionWithIP("conn4", nil, nil, "anon", nil, ip2)
+	manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, "", ip2)
+	manager.AddConnectionWithIP("conn4", nil, nil, "anon", nil, "", ip2)
 
 	assert.Equal(t, 4, manager.GetConnectionCount())
 	assert.Equal(t, 2, manager.GetIPConnectionCount(ip1))
@@ -364,7 +364,7 @@ func TestManager_PerIPLimitNotAppliedToAuthenticatedUsers(t *testing.T) {
 
 	// Authenticated users should not be limited by IP
 	for i := 0; i < 5; i++ {
-		conn, err := manager.AddConnectionWithIP("conn"+string(rune('a'+i)), nil, &userID, "authenticated", nil, ip)
+		conn, err := manager.AddConnectionWithIP("conn"+string(rune('a'+i)), nil, &userID, "authenticated", nil, "", ip)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	}
@@ -384,18 +384,18 @@ func TestManager_RemoveConnection_DecrementsUserCount(t *testing.T) {
 	userID := "user123"
 
 	// Add two connections
-	manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "192.168.1.1")
-	manager.AddConnectionWithIP("conn2", nil, &userID, "authenticated", nil, "192.168.1.1")
+	manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "", "192.168.1.1")
+	manager.AddConnectionWithIP("conn2", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 
 	// Verify at limit
-	_, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "192.168.1.1")
+	_, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.Equal(t, ErrMaxUserConnectionsReached, err)
 
 	// Remove one connection
 	manager.RemoveConnection("conn1")
 
 	// Should be able to add a new connection
-	conn3, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "192.168.1.1")
+	conn3, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.NoError(t, err)
 	assert.NotNil(t, conn3)
 }
@@ -409,18 +409,18 @@ func TestManager_RemoveConnection_DecrementsIPCount(t *testing.T) {
 	ip := "192.168.1.100"
 
 	// Add two connections
-	manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, ip)
-	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, ip)
+	manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, "", ip)
+	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, "", ip)
 
 	// Verify at limit
-	_, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, ip)
+	_, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, "", ip)
 	assert.Equal(t, ErrMaxIPConnectionsReached, err)
 
 	// Remove one connection
 	manager.RemoveConnection("conn1")
 
 	// Should be able to add a new connection
-	conn3, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, ip)
+	conn3, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, "", ip)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn3)
 }
@@ -436,8 +436,8 @@ func TestManager_Shutdown_ClearsTrackingMaps(t *testing.T) {
 	ip := "192.168.1.1"
 
 	// Add some connections
-	manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, ip)
-	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, ip)
+	manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "", ip)
+	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, "", ip)
 
 	// Shutdown
 	manager.Shutdown()
@@ -460,14 +460,14 @@ func TestManager_SetConnectionLimits(t *testing.T) {
 
 	// Add 5 connections
 	for i := 0; i < 5; i++ {
-		manager.AddConnectionWithIP("conn"+string(rune('a'+i)), nil, &userID, "authenticated", nil, "192.168.1.1")
+		manager.AddConnectionWithIP("conn"+string(rune('a'+i)), nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	}
 
 	// Reduce limit - existing connections remain but no new ones allowed
 	manager.SetConnectionLimits(3, 3)
 
 	// New connection should fail
-	_, err := manager.AddConnectionWithIP("conn_new", nil, &userID, "authenticated", nil, "192.168.1.1")
+	_, err := manager.AddConnectionWithIP("conn_new", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.Equal(t, ErrMaxUserConnectionsReached, err)
 }
 
@@ -483,12 +483,12 @@ func TestManager_GlobalLimitTakesPrecedence(t *testing.T) {
 	user2 := "user2"
 
 	// Add 3 connections (global limit)
-	manager.AddConnectionWithIP("conn1", nil, &user1, "authenticated", nil, "192.168.1.1")
-	manager.AddConnectionWithIP("conn2", nil, &user1, "authenticated", nil, "192.168.1.1")
-	manager.AddConnectionWithIP("conn3", nil, &user2, "authenticated", nil, "192.168.1.2")
+	manager.AddConnectionWithIP("conn1", nil, &user1, "authenticated", nil, "", "192.168.1.1")
+	manager.AddConnectionWithIP("conn2", nil, &user1, "authenticated", nil, "", "192.168.1.1")
+	manager.AddConnectionWithIP("conn3", nil, &user2, "authenticated", nil, "", "192.168.1.2")
 
 	// Fourth connection should fail due to global limit
-	_, err := manager.AddConnectionWithIP("conn4", nil, &user2, "authenticated", nil, "192.168.1.2")
+	_, err := manager.AddConnectionWithIP("conn4", nil, &user2, "authenticated", nil, "", "192.168.1.2")
 	assert.Equal(t, ErrMaxConnectionsReached, err)
 }
 
@@ -591,7 +591,7 @@ func TestManager_BroadcastGlobal(t *testing.T) {
 		manager := NewManager(ctx)
 
 		// Add a connection with subscription
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 		conn.Subscribe("test-channel")
 
 		// Broadcast should work without pubsub
@@ -677,7 +677,7 @@ func TestManager_handleGlobalMessage(t *testing.T) {
 		manager := NewManager(ctx)
 
 		// Add connection with subscription
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 		conn.Subscribe("test-channel")
 
 		// Simulate a global broadcast message
@@ -707,7 +707,7 @@ func TestManager_handleGlobalMessage(t *testing.T) {
 		manager := NewManager(ctx)
 
 		// Add connection WITHOUT subscription
-		_, _ = manager.AddConnection("conn1", nil, nil, "anon", nil)
+		_, _ = manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		// Simulate a global broadcast message
 		broadcast := GlobalBroadcast{
@@ -776,8 +776,8 @@ func TestManager_updateMetrics(t *testing.T) {
 	t.Run("counts active connections", func(t *testing.T) {
 		manager := NewManager(context.Background())
 
-		manager.AddConnection("conn1", nil, nil, "anon", nil)
-		manager.AddConnection("conn2", nil, nil, "anon", nil)
+		manager.AddConnection("conn1", nil, nil, "anon", nil, "")
+		manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 
 		// Should not panic
 		manager.updateMetrics()
@@ -786,11 +786,11 @@ func TestManager_updateMetrics(t *testing.T) {
 	t.Run("counts unique channels", func(t *testing.T) {
 		manager := NewManager(context.Background())
 
-		conn1, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn1, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 		conn1.Subscribe("channel1")
 		conn1.Subscribe("channel2")
 
-		conn2, _ := manager.AddConnection("conn2", nil, nil, "anon", nil)
+		conn2, _ := manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 		conn2.Subscribe("channel1") // Same channel
 		conn2.Subscribe("channel3") // Different channel
 
@@ -817,7 +817,7 @@ func TestManager_GetDetailedStats(t *testing.T) {
 		manager := NewManager(context.Background())
 
 		userID := "user123"
-		manager.AddConnection("conn1", nil, &userID, "authenticated", nil)
+		manager.AddConnection("conn1", nil, &userID, "authenticated", nil, "")
 
 		stats := manager.GetDetailedStats()
 
@@ -835,7 +835,7 @@ func TestManager_GetDetailedStats(t *testing.T) {
 	t.Run("includes connected timestamp", func(t *testing.T) {
 		manager := NewManager(context.Background())
 
-		manager.AddConnection("conn1", nil, nil, "anon", nil)
+		manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		stats := manager.GetDetailedStats()
 		connections := stats["connections"].([]ConnectionInfo)
@@ -858,8 +858,8 @@ func TestManager_GetConnectionsForStats(t *testing.T) {
 		manager := NewManager(context.Background())
 
 		userID := "user123"
-		manager.AddConnection("conn1", nil, &userID, "authenticated", nil)
-		manager.AddConnection("conn2", nil, nil, "anon", nil)
+		manager.AddConnection("conn1", nil, &userID, "authenticated", nil, "")
+		manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 
 		connections := manager.GetConnectionsForStats()
 
@@ -889,7 +889,7 @@ func TestManager_BroadcastConnectionEvent(t *testing.T) {
 
 		manager.SetPubSub(mockPubSub)
 
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		event := NewConnectionEvent(ConnectionEventConnected, conn, nil, nil)
 
@@ -904,7 +904,7 @@ func TestManager_BroadcastConnectionEvent(t *testing.T) {
 	t.Run("works without pubsub configured", func(t *testing.T) {
 		manager := NewManager(context.Background())
 
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		event := NewConnectionEvent(ConnectionEventConnected, conn, nil, nil)
 
@@ -931,11 +931,11 @@ func TestManager_SetMaxConnections(t *testing.T) {
 		manager.SetMaxConnections(2)
 
 		// Add 2 connections
-		manager.AddConnection("conn1", nil, nil, "anon", nil)
-		manager.AddConnection("conn2", nil, nil, "anon", nil)
+		manager.AddConnection("conn1", nil, nil, "anon", nil, "")
+		manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 
 		// Third should fail
-		_, err := manager.AddConnection("conn3", nil, nil, "anon", nil)
+		_, err := manager.AddConnection("conn3", nil, nil, "anon", nil, "")
 		assert.Equal(t, ErrMaxConnectionsReached, err)
 	})
 
@@ -945,7 +945,7 @@ func TestManager_SetMaxConnections(t *testing.T) {
 
 		// Should allow many connections
 		for i := 0; i < 100; i++ {
-			_, err := manager.AddConnection("conn"+string(rune(i)), nil, nil, "anon", nil)
+			_, err := manager.AddConnection("conn"+string(rune(i)), nil, nil, "anon", nil, "")
 			assert.NoError(t, err)
 		}
 	})
@@ -963,7 +963,7 @@ func TestManager_checkAndDisconnectSlowClients(t *testing.T) {
 			SlowClientTimeout:   1 * time.Second,
 		})
 
-		_, _ = manager.AddConnection("conn1", nil, nil, "anon", nil)
+		_, _ = manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		// Run check - should not disconnect
 		manager.checkAndDisconnectSlowClients()
@@ -979,7 +979,7 @@ func TestManager_checkAndDisconnectSlowClients(t *testing.T) {
 			SlowClientTimeout:      1 * time.Second,
 		})
 
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		// Cancel the connection context to stop the writer goroutine from draining the queue
 		conn.cancel()

--- a/sdk-react/package.json
+++ b/sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbleflux/fluxbase-sdk-react",
-  "version": "2026.5.3",
+  "version": "2026.5.4-rc.17",
   "description": "React hooks for Fluxbase SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@nimbleflux/fluxbase-sdk": "^2026.5.3",
+    "@nimbleflux/fluxbase-sdk": "^2026.5.4-rc.17",
     "@tanstack/react-query": "^5.96.2",
     "react": "^18.0.0 || ^19.0.0"
   },

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbleflux/fluxbase-sdk",
-  "version": "2026.5.3",
+  "version": "2026.5.4-rc.17",
   "description": "Official TypeScript SDK for Fluxbase - Backend as a Service",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Tenant context was lost when WebSocket connections (AI chat, realtime) and async goroutines (function execution completion, scheduler) created new context.Background() without propagating the tenant_id from Fiber Locals. This caused non-default tenant users to get CHATBOT_NOT_FOUND errors and function execution records to never complete.