### PR TITLE
fix: propagate tenant context in AI chat and realtime WebSocket handlers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,8 @@ jobs:
 
       - name: Install native dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libvips-dev libtesseract-dev libleptonica-dev
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libvips-dev libtesseract-dev libleptonica-dev
 
       - name: Get dependencies
         run: |
@@ -363,8 +363,8 @@ jobs:
 
       - name: Install native dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libvips-dev libtesseract-dev libleptonica-dev
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libvips-dev libtesseract-dev libleptonica-dev
 
       - name: Get dependencies
         run: |
@@ -666,7 +666,7 @@ jobs:
       needs.changes.outputs.go == 'true' ||
       needs.changes.outputs.ci-config == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     services:
       postgres:
@@ -713,8 +713,8 @@ jobs:
 
       - name: Install native dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libvips-dev libtesseract-dev libleptonica-dev
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libvips-dev libtesseract-dev libleptonica-dev
 
       - name: Get dependencies
         run: |
@@ -1003,8 +1003,8 @@ jobs:
 
       - name: Install native dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libvips-dev libtesseract-dev libleptonica-dev
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libvips-dev libtesseract-dev libleptonica-dev
 
       - name: Build server binary
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,11 +155,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Install native dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends libvips-dev libtesseract-dev libleptonica-dev
-
       - name: Get dependencies
         run: |
           go mod download
@@ -360,11 +355,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-
-      - name: Install native dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends libvips-dev libtesseract-dev libleptonica-dev
 
       - name: Get dependencies
         run: |
@@ -711,11 +701,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Install native dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends libvips-dev libtesseract-dev libleptonica-dev
-
       - name: Get dependencies
         run: |
           go mod download
@@ -1000,11 +985,6 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
-
-      - name: Install native dependencies
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends libvips-dev libtesseract-dev libleptonica-dev
 
       - name: Build server binary
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,6 +470,7 @@ jobs:
           # Bootstrap must have already run (creates schemas, extensions, roles).
           SCHEMA_DIR="internal/database/schema/schemas"
           for schema in platform auth storage jobs functions realtime ai rpc system migrations app api branching logging mcp; do
+            if [ ! -f "${SCHEMA_DIR}/${schema}.sql" ]; then continue; fi
             echo "Applying schema: $schema"
             sed "s/{{APP_USER}}/fluxbase_app/g" "${SCHEMA_DIR}/${schema}.sql" | psql -h localhost -U postgres -d fluxbase_test -v ON_ERROR_STOP=1
           done
@@ -803,6 +804,7 @@ jobs:
         run: |
           SCHEMA_DIR="internal/database/schema/schemas"
           for schema in platform auth storage jobs functions realtime ai rpc system migrations app api branching logging mcp; do
+            if [ ! -f "${SCHEMA_DIR}/${schema}.sql" ]; then continue; fi
             echo "Applying schema: $schema"
             sed "s/{{APP_USER}}/fluxbase_app/g" "${SCHEMA_DIR}/${schema}.sql" | psql -h localhost -U postgres -d fluxbase_test -v ON_ERROR_STOP=1
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -666,7 +666,7 @@ jobs:
       needs.changes.outputs.go == 'true' ||
       needs.changes.outputs.ci-config == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     services:
       postgres:

--- a/cli/bundler/display.go
+++ b/cli/bundler/display.go
@@ -50,7 +50,8 @@ func DisplayAnalysis(w io.Writer, result *AnalysisResult, showDetails bool) {
 
 			displayPath := truncatePath(file.Path, 50)
 			padding := strings.Repeat(" ", maxPathLen-len(displayPath))
-			_, _ = fmt.Fprintf(w, "  %s%s  %8s  %5.1f%%\n",
+			_, _ = fmt.Fprintf(
+				w, "  %s%s  %8s  %5.1f%%\n",
 				displayPath,
 				padding,
 				formatBytesHuman(file.BytesInOutput),
@@ -99,7 +100,8 @@ func DisplaySummary(w io.Writer, results []*AnalysisResult) {
 	for _, r := range results {
 		totalSize += r.TotalBytes
 		padding := strings.Repeat(" ", maxNameLen-len(r.FunctionName))
-		_, _ = fmt.Fprintf(w, "%s%s  %11s  %5d  %9d\n",
+		_, _ = fmt.Fprintf(
+			w, "%s%s  %11s  %5d  %9d\n",
 			r.FunctionName,
 			padding,
 			formatBytesHuman(r.TotalBytes),

--- a/cli/client/client_test.go
+++ b/cli/client/client_test.go
@@ -37,7 +37,8 @@ func TestNewClient_Options(t *testing.T) {
 		Server: "http://localhost:8080",
 	}
 
-	c := NewClient(cfg, profile,
+	c := NewClient(
+		cfg, profile,
 		WithDebug(true),
 		WithTimeout(10*time.Second),
 		WithConfigPath("/tmp/test-config"),

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -203,7 +203,8 @@ func initializeClient(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create API client
-	apiClient = client.NewClient(cfg, profile,
+	apiClient = client.NewClient(
+		cfg, profile,
 		client.WithDebug(debug),
 		client.WithConfigPath(configPath),
 	)

--- a/cmd/fluxbase/main.go
+++ b/cmd/fluxbase/main.go
@@ -583,7 +583,8 @@ func ensureDefaultTenantAndKeys(pool *pgxpool.Pool, cfg *config.Config) error {
 	// that can occur right after pool recreation).
 	var err error
 	for attempt := 0; attempt < 3; attempt++ {
-		err = pool.QueryRow(ctx,
+		err = pool.QueryRow(
+			ctx,
 			"SELECT id, true FROM platform.tenants WHERE slug = 'default' AND deleted_at IS NULL",
 		).Scan(&tenantID, &tenantExists)
 		if err == nil {
@@ -614,7 +615,8 @@ func ensureDefaultTenantAndKeys(pool *pgxpool.Pool, cfg *config.Config) error {
 			tenantName = "Default"
 		}
 
-		err := pool.QueryRow(ctx,
+		err := pool.QueryRow(
+			ctx,
 			"INSERT INTO platform.tenants (slug, name, is_default) VALUES ('default', $1, true) RETURNING id",
 			tenantName,
 		).Scan(&tenantID)
@@ -673,7 +675,8 @@ func ensureServiceKey(ctx context.Context, pool *pgxpool.Pool, cfg *config.Confi
 	// Check for existing key of this type in auth.service_keys
 	var existingKeyID uuid.UUID
 	var existingKeyHash string
-	err := pool.QueryRow(ctx,
+	err := pool.QueryRow(
+		ctx,
 		"SELECT id, key_hash FROM auth.service_keys WHERE key_type = $1 AND enabled = true AND revoked_at IS NULL",
 		keyType,
 	).Scan(&existingKeyID, &existingKeyHash)
@@ -693,7 +696,8 @@ func ensureServiceKey(ctx context.Context, pool *pgxpool.Pool, cfg *config.Confi
 				return nil
 			}
 			// Key changed, disable old and create new
-			_, err := pool.Exec(ctx,
+			_, err := pool.Exec(
+				ctx,
 				"UPDATE auth.service_keys SET enabled = false WHERE id = $1",
 				existingKeyID,
 			)
@@ -704,7 +708,8 @@ func ensureServiceKey(ctx context.Context, pool *pgxpool.Pool, cfg *config.Confi
 
 		// Insert new config-managed key
 		keyPrefix := keys.ExtractPrefix(configKey)
-		_, err = pool.Exec(ctx,
+		_, err = pool.Exec(
+			ctx,
 			`INSERT INTO auth.service_keys 
 			(name, key_hash, key_prefix, key_type, enabled, scopes, rate_limit_per_minute)
 			VALUES ($1, $2, $3, $4, true, $5, $6)`,
@@ -731,7 +736,8 @@ func ensureServiceKey(ctx context.Context, pool *pgxpool.Pool, cfg *config.Confi
 	}
 
 	// Insert generated key
-	_, err = pool.Exec(ctx,
+	_, err = pool.Exec(
+		ctx,
 		`INSERT INTO auth.service_keys 
 		(name, key_hash, key_prefix, key_type, enabled, scopes, rate_limit_per_minute)
 		VALUES ($1, $2, $3, $4, true, $5, $6)`,
@@ -779,7 +785,8 @@ func getDefaultTenantID(pool *pgxpool.Pool) *string {
 	defer cancel()
 
 	var tenantID string
-	err := pool.QueryRow(ctx,
+	err := pool.QueryRow(
+		ctx,
 		"SELECT id::text FROM platform.tenants WHERE slug = 'default' AND deleted_at IS NULL",
 	).Scan(&tenantID)
 	if err != nil {
@@ -808,7 +815,8 @@ func backfillTenantIDToDefault(pool *pgxpool.Pool) error {
 
 	// Get default tenant ID
 	var defaultTenantID string
-	err := pool.QueryRow(ctx,
+	err := pool.QueryRow(
+		ctx,
 		"SELECT id::text FROM platform.tenants WHERE is_default = true AND deleted_at IS NULL LIMIT 1",
 	).Scan(&defaultTenantID)
 	if err != nil {
@@ -944,7 +952,8 @@ func backfillTenantIDToDefault(pool *pgxpool.Pool) error {
 			}
 		}
 
-		result, err := pool.Exec(ctx,
+		result, err := pool.Exec(
+			ctx,
 			fmt.Sprintf("UPDATE %s SET tenant_id = $1::uuid WHERE tenant_id IS NULL", table),
 			defaultTenantID,
 		)

--- a/internal/ai/audit.go
+++ b/internal/ai/audit.go
@@ -98,7 +98,8 @@ func (l *AuditLogger) LogQuery(ctx context.Context, entry *AuditEntry) error {
 	`
 
 	err := l.WithTenant(ctx, func(tx pgx.Tx) error {
-		_, execErr := tx.Exec(ctx, query,
+		_, execErr := tx.Exec(
+			ctx, query,
 			entry.ID, entry.ChatbotID, entry.ConversationID, entry.MessageID, validUserID,
 			entry.GeneratedSQL, entry.SanitizedSQL, entry.Executed,
 			entry.ValidationPassed, entry.ValidationErrors,

--- a/internal/ai/chat_handler.go
+++ b/internal/ai/chat_handler.go
@@ -192,6 +192,10 @@ func (h *ChatHandler) handleConnection(c *websocket.Conn) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	if tenantID := extractStringDefault(c.Locals("tenant_id"), ""); tenantID != "" {
+		ctx = database.ContextWithTenant(ctx, tenantID)
+	}
+
 	// Extract auth context from locals (set by auth middleware)
 	userID := extractString(c.Locals("user_id"))
 	role := extractStringDefault(c.Locals("rls_role"), "anon")

--- a/internal/ai/conversation.go
+++ b/internal/ai/conversation.go
@@ -356,7 +356,8 @@ func (cm *ConversationManager) saveConversation(ctx context.Context, conv *Conve
 	`
 
 	return cm.WithTenant(ctx, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			conv.ID, conv.ChatbotID, validUserID, conv.SessionID, conv.Title, conv.Status,
 			conv.TurnCount, conv.TotalPromptTokens, conv.TotalCompletionTokens,
 			conv.CreatedAt, conv.UpdatedAt, conv.LastMessageAt, conv.ExpiresAt,
@@ -449,7 +450,8 @@ func (cm *ConversationManager) saveMessage(ctx context.Context, msg *Conversatio
 	`
 
 	return cm.WithTenant(ctx, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			msg.ID, msg.ConversationID, msg.Role, msg.Content, msg.ToolCallID, msg.ToolName,
 			msg.ExecutedSQL, msg.SQLResultSummary, msg.SQLRowCount, msg.SQLError, msg.SQLDurationMs,
 			msg.QueryResults, msg.PromptTokens, msg.CompletionTokens, msg.CreatedAt, msg.SequenceNumber,
@@ -470,7 +472,8 @@ func (cm *ConversationManager) updateConversationStats(ctx context.Context, conv
 	`
 
 	return cm.WithTenant(ctx, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			conversationID,
 			state.TurnCount,
 			state.TotalPromptTokens,

--- a/internal/ai/kb_storage.go
+++ b/internal/ai/kb_storage.go
@@ -46,7 +46,8 @@ func (s *KnowledgeBaseStorage) CreateKnowledgeBase(ctx context.Context, kb *Know
 			RETURNING created_at, updated_at
 		`
 
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			kb.ID, kb.Name, kb.Namespace, kb.Description,
 			kb.EmbeddingModel, kb.EmbeddingDimensions,
 			kb.ChunkSize, kb.ChunkOverlap, kb.ChunkStrategy,
@@ -186,7 +187,8 @@ func (s *KnowledgeBaseStorage) UpdateKnowledgeBase(ctx context.Context, kb *Know
 			RETURNING updated_at
 		`
 
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			kb.ID, kb.Name, kb.Description,
 			kb.EmbeddingModel, kb.EmbeddingDimensions,
 			kb.ChunkSize, kb.ChunkOverlap, kb.ChunkStrategy,
@@ -675,7 +677,8 @@ func (s *KnowledgeBaseStorage) SetUserQuota(ctx context.Context, quota *UserQuot
 			    updated_at = NOW()
 		`
 
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			quota.UserID,
 			quota.MaxDocuments,
 			quota.MaxChunks,

--- a/internal/ai/kb_storage_docs.go
+++ b/internal/ai/kb_storage_docs.go
@@ -41,7 +41,8 @@ func (s *KnowledgeBaseStorage) CreateDocument(ctx context.Context, doc *Document
 			RETURNING created_at, updated_at
 		`
 
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			doc.ID, doc.KnowledgeBaseID, doc.Title, doc.SourceURL, doc.SourceType,
 			doc.MimeType, doc.Content, doc.ContentHash, doc.Status, metadataJSON, doc.Tags, doc.CreatedBy, doc.OwnerID,
 		).Scan(&doc.CreatedAt, &doc.UpdatedAt)
@@ -416,7 +417,8 @@ func (s *KnowledgeBaseStorage) CreateChunks(ctx context.Context, chunks []Chunk)
 			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, %s, $9)
 		`, embeddingExpr)
 
-		batch.Queue(query,
+		batch.Queue(
+			query,
 			chunk.ID, chunk.DocumentID, chunk.KnowledgeBaseID, chunk.Content,
 			chunk.ChunkIndex, chunk.StartOffset, chunk.EndOffset, chunk.TokenCount,
 			metadataJSON,

--- a/internal/ai/kb_storage_sync.go
+++ b/internal/ai/kb_storage_sync.go
@@ -55,7 +55,8 @@ func (s *KnowledgeBaseStorage) LinkChatbotKnowledgeBase(ctx context.Context, lin
 			RETURNING created_at, updated_at
 		`
 
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			link.ID, link.ChatbotID, link.KnowledgeBaseID,
 			link.AccessLevel, link.FilterExpression, link.ContextWeight, link.Priority,
 			link.IntentKeywords, link.MaxChunks, link.SimilarityThreshold,
@@ -169,7 +170,8 @@ func (s *KnowledgeBaseStorage) GetKnowledgeBaseChatbots(ctx context.Context, kno
 // UnlinkChatbotKnowledgeBase removes a link between chatbot and knowledge base
 func (s *KnowledgeBaseStorage) UnlinkChatbotKnowledgeBase(ctx context.Context, chatbotID, knowledgeBaseID string) error {
 	return s.WithTenant(ctx, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx,
+		_, err := tx.Exec(
+			ctx,
 			"DELETE FROM ai.chatbot_knowledge_bases WHERE chatbot_id = $1 AND knowledge_base_id = $2",
 			chatbotID, knowledgeBaseID,
 		)
@@ -197,7 +199,8 @@ func (s *KnowledgeBaseStorage) LogRetrieval(ctx context.Context, log *RetrievalL
 			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		`
 
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			log.ID, log.ChatbotID, log.ConversationID, log.KnowledgeBaseID, log.UserID,
 			log.QueryText, log.QueryEmbeddingModel, log.ChunksRetrieved,
 			log.ChunkIDs, log.SimilarityScores, log.RetrievalDurationMs,

--- a/internal/ai/knowledge_graph.go
+++ b/internal/ai/knowledge_graph.go
@@ -55,7 +55,8 @@ func (kg *KnowledgeGraph) AddEntity(ctx context.Context, entity *Entity) error {
 	`
 
 	return kg.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			entity.ID, entity.KnowledgeBaseID, entity.EntityType, entity.Name,
 			entity.CanonicalName, entity.Aliases, entity.Metadata,
 			entity.CreatedAt, entity.UpdatedAt,
@@ -213,7 +214,8 @@ func (kg *KnowledgeGraph) AddRelationship(ctx context.Context, rel *EntityRelati
 	`
 
 	return kg.WithTenant(ctx, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			rel.ID, rel.KnowledgeBaseID, rel.SourceEntityID, rel.TargetEntityID,
 			rel.RelationshipType, rel.Direction, rel.Confidence, rel.Metadata,
 			rel.CreatedAt,
@@ -359,7 +361,8 @@ func (kg *KnowledgeGraph) AddDocumentEntities(ctx context.Context, docEntities [
 			}
 			de.CreatedAt = time.Now()
 
-			_, err := tx.Exec(ctx, query,
+			_, err := tx.Exec(
+				ctx, query,
 				de.ID, de.DocumentID, de.EntityID, de.MentionCount,
 				de.FirstMentionOffset, de.Salience, de.Context, de.CreatedAt,
 			)
@@ -491,7 +494,8 @@ func (kg *KnowledgeGraph) BatchAddEntities(ctx context.Context, entities []Entit
 			entity.CreatedAt = time.Now()
 			entity.UpdatedAt = time.Now()
 
-			batch.Queue(query,
+			batch.Queue(
+				query,
 				entity.ID, entity.KnowledgeBaseID, entity.EntityType, entity.Name,
 				entity.CanonicalName, entity.Aliases, entity.Metadata,
 				entity.CreatedAt, entity.UpdatedAt,

--- a/internal/ai/provider_storage.go
+++ b/internal/ai/provider_storage.go
@@ -61,7 +61,8 @@ func (s *Storage) CreateProviderWithTenant(ctx context.Context, tenantID string,
 	provider.UpdatedAt = time.Now()
 
 	err := database.WrapWithTenantAwareRole(ctx, s.db, tenantID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			provider.ID, provider.Name, provider.DisplayName, provider.ProviderType,
 			provider.IsDefault, provider.UseForEmbeddings, provider.EmbeddingModel, provider.Config, provider.Enabled, provider.CreatedBy,
 			provider.CreatedAt, provider.UpdatedAt,
@@ -107,7 +108,8 @@ func (s *Storage) UpdateProviderWithTenant(ctx context.Context, tenantID string,
 	var result pgconn.CommandTag
 	err := database.WrapWithTenantAwareRole(ctx, s.db, tenantID, func(tx pgx.Tx) error {
 		var execErr error
-		result, execErr = tx.Exec(ctx, query,
+		result, execErr = tx.Exec(
+			ctx, query,
 			provider.ID,
 			provider.DisplayName,
 			provider.Config,

--- a/internal/ai/storage.go
+++ b/internal/ai/storage.go
@@ -111,7 +111,8 @@ func (s *Storage) CreateChatbotWithTenant(ctx context.Context, tenantID string, 
 	}
 
 	err = database.WrapWithTenantAwareRole(ctx, s.db, tenantID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			chatbot.ID, chatbot.Name, chatbot.Namespace, chatbot.Description,
 			chatbot.Code, chatbot.OriginalCode, chatbot.IsBundled, chatbot.BundleError,
 			chatbot.AllowedTables, chatbot.AllowedOperations, chatbot.AllowedSchemas, chatbot.HTTPAllowedDomains,
@@ -206,7 +207,8 @@ func (s *Storage) UpdateChatbotWithTenant(ctx context.Context, tenantID string, 
 	var result pgconn.CommandTag
 	err = database.WrapWithTenantAwareRole(ctx, s.db, tenantID, func(tx pgx.Tx) error {
 		var execErr error
-		result, execErr = tx.Exec(ctx, query,
+		result, execErr = tx.Exec(
+			ctx, query,
 			chatbot.ID,
 			chatbot.Description,
 			chatbot.Code,

--- a/internal/ai/table_export_sync.go
+++ b/internal/ai/table_export_sync.go
@@ -128,7 +128,8 @@ func (s *TableExportSyncService) CreateSyncConfig(ctx context.Context, config *C
 	}
 
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			id, config.KnowledgeBaseID, config.SchemaName, config.TableName, columns,
 			config.SyncMode, config.SyncOnInsert, config.SyncOnUpdate, config.SyncOnDelete,
 			config.DebounceSeconds, config.IncludeForeignKeys, config.IncludeIndexes,

--- a/internal/api/admin_auth_handler.go
+++ b/internal/api/admin_auth_handler.go
@@ -238,7 +238,8 @@ func (h *AdminAuthHandler) AdminLogin(c fiber.Ctx) error {
 
 	// Query user's role from database (DashboardUser struct doesn't include role)
 	var userRole string
-	err = h.dashboardAuth.GetDB().QueryRow(ctx,
+	err = h.dashboardAuth.GetDB().QueryRow(
+		ctx,
 		"SELECT role FROM platform.users WHERE id = $1",
 		user.ID,
 	).Scan(&userRole)

--- a/internal/api/auth_saml.go
+++ b/internal/api/auth_saml.go
@@ -348,7 +348,8 @@ func (h *SAMLHandler) HandleSAMLAssertion(c fiber.Ctx) error {
 				if strings.Contains(validatedURL, "#") {
 					separator = "&"
 				}
-				validatedURL = fmt.Sprintf("%s%saccess_token=%s&refresh_token=%s&token_type=bearer",
+				validatedURL = fmt.Sprintf(
+					"%s%saccess_token=%s&refresh_token=%s&token_type=bearer",
 					validatedURL, separator,
 					url.QueryEscape(accessToken),
 					url.QueryEscape(refreshToken),

--- a/internal/api/oauth_provider_handler.go
+++ b/internal/api/oauth_provider_handler.go
@@ -456,7 +456,8 @@ func (h *OAuthProviderHandler) CreateOAuthProvider(c fiber.Ctx) error {
 
 	if isInstanceLevel {
 		err = database.WrapWithServiceRole(ctx, h.db, func(tx pgx.Tx) error {
-			return tx.QueryRow(ctx, query,
+			return tx.QueryRow(
+				ctx, query,
 				req.ProviderName, req.DisplayName, req.Enabled, req.ClientID, encryptedSecret,
 				req.RedirectURL, req.Scopes, req.IsCustom, req.AuthorizationURL, req.TokenURL,
 				req.UserInfoURL, req.RevocationEndpoint, req.EndSessionEndpoint,

--- a/internal/api/rest_geojson.go
+++ b/internal/api/rest_geojson.go
@@ -90,7 +90,8 @@ func buildSelectColumnsWithTruncation(table database.TableInfo, truncateLength *
 			// Truncate text columns: show first N chars + length indicator if truncated
 			columns = append(columns, fmt.Sprintf(
 				"CASE WHEN %s IS NULL THEN NULL WHEN LENGTH(%s) > %d THEN LEFT(%s, %d) || '... (' || LENGTH(%s) || ' chars)' ELSE %s END AS %s",
-				quotedName, quotedName, *truncateLength, quotedName, *truncateLength, quotedName, quotedName, quotedName))
+				quotedName, quotedName, *truncateLength, quotedName, *truncateLength, quotedName, quotedName, quotedName,
+			))
 		} else {
 			columns = append(columns, quotedName)
 		}

--- a/internal/api/rest_query.go
+++ b/internal/api/rest_query.go
@@ -277,7 +277,8 @@ func (h *RESTHandler) buildSelectQuery(table database.TableInfo, params *QueryPa
 					// Truncate text columns if requested
 					validColumns = append(validColumns, fmt.Sprintf(
 						"CASE WHEN %s IS NULL THEN NULL WHEN LENGTH(%s) > %d THEN LEFT(%s, %d) || '... (' || LENGTH(%s) || ' chars)' ELSE %s END AS %s",
-						quotedCol, quotedCol, *params.TruncateLength, quotedCol, *params.TruncateLength, quotedCol, quotedCol, quotedCol))
+						quotedCol, quotedCol, *params.TruncateLength, quotedCol, *params.TruncateLength, quotedCol, quotedCol, quotedCol,
+					))
 				} else {
 					validColumns = append(validColumns, quotedCol)
 				}

--- a/internal/api/route_isolation_test.go
+++ b/internal/api/route_isolation_test.go
@@ -25,7 +25,8 @@ func TestRouteGroupIsolation(t *testing.T) {
 
 	// Register webhook route with rate limiting directly (not as a group)
 	// This is the correct way to avoid middleware leakage
-	app.Post("/api/v1/webhooks/github",
+	app.Post(
+		"/api/v1/webhooks/github",
 		middleware.GitHubWebhookLimiter(),
 		func(c fiber.Ctx) error {
 			return c.SendString("webhook ok")
@@ -51,7 +52,8 @@ func TestRouteGroupIsolation(t *testing.T) {
 		app2 := fiber.New()
 
 		// Register webhook with rate limiter
-		app2.Post("/api/v1/webhooks/github",
+		app2.Post(
+			"/api/v1/webhooks/github",
 			middleware.GitHubWebhookLimiter(),
 			func(c fiber.Ctx) error {
 				return c.SendString("webhook ok")

--- a/internal/api/routes/knowledge_base.go
+++ b/internal/api/routes/knowledge_base.go
@@ -51,7 +51,8 @@ func BuildKnowledgeBaseRoutes(deps *KnowledgeBaseDeps) *RouteGroup {
 	}
 
 	if deps.ListDocuments != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "GET", Path: "/api/v1/ai/knowledge-bases/:id/documents", Handler: deps.ListDocuments, Summary: "List KB documents", Auth: AuthRequired},
 			Route{Method: "GET", Path: "/api/v1/ai/knowledge-bases/:id/documents/:doc_id", Handler: deps.GetDocument, Summary: "Get KB document", Auth: AuthRequired},
 			Route{Method: "POST", Path: "/api/v1/ai/knowledge-bases/:id/documents", Handler: deps.AddDocument, Summary: "Add document to KB", Auth: AuthRequired},
@@ -63,46 +64,54 @@ func BuildKnowledgeBaseRoutes(deps *KnowledgeBaseDeps) *RouteGroup {
 
 	// Document management extended routes
 	if deps.UpdateDocument != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "PATCH", Path: "/api/v1/ai/knowledge-bases/:id/documents/:doc_id", Handler: deps.UpdateDocument, Summary: "Update KB document", Auth: AuthRequired},
 		)
 	}
 	if deps.DeleteDocsByFilter != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "POST", Path: "/api/v1/ai/knowledge-bases/:id/documents/delete-by-filter", Handler: deps.DeleteDocsByFilter, Summary: "Delete KB documents by filter", Auth: AuthRequired},
 		)
 	}
 	if deps.DebugSearch != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "POST", Path: "/api/v1/ai/knowledge-bases/:id/debug-search", Handler: deps.DebugSearch, Summary: "Debug search knowledge base", Auth: AuthRequired},
 		)
 	}
 
 	// Knowledge Graph / Entities routes
 	if deps.ListEntities != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "GET", Path: "/api/v1/ai/knowledge-bases/:id/entities", Handler: deps.ListEntities, Summary: "List KB entities", Auth: AuthRequired},
 		)
 	}
 	if deps.SearchEntities != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "GET", Path: "/api/v1/ai/knowledge-bases/:id/entities/search", Handler: deps.SearchEntities, Summary: "Search KB entities", Auth: AuthRequired},
 		)
 	}
 	if deps.GetEntityRelationships != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "GET", Path: "/api/v1/ai/knowledge-bases/:id/entities/:entity_id/relationships", Handler: deps.GetEntityRelationships, Summary: "Get entity relationships", Auth: AuthRequired},
 		)
 	}
 	if deps.GetKnowledgeGraph != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "GET", Path: "/api/v1/ai/knowledge-bases/:id/graph", Handler: deps.GetKnowledgeGraph, Summary: "Get knowledge graph", Auth: AuthRequired},
 		)
 	}
 
 	// Chatbot links
 	if deps.ListLinkedChatbots != nil {
-		routes = append(routes,
+		routes = append(
+			routes,
 			Route{Method: "GET", Path: "/api/v1/ai/knowledge-bases/:id/chatbots", Handler: deps.ListLinkedChatbots, Summary: "List linked chatbots", Auth: AuthRequired},
 		)
 	}

--- a/internal/api/saml_provider_handler.go
+++ b/internal/api/saml_provider_handler.go
@@ -382,7 +382,8 @@ func (h *SAMLProviderHandler) CreateSAMLProvider(c fiber.Ctx) error {
 
 	if isInstanceLevel {
 		err = database.WrapWithServiceRole(ctx, h.db, func(tx pgx.Tx) error {
-			return tx.QueryRow(ctx, query,
+			return tx.QueryRow(
+				ctx, query,
 				req.Name, displayName, req.Enabled, entityID, acsURL,
 				req.IdPMetadataURL, req.IdPMetadataXML, metadataInfo.CachedXML,
 				attrMapping, autoCreateUsers, defaultRole,

--- a/internal/api/sql_handler.go
+++ b/internal/api/sql_handler.go
@@ -547,7 +547,8 @@ func convertValue(v any) any {
 }
 
 func formatUUID(b []byte) string {
-	return fmt.Sprintf("%s-%s-%s-%s-%s",
+	return fmt.Sprintf(
+		"%s-%s-%s-%s-%s",
 		hex.EncodeToString(b[0:4]),
 		hex.EncodeToString(b[4:6]),
 		hex.EncodeToString(b[6:8]),

--- a/internal/api/storage_chunked.go
+++ b/internal/api/storage_chunked.go
@@ -571,7 +571,8 @@ func (h *StorageHandler) storeUploadedObject(fiberCtx interface{}, session *stor
 		ownerID = session.OwnerID
 	}
 
-	_, err = tx.Exec(ctx, query,
+	_, err = tx.Exec(
+		ctx, query,
 		object.Bucket,
 		object.Key,
 		object.Size,

--- a/internal/api/storage_files.go
+++ b/internal/api/storage_files.go
@@ -48,7 +48,8 @@ func (h *StorageHandler) UploadFile(c fiber.Ctx) error {
 	// H-19: Check if bucket exists before upload
 	// Use SECURITY DEFINER function to bypass RLS when checking bucket existence
 	var bucketExists bool
-	err = h.getPool(c).QueryRow(c.RequestCtx(),
+	err = h.getPool(c).QueryRow(
+		c.RequestCtx(),
 		`SELECT storage.bucket_exists($1::text, $2::uuid)`,
 		bucket, getTenantIDArg(c),
 	).Scan(&bucketExists)
@@ -83,7 +84,8 @@ func (h *StorageHandler) UploadFile(c fiber.Ctx) error {
 	// Use SECURITY DEFINER function to bypass RLS when fetching bucket settings
 	var bucketMaxFileSize *int64
 	var bucketAllowedMimeTypes []string
-	err = h.getPool(c).QueryRow(c.RequestCtx(),
+	err = h.getPool(c).QueryRow(
+		c.RequestCtx(),
 		`SELECT max_file_size, allowed_mime_types FROM storage.get_bucket_settings($1::text, $2::uuid)`,
 		bucket, getTenantIDArg(c),
 	).Scan(&bucketMaxFileSize, &bucketAllowedMimeTypes)

--- a/internal/api/storage_multipart.go
+++ b/internal/api/storage_multipart.go
@@ -35,7 +35,8 @@ func (h *StorageHandler) MultipartUpload(c fiber.Ctx) error {
 	// H-19: Check if bucket exists before upload
 	// Use SECURITY DEFINER function to bypass RLS when checking bucket existence
 	var bucketExists bool
-	err = h.db.Pool().QueryRow(c.RequestCtx(),
+	err = h.db.Pool().QueryRow(
+		c.RequestCtx(),
 		`SELECT storage.bucket_exists($1::text, $2::uuid)`,
 		bucket, getTenantIDArg(c),
 	).Scan(&bucketExists)
@@ -54,7 +55,8 @@ func (h *StorageHandler) MultipartUpload(c fiber.Ctx) error {
 	// C-3: Get bucket MIME type settings
 	// Use SECURITY DEFINER function to bypass RLS when fetching bucket settings
 	var bucketAllowedMimeTypes []string
-	err = h.db.Pool().QueryRow(c.RequestCtx(),
+	err = h.db.Pool().QueryRow(
+		c.RequestCtx(),
 		`SELECT allowed_mime_types FROM storage.get_bucket_settings($1::text, $2::uuid)`,
 		bucket, getTenantIDArg(c),
 	).Scan(&bucketAllowedMimeTypes)

--- a/internal/api/tenant_handler.go
+++ b/internal/api/tenant_handler.go
@@ -471,7 +471,8 @@ func (h *TenantHandler) AssignAdmin(c fiber.Ctx) error {
 	}
 
 	var userExists bool
-	err := h.DB.Pool().QueryRow(ctx,
+	err := h.DB.Pool().QueryRow(
+		ctx,
 		`SELECT EXISTS(SELECT 1 FROM platform.users WHERE id = $1::uuid AND deleted_at IS NULL)`,
 		req.UserID,
 	).Scan(&userExists)

--- a/internal/auth/email_verification.go
+++ b/internal/auth/email_verification.go
@@ -101,7 +101,8 @@ func (r *EmailVerificationRepository) Create(ctx context.Context, userID string,
 
 	tenantID := database.TenantFromContext(ctx)
 	err = database.WrapWithServiceRoleAndTenant(ctx, r.db, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			token.ID,
 			token.UserID,
 			token.TokenHash,

--- a/internal/auth/identity.go
+++ b/internal/auth/identity.go
@@ -165,7 +165,8 @@ func (r *IdentityRepository) Create(ctx context.Context, userID, provider, provi
 
 	tenantID := database.TenantFromContext(ctx)
 	err := database.WrapWithServiceRoleAndTenant(ctx, r.db, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			identity.ID,
 			identity.UserID,
 			identity.Provider,

--- a/internal/auth/impersonation.go
+++ b/internal/auth/impersonation.go
@@ -97,7 +97,8 @@ func (r *ImpersonationRepository) Create(ctx context.Context, session *Impersona
 
 	result := &ImpersonationSession{}
 	err := database.WrapWithServiceRole(ctx, r.db, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			session.ID,
 			session.AdminUserID,
 			session.TargetUserID,

--- a/internal/auth/invitation.go
+++ b/internal/auth/invitation.go
@@ -110,7 +110,8 @@ func (s *InvitationService) CreateInvitationWithTenant(ctx context.Context, emai
 	}
 
 	err = database.WrapWithServiceRole(ctx, s.db, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
+		return tx.QueryRow(
+			ctx, `
 			INSERT INTO platform.invitation_tokens (id, email, token, token_hash, role, tenant_id, invited_by, expires_at, accepted, created_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 			RETURNING id, email, token, token_hash, role, tenant_id, invited_by, expires_at, accepted, created_at

--- a/internal/auth/magiclink.go
+++ b/internal/auth/magiclink.go
@@ -88,7 +88,8 @@ func (r *MagicLinkRepository) Create(ctx context.Context, email string, expiryDu
 
 	tenantID := database.TenantFromContext(ctx)
 	err = database.WrapWithServiceRoleAndTenant(ctx, r.db, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			magicLink.ID,
 			magicLink.Email,
 			magicLink.TokenHash,

--- a/internal/auth/otp.go
+++ b/internal/auth/otp.go
@@ -103,7 +103,8 @@ func (r *OTPRepository) Create(ctx context.Context, email *string, phone *string
 
 	tenantID := database.TenantFromContext(ctx)
 	err = database.WrapWithServiceRoleAndTenant(ctx, r.db, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			otpCode.ID,
 			otpCode.Email,
 			otpCode.Phone,

--- a/internal/auth/password_reset.go
+++ b/internal/auth/password_reset.go
@@ -97,7 +97,8 @@ func (r *PasswordResetRepository) Create(ctx context.Context, userID string, exp
 
 	tenantID := database.TenantFromContext(ctx)
 	err = database.WrapWithServiceRoleAndTenant(ctx, r.db, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			passwordResetToken.ID,
 			passwordResetToken.UserID,
 			passwordResetToken.TokenHash,

--- a/internal/auth/saml_session.go
+++ b/internal/auth/saml_session.go
@@ -19,7 +19,8 @@ func NewSAMLSessionStore(db *database.Connection) *SAMLSessionStore {
 func (ss *SAMLSessionStore) CreateSAMLSession(ctx context.Context, session *SAMLSession) error {
 	tenantID := database.TenantFromContext(ctx)
 	return database.WrapWithServiceRoleAndTenant(ctx, ss.db, tenantID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, `
+		_, err := tx.Exec(
+			ctx, `
 			INSERT INTO auth.saml_sessions (id, user_id, provider_id, provider_name, name_id, name_id_format, session_index, attributes, expires_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 		`,

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -75,7 +75,8 @@ func (r *SessionRepository) Create(ctx context.Context, userID, accessToken, ref
 
 	tenantID := database.TenantFromContext(ctx)
 	err := database.WrapWithServiceRoleAndTenant(ctx, r.db, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			session.ID,
 			session.UserID,
 			accessTokenHash,

--- a/internal/auth/token_blacklist.go
+++ b/internal/auth/token_blacklist.go
@@ -53,7 +53,8 @@ func (r *TokenBlacklistRepository) Add(ctx context.Context, jti string, revokedB
 	logEvent.Msg("Blacklisting token")
 
 	return database.WrapWithServiceRole(ctx, r.db, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			uuid.New().String(),
 			jti,
 			revokedBy,

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -108,7 +108,8 @@ func (r *UserRepository) Create(ctx context.Context, req CreateUserRequest, pass
 
 	tenantID := database.TenantFromContext(ctx)
 	err := database.WrapWithServiceRoleAndTenant(ctx, r.db, tenantID, func(tx pgx.Tx) error {
-		row := tx.QueryRow(ctx, query,
+		row := tx.QueryRow(
+			ctx, query,
 			user.ID,
 			user.Email,
 			user.PasswordHash,

--- a/internal/auth/user_management.go
+++ b/internal/auth/user_management.go
@@ -345,7 +345,8 @@ func (s *UserManagementService) InviteUser(ctx context.Context, req InviteUserRe
 
 	// Add user to tenant if tenant_id is provided (for app users only)
 	if userType == "app" && req.TenantID != "" && s.userRepo.db != nil {
-		_, err := s.userRepo.db.Pool().Exec(ctx,
+		_, err := s.userRepo.db.Pool().Exec(
+			ctx,
 			`INSERT INTO platform.tenant_memberships (tenant_id, user_id, role)
 			 VALUES ($1::uuid, $2::uuid, 'tenant_member')
 			 ON CONFLICT (tenant_id, user_id) DO NOTHING`,

--- a/internal/branching/storage.go
+++ b/internal/branching/storage.go
@@ -51,7 +51,8 @@ func (s *Storage) CreateBranch(ctx context.Context, branch *Branch) error {
 	}
 
 	return s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			branch.ID,
 			branch.Name,
 			branch.Slug,
@@ -473,7 +474,8 @@ func (s *Storage) LogActivity(ctx context.Context, log *ActivityLog) error {
 	}
 
 	return s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			log.ID,
 			log.BranchID,
 			log.TenantID,
@@ -727,7 +729,8 @@ func (s *Storage) UpsertGitHubConfig(ctx context.Context, config *GitHubConfig) 
 	}
 
 	return s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			config.ID,
 			config.Repository,
 			config.TenantID,
@@ -835,7 +838,8 @@ func (s *Storage) GrantAccess(ctx context.Context, access *BranchAccess) error {
 	}
 
 	return s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			access.ID,
 			access.BranchID,
 			access.TenantID,
@@ -932,7 +936,8 @@ func (s *Storage) HasAccess(ctx context.Context, branchID, userID uuid.UUID, min
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
 		// First check if user is the creator (always has admin access)
 		var createdBy *uuid.UUID
-		err := tx.QueryRow(ctx,
+		err := tx.QueryRow(
+			ctx,
 			`SELECT created_by FROM branching.branches WHERE id = $1`,
 			branchID,
 		).Scan(&createdBy)

--- a/internal/database/bootstrap/bootstrap.go
+++ b/internal/database/bootstrap/bootstrap.go
@@ -59,7 +59,8 @@ func (s *Service) getAdminPool(ctx context.Context) (*pgxpool.Pool, error) {
 
 	// If we have config, create an admin pool
 	if s.config.AdminUser != "" && s.config.AdminPassword != "" {
-		connStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		connStr := fmt.Sprintf(
+			"postgres://%s:%s@%s:%d/%s?sslmode=disable",
 			s.config.AdminUser,
 			s.config.AdminPassword,
 			s.config.Host,

--- a/internal/database/connection.go
+++ b/internal/database/connection.go
@@ -387,7 +387,8 @@ func (c *Connection) runUserMigrations() error {
 	}
 
 	// Create admin connection for migrations
-	adminConnStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+	adminConnStr := fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		c.config.AdminUser,
 		adminPassword,
 		c.config.Host,
@@ -617,7 +618,8 @@ func (c *Connection) grantRolesToRuntimeUser() error {
 		adminPassword = c.config.Password
 	}
 
-	adminConnStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+	adminConnStr := fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s",
 		c.config.AdminUser,
 		adminPassword,
 		c.config.Host,
@@ -637,7 +639,8 @@ func (c *Connection) grantRolesToRuntimeUser() error {
 	for _, role := range roles {
 		// Check if role exists before granting
 		var exists bool
-		err := adminConn.QueryRow(ctx,
+		err := adminConn.QueryRow(
+			ctx,
 			"SELECT EXISTS(SELECT FROM pg_catalog.pg_roles WHERE rolname = $1)",
 			role,
 		).Scan(&exists)

--- a/internal/database/schema/schemas/post-schema.sql
+++ b/internal/database/schema/schemas/post-schema.sql
@@ -220,7 +220,7 @@ END $$;
 --
 
 DO $$ BEGIN
-    CREATE POLICY platform_oauth_providers_tenant ON platform.oauth_providers TO PUBLIC USING ((auth.is_admin() OR current_user_role() = 'tenant_service') AND auth.has_tenant_access(tenant_id)) WITH CHECK ((auth.is_admin() OR current_user_role() = 'tenant_service') AND auth.has_tenant_access(tenant_id));
+    CREATE POLICY platform_oauth_providers_tenant ON platform.oauth_providers TO PUBLIC USING ((auth.is_admin() OR auth.current_user_role() = 'tenant_service') AND auth.has_tenant_access(tenant_id)) WITH CHECK ((auth.is_admin() OR auth.current_user_role() = 'tenant_service') AND auth.has_tenant_access(tenant_id));
     EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 

--- a/internal/functions/storage.go
+++ b/internal/functions/storage.go
@@ -163,7 +163,8 @@ func (s *Storage) CreateFunction(ctx context.Context, fn *EdgeFunction) error {
 	`
 
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			fn.Name, fn.Namespace, fn.Description, fn.Code, fn.OriginalCode, fn.IsBundled, fn.BundleError,
 			fn.Enabled, fn.TimeoutSeconds, fn.MemoryLimitMB,
 			fn.AllowNet, fn.AllowEnv, fn.AllowRead, fn.AllowWrite, fn.AllowUnauthenticated, fn.IsPublic, fn.DisableExecutionLogs,
@@ -755,7 +756,8 @@ func (s *Storage) LogExecution(ctx context.Context, exec *EdgeFunctionExecution)
 	`
 
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			exec.FunctionID, exec.TriggerType, exec.Status, exec.StatusCode,
 			exec.DurationMs, exec.Result, exec.Logs, exec.ErrorMessage, exec.CompletedAt,
 		).Scan(&exec.ID, &exec.ExecutedAt)
@@ -993,7 +995,8 @@ func (s *Storage) CreateSharedModule(ctx context.Context, module *SharedModule) 
 	`
 
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			module.ModulePath, module.Content, module.Description, module.CreatedBy,
 		).Scan(&module.ID, &module.Version, &module.CreatedAt, &module.UpdatedAt)
 	})

--- a/internal/jobs/storage.go
+++ b/internal/jobs/storage.go
@@ -48,7 +48,8 @@ func (s *Storage) CreateJobFunctionWithTenant(ctx context.Context, tenantID stri
 	`
 
 	return database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			fn.ID, fn.Name, fn.Namespace, fn.Description, fn.Code, fn.OriginalCode,
 			fn.IsBundled, fn.BundleError, fn.Enabled, fn.Schedule, fn.TimeoutSeconds,
 			fn.MemoryLimitMB, fn.MaxRetries, fn.ProgressTimeoutSeconds,
@@ -77,7 +78,8 @@ func (s *Storage) UpdateJobFunctionWithTenant(ctx context.Context, tenantID stri
 	`
 
 	return database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			fn.Description, fn.Code, fn.OriginalCode, fn.IsBundled, fn.BundleError,
 			fn.Enabled, fn.Schedule, fn.TimeoutSeconds, fn.MemoryLimitMB,
 			fn.MaxRetries, fn.ProgressTimeoutSeconds, fn.AllowNet, fn.AllowEnv,
@@ -98,7 +100,8 @@ func (s *Storage) UpdateJobFunctionForSync(ctx context.Context, tenantID string,
 	`
 
 	return database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			fn.Description, fn.Code, fn.OriginalCode, fn.IsBundled, fn.BundleError,
 			fn.Enabled, fn.Schedule, fn.TimeoutSeconds, fn.MemoryLimitMB,
 			fn.MaxRetries, fn.ProgressTimeoutSeconds, fn.AllowNet, fn.AllowEnv,
@@ -148,7 +151,8 @@ func (s *Storage) UpsertJobFunctionWithTenant(ctx context.Context, tenantID stri
 	`
 
 	return database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			fn.ID, fn.Name, fn.Namespace, fn.Description, fn.Code, fn.OriginalCode,
 			fn.IsBundled, fn.BundleError, fn.Enabled, fn.Schedule, fn.TimeoutSeconds,
 			fn.MemoryLimitMB, fn.MaxRetries, fn.ProgressTimeoutSeconds,
@@ -442,7 +446,8 @@ func (s *Storage) CreateJobFunctionFile(ctx context.Context, file *JobFunctionFi
 		RETURNING created_at
 	`
 
-	return s.DB.Pool().QueryRow(ctx, query,
+	return s.DB.Pool().QueryRow(
+		ctx, query,
 		file.ID, file.JobFunctionID, file.FilePath, file.Content,
 	).Scan(&file.CreatedAt)
 }
@@ -500,7 +505,8 @@ func (s *Storage) EnqueueJobWithTenant(ctx context.Context, tenantID string, job
 	`
 
 	return database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			job.ID, job.Namespace, job.JobFunctionID, job.JobName, job.Status, job.Payload,
 			job.Priority, job.MaxDurationSeconds, job.ProgressTimeoutSeconds,
 			job.MaxRetries, job.CreatedBy, job.UserRole, job.UserEmail, job.ScheduledAt,
@@ -804,7 +810,8 @@ func (s *Storage) ResubmitJob(ctx context.Context, originalJobID uuid.UUID) (*Jo
 	`
 
 	err = s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			newJob.ID, newJob.Namespace, newJob.JobFunctionID, newJob.JobName, newJob.Status,
 			newJob.Payload, newJob.Priority, newJob.MaxDurationSeconds, newJob.ProgressTimeoutSeconds,
 			newJob.MaxRetries, newJob.CreatedBy, newJob.UserRole, newJob.UserEmail,
@@ -1293,7 +1300,8 @@ func (s *Storage) RegisterWorker(ctx context.Context, worker *WorkerRecord) erro
 	`
 
 	return database.WrapWithServiceRole(ctx, s.DB, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			worker.ID, worker.Name, worker.Hostname, worker.Status,
 			worker.MaxConcurrentJobs, worker.Metadata,
 		).Scan(&worker.StartedAt, &worker.LastHeartbeatAt)

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -201,8 +201,17 @@ func (w *Worker) setDraining(draining bool) {
 // Stop stops the worker gracefully
 func (w *Worker) Stop() {
 	log.Info().Str("worker_id", w.ID.String()).Msg("Stopping worker")
-	close(w.shutdownChan)
-	<-w.shutdownComplete
+	select {
+	case <-w.shutdownChan:
+		// Already stopped
+	default:
+		close(w.shutdownChan)
+	}
+	select {
+	case <-w.shutdownComplete:
+	case <-time.After(10 * time.Second):
+		log.Warn().Str("worker_id", w.ID.String()).Msg("Worker did not shut down within timeout, proceeding")
+	}
 }
 
 // pollLoop continuously polls for and executes jobs

--- a/internal/mcp/custom/storage.go
+++ b/internal/mcp/custom/storage.go
@@ -98,7 +98,8 @@ func (s *Storage) CreateTool(ctx context.Context, req *CreateToolRequest, create
 
 	tool := &CustomTool{}
 	err = s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
+		return tx.QueryRow(
+			ctx, `
 			INSERT INTO mcp.custom_tools (
 				name, namespace, description, code, input_schema,
 				required_scopes, timeout_seconds, memory_limit_mb,
@@ -329,7 +330,8 @@ func (s *Storage) UpdateTool(ctx context.Context, id uuid.UUID, req *UpdateToolR
 
 	tool := &CustomTool{}
 	err = s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
+		return tx.QueryRow(
+			ctx, `
 			UPDATE mcp.custom_tools SET
 				name = $2,
 				description = $3,
@@ -481,7 +483,8 @@ func (s *Storage) CreateResource(ctx context.Context, req *CreateResourceRequest
 
 	resource := &CustomResource{}
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
+		return tx.QueryRow(
+			ctx, `
 			INSERT INTO mcp.custom_resources (
 				uri, name, namespace, description, mime_type,
 				code, is_template, required_scopes,
@@ -699,7 +702,8 @@ func (s *Storage) UpdateResource(ctx context.Context, id uuid.UUID, req *UpdateR
 
 	resource := &CustomResource{}
 	err = s.WithTenant(ctx, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, `
+		return tx.QueryRow(
+			ctx, `
 			UPDATE mcp.custom_resources SET
 				uri = $2,
 				name = $3,

--- a/internal/middleware/clientkey_auth.go
+++ b/internal/middleware/clientkey_auth.go
@@ -814,7 +814,8 @@ func lookupPlatformServiceKey(c fiber.Ctx, db *pgxpool.Pool, serviceKey string) 
 	var keyHash string
 
 	err := queryWithServiceRole(c.RequestCtx(), pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(c.RequestCtx(),
+		return tx.QueryRow(
+			c.RequestCtx(),
 			`SELECT id, name, key_hash, key_type, scopes, allowed_namespaces,
 			        is_active, expires_at, rate_limit_per_minute, tenant_id
 			 FROM platform.service_keys
@@ -852,7 +853,8 @@ func lookupAuthServiceKey(c fiber.Ctx, db *pgxpool.Pool, serviceKey string) (*se
 	var rateLimitPerHour *int
 
 	err := queryWithServiceRole(c.RequestCtx(), pool, func(tx pgx.Tx) error {
-		return tx.QueryRow(c.RequestCtx(),
+		return tx.QueryRow(
+			c.RequestCtx(),
 			`SELECT id, name, key_hash, COALESCE(key_type, 'service'), scopes, allowed_namespaces,
 			        enabled, expires_at, rate_limit_per_minute, rate_limit_per_hour,
 			        revoked_at, tenant_id
@@ -944,7 +946,8 @@ func updateLastUsedAt(c fiber.Ctx, db *pgxpool.Pool, info *serviceKeyInfo) {
 			return
 		}
 
-		_, _ = tx.Exec(ctx,
+		_, _ = tx.Exec(
+			ctx,
 			`UPDATE `+table+` SET last_used_at = NOW() WHERE id = $1`,
 			keyID,
 		)

--- a/internal/middleware/migrations_security.go
+++ b/internal/middleware/migrations_security.go
@@ -275,7 +275,8 @@ func migrationsGetTenantID(c fiber.Ctx, claims *auth.TokenClaims) string {
 
 func migrationsValidateTenantMembership(ctx context.Context, db *pgxpool.Pool, userID, tenantID string) bool {
 	var isMember bool
-	err := db.QueryRow(ctx,
+	err := db.QueryRow(
+		ctx,
 		`SELECT EXISTS(
 			SELECT 1 FROM platform.tenant_admin_assignments taa
 			INNER JOIN platform.tenants t ON t.id = taa.tenant_id
@@ -304,7 +305,8 @@ func migrationsValidateServiceKeyWithScope(c fiber.Ctx, db *pgxpool.Pool, servic
 	var expiresAt *time.Time
 	var keyType string
 
-	err := db.QueryRow(c.RequestCtx(),
+	err := db.QueryRow(
+		c.RequestCtx(),
 		`SELECT id, name, key_hash, COALESCE(key_type, 'service'), scopes, enabled, expires_at FROM auth.service_keys WHERE key_prefix = $1`,
 		keyPrefix,
 	).Scan(&keyID, &keyName, &keyHash, &keyType, &scopes, &enabled, &expiresAt)

--- a/internal/middleware/rls.go
+++ b/internal/middleware/rls.go
@@ -449,7 +449,8 @@ func LogRLSViolation(ctx context.Context, db *database.Connection, c fiber.Ctx, 
 		)
 	`
 
-	_, err = db.Exec(ctx, query,
+	_, err = db.Exec(
+		ctx, query,
 		userIDStr,   // user_id
 		role,        // role
 		operation,   // operation (INSERT, UPDATE, DELETE, SELECT)

--- a/internal/middleware/rls_integration_test.go
+++ b/internal/middleware/rls_integration_test.go
@@ -50,7 +50,8 @@ func setupRLSIntegrationTest(t *testing.T) *rlsTestEnv {
 	cfg := dbhelpers.GetTestConfig()
 
 	// Create admin pool for CREATE DATABASE and privileged operations.
-	adminDBURL := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=disable",
+	adminDBURL := fmt.Sprintf(
+		"postgresql://%s:%s@%s:%d/%s?sslmode=disable",
 		cfg.Database.AdminUser,
 		cfg.Database.AdminPassword,
 		cfg.Database.Host,

--- a/internal/middleware/tenant.go
+++ b/internal/middleware/tenant.go
@@ -62,7 +62,8 @@ func TenantMiddleware(cfg TenantConfig) fiber.Handler {
 				// For anonymous/unauthenticated requests, validate the tenant exists
 				if headerTenant != "" {
 					var exists bool
-					err := cfg.DB.Pool().QueryRow(c.Context(),
+					err := cfg.DB.Pool().QueryRow(
+						c.Context(),
 						`SELECT EXISTS(SELECT 1 FROM platform.tenants WHERE (id::text = $1 OR slug = $1) AND deleted_at IS NULL)`,
 						headerTenant,
 					).Scan(&exists)
@@ -112,7 +113,8 @@ func TenantMiddleware(cfg TenantConfig) fiber.Handler {
 		if tenantID != "" {
 			var slug string
 			var isDefault bool
-			err := cfg.DB.Pool().QueryRow(c.Context(),
+			err := cfg.DB.Pool().QueryRow(
+				c.Context(),
 				"SELECT slug, is_default FROM platform.tenants WHERE id = $1::uuid",
 				tenantID,
 			).Scan(&slug, &isDefault)
@@ -172,7 +174,8 @@ func TenantMiddleware(cfg TenantConfig) fiber.Handler {
 // ValidateTenantMembership checks if user is assigned to manage the specified tenant
 func ValidateTenantMembership(ctx context.Context, db *database.Connection, userID, tenantID string) (bool, error) {
 	var isMember bool
-	err := db.Pool().QueryRow(ctx,
+	err := db.Pool().QueryRow(
+		ctx,
 		`SELECT EXISTS(
 			SELECT 1 FROM platform.tenant_admin_assignments taa
 			INNER JOIN platform.tenants t ON t.id = taa.tenant_id
@@ -203,7 +206,8 @@ func GetUserTenantRole(ctx context.Context, db *database.Connection, userID, ten
 	}
 
 	var isAdmin bool
-	err := db.Pool().QueryRow(ctx,
+	err := db.Pool().QueryRow(
+		ctx,
 		`SELECT EXISTS(
 			SELECT 1 FROM platform.users
 			WHERE id = $1::uuid
@@ -221,7 +225,8 @@ func GetUserTenantRole(ctx context.Context, db *database.Connection, userID, ten
 	}
 
 	var isAssigned bool
-	err = db.Pool().QueryRow(ctx,
+	err = db.Pool().QueryRow(
+		ctx,
 		`SELECT EXISTS(
 			SELECT 1 FROM platform.tenant_admin_assignments taa
 			INNER JOIN platform.tenants t ON t.id = taa.tenant_id
@@ -244,7 +249,8 @@ func GetUserTenantRole(ctx context.Context, db *database.Connection, userID, ten
 // GetDefaultTenantID gets the default tenant ID
 func GetDefaultTenantID(ctx context.Context, db *database.Connection) (string, error) {
 	var id string
-	err := db.Pool().QueryRow(ctx,
+	err := db.Pool().QueryRow(
+		ctx,
 		`SELECT id::text FROM platform.tenants WHERE is_default = true AND deleted_at IS NULL LIMIT 1`,
 	).Scan(&id)
 	if err != nil {
@@ -260,7 +266,8 @@ func GetDefaultTenantID(ctx context.Context, db *database.Connection) (string, e
 // IsInstanceAdmin checks if the user is an instance-level admin
 func IsInstanceAdmin(ctx context.Context, db *database.Connection, userID string) (bool, error) {
 	var isAdmin bool
-	err := db.Pool().QueryRow(ctx,
+	err := db.Pool().QueryRow(
+		ctx,
 		`SELECT EXISTS(
 			SELECT 1 FROM platform.users
 			WHERE id = $1::uuid
@@ -349,7 +356,8 @@ func RequireInstanceAdmin() fiber.Handler {
 // Instance admins get all tenants, others get only their assigned tenants
 func GetUserTenantIDs(ctx context.Context, db *database.Connection, userID string) ([]string, error) {
 	var isAdmin bool
-	err := db.Pool().QueryRow(ctx,
+	err := db.Pool().QueryRow(
+		ctx,
 		`SELECT EXISTS(
 			SELECT 1 FROM platform.users
 			WHERE id = $1::uuid
@@ -364,7 +372,8 @@ func GetUserTenantIDs(ctx context.Context, db *database.Connection, userID strin
 	}
 
 	if isAdmin {
-		rows, err := db.Pool().Query(ctx,
+		rows, err := db.Pool().Query(
+			ctx,
 			`SELECT id::text FROM platform.tenants
 			WHERE deleted_at IS NULL
 			ORDER BY name`,
@@ -385,7 +394,8 @@ func GetUserTenantIDs(ctx context.Context, db *database.Connection, userID strin
 		return tenantIDs, nil
 	}
 
-	rows, err := db.Pool().Query(ctx,
+	rows, err := db.Pool().Query(
+		ctx,
 		`SELECT taa.tenant_id::text FROM platform.tenant_admin_assignments taa
 		INNER JOIN platform.tenants t ON t.id = taa.tenant_id
 		WHERE taa.user_id = $1::uuid

--- a/internal/middleware/tenant_db_integration_test.go
+++ b/internal/middleware/tenant_db_integration_test.go
@@ -55,7 +55,8 @@ func setupMiddlewareIntegration(t *testing.T) *middlewareTestEnv {
 
 	// Create an admin pool (same DB, admin user for CREATE DATABASE)
 	cfg := dbhelpers.GetTestConfig()
-	adminDBURL := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=disable",
+	adminDBURL := fmt.Sprintf(
+		"postgresql://%s:%s@%s:%d/%s?sslmode=disable",
 		cfg.Database.AdminUser,
 		cfg.Database.AdminPassword,
 		cfg.Database.Host,

--- a/internal/middleware/tracing.go
+++ b/internal/middleware/tracing.go
@@ -80,7 +80,8 @@ func TracingMiddleware(cfg TracingConfig) fiber.Handler {
 		spanName = fmt.Sprintf("%s %s", c.Method(), spanName)
 
 		// Start span
-		ctx, span := tracer.Start(ctx, spanName,
+		ctx, span := tracer.Start(
+			ctx, spanName,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
 				attribute.String("http.request.method", c.Method()),

--- a/internal/migrations/declarative.go
+++ b/internal/migrations/declarative.go
@@ -939,7 +939,8 @@ func (s *DeclarativeService) ensureMissingColumns(ctx context.Context, schema st
 
 		// Skip tables that don't exist yet (CREATE TABLE will handle them)
 		var tableExists bool
-		if err := pool.QueryRow(ctx,
+		if err := pool.QueryRow(
+			ctx,
 			"SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2)",
 			schema, tableName,
 		).Scan(&tableExists); err != nil || !tableExists {
@@ -953,7 +954,8 @@ func (s *DeclarativeService) ensureMissingColumns(ctx context.Context, schema st
 			}
 
 			var colExists bool
-			if err := pool.QueryRow(ctx,
+			if err := pool.QueryRow(
+				ctx,
 				"SELECT EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3)",
 				schema, tableName, col.Colname,
 			).Scan(&colExists); err != nil || colExists {
@@ -984,7 +986,8 @@ func (s *DeclarativeService) ensureMissingColumns(ctx context.Context, schema st
 // within the given schema. Columns added to the parent propagate automatically.
 func (s *DeclarativeService) listPartitionTables(ctx context.Context, schema string, pool *pgxpool.Pool) map[string]bool {
 	partitions := make(map[string]bool)
-	rows, err := pool.Query(ctx,
+	rows, err := pool.Query(
+		ctx,
 		`SELECT c.relname FROM pg_class c
 		 JOIN pg_namespace n ON n.oid = c.relnamespace
 		 WHERE n.nspname = $1 AND c.relispartition`,
@@ -1033,7 +1036,8 @@ func extractAlterTableName(sql string) string {
 // (relkind = 'p') within the given schema.
 func (s *DeclarativeService) listPartitionedTables(ctx context.Context, schema string, pool *pgxpool.Pool) map[string]bool {
 	tables := make(map[string]bool)
-	rows, err := pool.Query(ctx,
+	rows, err := pool.Query(
+		ctx,
 		`SELECT c.relname FROM pg_class c
 		 JOIN pg_namespace n ON n.oid = c.relnamespace
 		 WHERE n.nspname = $1 AND c.relkind = 'p'`,

--- a/internal/migrations/storage.go
+++ b/internal/migrations/storage.go
@@ -62,7 +62,8 @@ func (s *Storage) CreateMigration(ctx context.Context, m *Migration) error {
 	`
 
 	err := database.WrapWithServiceRole(ctx, s.db, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			m.Namespace, m.Name, m.Description, m.UpSQL, m.DownSQL, m.CreatedBy,
 		).Scan(&m.ID, &m.Version, &m.Status, &m.CreatedAt, &m.UpdatedAt)
 	})
@@ -255,7 +256,8 @@ func (s *Storage) LogExecution(ctx context.Context, log *ExecutionLog) error {
 	`
 
 	err := database.WrapWithServiceRole(ctx, s.db, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			log.MigrationID, log.Action, log.Status, log.DurationMs,
 			log.ErrorMessage, log.Logs, log.ExecutedBy,
 		).Scan(&log.ID, &log.ExecutedAt)

--- a/internal/observability/tracer.go
+++ b/internal/observability/tracer.go
@@ -203,7 +203,8 @@ func AddSpanEvent(ctx context.Context, name string, attrs ...attribute.KeyValue)
 // StartDBSpan starts a span for a database operation
 func StartDBSpan(ctx context.Context, operation, table string) (context.Context, trace.Span) {
 	tracer := otel.Tracer("fluxbase-db")
-	return tracer.Start(ctx, fmt.Sprintf("db.%s", operation),
+	return tracer.Start(
+		ctx, fmt.Sprintf("db.%s", operation),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			semconv.DBSystemPostgreSQL,
@@ -227,7 +228,8 @@ func EndDBSpan(span trace.Span, err error) {
 // StartStorageSpan starts a span for a storage operation
 func StartStorageSpan(ctx context.Context, operation, bucket, key string) (context.Context, trace.Span) {
 	tracer := otel.Tracer("fluxbase-storage")
-	return tracer.Start(ctx, fmt.Sprintf("storage.%s", operation),
+	return tracer.Start(
+		ctx, fmt.Sprintf("storage.%s", operation),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("storage.operation", operation),
@@ -242,7 +244,8 @@ func StartStorageSpan(ctx context.Context, operation, bucket, key string) (conte
 // StartAuthSpan starts a span for an authentication operation
 func StartAuthSpan(ctx context.Context, operation string) (context.Context, trace.Span) {
 	tracer := otel.Tracer("fluxbase-auth")
-	return tracer.Start(ctx, fmt.Sprintf("auth.%s", operation),
+	return tracer.Start(
+		ctx, fmt.Sprintf("auth.%s", operation),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("auth.operation", operation),
@@ -303,7 +306,8 @@ func StartFunctionSpan(ctx context.Context, cfg FunctionSpanConfig) (context.Con
 		attrs = append(attrs, attribute.String("user.id", cfg.UserID))
 	}
 
-	return tracer.Start(ctx, spanName,
+	return tracer.Start(
+		ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(attrs...),
 	)
@@ -377,7 +381,8 @@ func StartJobSpan(ctx context.Context, cfg JobSpanConfig) (context.Context, trac
 		attrs = append(attrs, attribute.String("user.id", cfg.UserID))
 	}
 
-	return tracer.Start(ctx, spanName,
+	return tracer.Start(
+		ctx, spanName,
 		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(attrs...),
 	)
@@ -438,7 +443,8 @@ func GetTraceContextEnv(ctx context.Context) map[string]string {
 
 	// W3C Trace Context format
 	if sc.HasTraceID() {
-		env["TRACEPARENT"] = fmt.Sprintf("00-%s-%s-%s",
+		env["TRACEPARENT"] = fmt.Sprintf(
+			"00-%s-%s-%s",
 			sc.TraceID().String(),
 			sc.SpanID().String(),
 			sc.TraceFlags().String(),

--- a/internal/observability/tracer_test.go
+++ b/internal/observability/tracer_test.go
@@ -213,7 +213,8 @@ func TestSetSpanAttributes(t *testing.T) {
 		ctx := context.Background()
 
 		assert.NotPanics(t, func() {
-			SetSpanAttributes(ctx,
+			SetSpanAttributes(
+				ctx,
 				attribute.String("key", "value"),
 				attribute.Int("count", 42),
 			)
@@ -234,7 +235,8 @@ func TestSetSpanAttributes(t *testing.T) {
 		defer span.End()
 
 		assert.NotPanics(t, func() {
-			SetSpanAttributes(ctx,
+			SetSpanAttributes(
+				ctx,
 				attribute.String("service.name", "test-service"),
 				attribute.Bool("feature.enabled", true),
 			)
@@ -265,7 +267,8 @@ func TestAddSpanEvent(t *testing.T) {
 		defer span.End()
 
 		assert.NotPanics(t, func() {
-			AddSpanEvent(ctx, "cache.hit",
+			AddSpanEvent(
+				ctx, "cache.hit",
 				attribute.String("cache.key", "user:123"),
 				attribute.Int("cache.ttl", 3600),
 			)
@@ -530,7 +533,8 @@ func BenchmarkSetSpanAttributes(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		SetSpanAttributes(ctx,
+		SetSpanAttributes(
+			ctx,
 			attribute.String("key", "value"),
 			attribute.Int("count", i),
 		)
@@ -544,7 +548,8 @@ func BenchmarkAddSpanEvent(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		AddSpanEvent(ctx, "test.event",
+		AddSpanEvent(
+			ctx, "test.event",
 			attribute.Int("iteration", i),
 		)
 	}
@@ -722,7 +727,8 @@ func TestAddFunctionEvent(t *testing.T) {
 		defer span.End()
 
 		assert.NotPanics(t, func() {
-			AddFunctionEvent(ctx, "function.timeout",
+			AddFunctionEvent(
+				ctx, "function.timeout",
 				attribute.Int("timeout_ms", 30000),
 			)
 		})
@@ -882,7 +888,8 @@ func TestAddJobEvent(t *testing.T) {
 		defer span.End()
 
 		assert.NotPanics(t, func() {
-			AddJobEvent(ctx, "job.checkpoint",
+			AddJobEvent(
+				ctx, "job.checkpoint",
 				attribute.String("checkpoint", "data-loaded"),
 			)
 		})

--- a/internal/realtime/connection.go
+++ b/internal/realtime/connection.go
@@ -37,6 +37,7 @@ type Connection struct {
 	UserID          *string                // Authenticated user ID (nil if anonymous)
 	Role            string                 // User role (e.g., "authenticated", "anon", "instance_admin")
 	Claims          map[string]interface{} // Full JWT claims for RLS (includes custom claims like meeting_id, player_id)
+	TenantID        string                 // Tenant ID for multi-tenancy (empty = default tenant)
 	ConnectedAt     time.Time              // Connection timestamp
 	mu              sync.RWMutex
 	slowClientCount atomic.Int32 // Count of slow client warnings
@@ -59,16 +60,16 @@ type Connection struct {
 
 // NewConnection creates a new WebSocket connection with async message queue.
 // If parentCtx is nil, context.Background() is used.
-func NewConnection(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, parentCtx context.Context) *Connection {
+func NewConnection(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, tenantID string, parentCtx context.Context) *Connection {
 	if parentCtx == nil {
 		parentCtx = context.Background()
 	}
-	return NewConnectionWithQueueSize(id, conn, userID, role, claims, DefaultMessageQueueSize, parentCtx)
+	return NewConnectionWithQueueSize(id, conn, userID, role, claims, tenantID, DefaultMessageQueueSize, parentCtx)
 }
 
 // NewConnectionWithQueueSize creates a new WebSocket connection with custom queue size.
 // If parentCtx is nil, context.Background() is used.
-func NewConnectionWithQueueSize(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, queueSize int, parentCtx context.Context) *Connection {
+func NewConnectionWithQueueSize(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, tenantID string, queueSize int, parentCtx context.Context) *Connection {
 	if queueSize <= 0 {
 		queueSize = DefaultMessageQueueSize
 	}
@@ -85,6 +86,7 @@ func NewConnectionWithQueueSize(id string, conn *websocket.Conn, userID *string,
 		UserID:        userID,
 		Role:          role,
 		Claims:        claims,
+		TenantID:      tenantID,
 		ConnectedAt:   time.Now(),
 		sendCh:        make(chan interface{}, queueSize),
 		ctx:           ctx,

--- a/internal/realtime/connection_test.go
+++ b/internal/realtime/connection_test.go
@@ -49,7 +49,7 @@ func TestNewConnection(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
 	userID := "user123"
 
-	connection := NewConnection("conn1", conn, &userID, "authenticated", nil, nil)
+	connection := NewConnection("conn1", conn, &userID, "authenticated", nil, "", nil)
 
 	assert.NotNil(t, connection)
 	assert.Equal(t, "conn1", connection.ID)
@@ -61,7 +61,7 @@ func TestNewConnection(t *testing.T) {
 
 func TestConnection_Subscribe(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe to a channel
 	connection.Subscribe("table:public.products")
@@ -72,7 +72,7 @@ func TestConnection_Subscribe(t *testing.T) {
 
 func TestConnection_SubscribeMultiple(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe to multiple channels
 	connection.Subscribe("table:public.products")
@@ -87,7 +87,7 @@ func TestConnection_SubscribeMultiple(t *testing.T) {
 
 func TestConnection_SubscribeDuplicate(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe to same channel twice
 	connection.Subscribe("table:public.products")
@@ -99,7 +99,7 @@ func TestConnection_SubscribeDuplicate(t *testing.T) {
 
 func TestConnection_Unsubscribe(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe then unsubscribe
 	connection.Subscribe("table:public.products")
@@ -112,7 +112,7 @@ func TestConnection_Unsubscribe(t *testing.T) {
 
 func TestConnection_UnsubscribeNonExistent(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Unsubscribe from channel we never subscribed to
 	connection.Unsubscribe("table:public.products")
@@ -123,7 +123,7 @@ func TestConnection_UnsubscribeNonExistent(t *testing.T) {
 
 func TestConnection_IsSubscribed(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Initially not subscribed
 	assert.False(t, connection.IsSubscribed("table:public.products"))
@@ -139,7 +139,7 @@ func TestConnection_IsSubscribed(t *testing.T) {
 
 func TestConnection_ConcurrentSubscribe(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	var wg sync.WaitGroup
 	numGoroutines := 100
@@ -162,7 +162,7 @@ func TestConnection_ConcurrentSubscribe(t *testing.T) {
 
 func TestConnection_ConcurrentUnsubscribe(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Subscribe to multiple channels first
 	numChannels := 100
@@ -193,7 +193,7 @@ func TestConnection_ConcurrentUnsubscribe(t *testing.T) {
 
 func TestConnection_ConcurrentIsSubscribed(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	connection.Subscribe("table:public.products")
 
@@ -218,7 +218,7 @@ func TestConnection_ConcurrentIsSubscribed(t *testing.T) {
 
 func TestConnection_MixedConcurrentOperations(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 	defer func() { _ = connection.Close() }()
 
 	var wg sync.WaitGroup
@@ -264,7 +264,7 @@ func TestConnection_MixedConcurrentOperations(t *testing.T) {
 
 func TestNewConnectionWithQueueSize(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, 128, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", 128, nil)
 	defer func() { _ = connection.Close() }()
 
 	assert.NotNil(t, connection)
@@ -273,7 +273,7 @@ func TestNewConnectionWithQueueSize(t *testing.T) {
 
 func TestNewConnectionWithQueueSize_DefaultOnZero(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, 0, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", 0, nil)
 	defer func() { _ = connection.Close() }()
 
 	assert.Equal(t, DefaultMessageQueueSize, cap(connection.sendCh))
@@ -281,7 +281,7 @@ func TestNewConnectionWithQueueSize_DefaultOnZero(t *testing.T) {
 
 func TestNewConnectionWithQueueSize_DefaultOnNegative(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, -10, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", -10, nil)
 	defer func() { _ = connection.Close() }()
 
 	assert.Equal(t, DefaultMessageQueueSize, cap(connection.sendCh))
@@ -298,7 +298,7 @@ func TestNewConnectionSync(t *testing.T) {
 
 func TestConnection_SendMessage_ToClosedConnection(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 
 	// Close the connection first
 	_ = connection.Close()
@@ -310,7 +310,7 @@ func TestConnection_SendMessage_ToClosedConnection(t *testing.T) {
 
 func TestConnection_GetQueueStats(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, 100, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", 100, nil)
 	defer func() { _ = connection.Close() }()
 
 	stats := connection.GetQueueStats()
@@ -324,7 +324,7 @@ func TestConnection_GetQueueStats(t *testing.T) {
 }
 
 func TestConnection_Close_MultipleTimes(t *testing.T) {
-	connection := NewConnection("conn1", nil, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", nil, nil, "anon", nil, "", nil)
 
 	// First close should succeed
 	err := connection.Close()
@@ -337,7 +337,7 @@ func TestConnection_Close_MultipleTimes(t *testing.T) {
 
 func TestConnection_IsSlowClient_Initial(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 	defer func() { _ = connection.Close() }()
 
 	assert.False(t, connection.IsSlowClient())
@@ -345,7 +345,7 @@ func TestConnection_IsSlowClient_Initial(t *testing.T) {
 
 func TestConnection_IsSlowClient_AfterWarnings(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 	defer func() { _ = connection.Close() }()
 
 	// Manually increment slow client count
@@ -376,7 +376,7 @@ func TestConnectionQueueStats_Struct(t *testing.T) {
 
 func TestConnection_SendMessage_WithSlowClientMarked(t *testing.T) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnection("conn1", conn, nil, "anon", nil, nil)
+	connection := NewConnection("conn1", conn, nil, "anon", nil, "", nil)
 	defer func() { _ = connection.Close() }()
 
 	// Mark as slow client
@@ -415,7 +415,7 @@ func BenchmarkConnection_IsSubscribed(b *testing.B) {
 
 func BenchmarkConnection_GetQueueStats(b *testing.B) {
 	var conn *websocket.Conn // nil connection for testing
-	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, 256, nil)
+	connection := NewConnectionWithQueueSize("conn1", conn, nil, "anon", nil, "", 256, nil)
 	defer func() { _ = connection.Close() }()
 
 	b.ResetTimer()

--- a/internal/realtime/handler.go
+++ b/internal/realtime/handler.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+
+	"github.com/nimbleflux/fluxbase/internal/database"
 )
 
 // MessageType represents the type of WebSocket message
@@ -208,8 +210,15 @@ func (h *RealtimeHandler) handleConnection(c *websocket.Conn) {
 		}
 	}
 
+	var tenantID string
+	if tid := c.Locals("tenant_id"); tid != nil {
+		if id, ok := tid.(string); ok {
+			tenantID = id
+		}
+	}
+
 	// Add connection to manager (checks connection limit)
-	connection, err := h.manager.AddConnection(connectionID, c, userID, role, claims)
+	connection, err := h.manager.AddConnection(connectionID, c, userID, role, claims, tenantID)
 	if err != nil {
 		// Connection limit reached - send error and close
 		_ = c.WriteJSON(ServerMessage{
@@ -915,8 +924,12 @@ func (h *RealtimeHandler) handleSubscribeLogs(conn *Connection, msg ClientMessag
 			return
 		}
 
+		ownCtx := context.Background()
+		if conn.TenantID != "" {
+			ownCtx = database.ContextWithTenant(ownCtx, conn.TenantID)
+		}
 		isOwner, exists, err := h.subManager.CheckExecutionOwnership(
-			context.Background(), executionID, *conn.UserID, executionType,
+			ownCtx, executionID, *conn.UserID, executionType,
 		)
 		if err != nil {
 			log.Error().Err(err).Str("execution_id", executionID).Msg("Failed to check execution ownership")

--- a/internal/realtime/manager.go
+++ b/internal/realtime/manager.go
@@ -241,7 +241,7 @@ func (m *Manager) BroadcastGlobal(channel string, message ServerMessage) error {
 // Returns nil and ErrMaxConnectionsReached if the connection limit is exceeded
 // Returns nil and ErrMaxUserConnectionsReached if the per-user limit is exceeded
 // Returns nil and ErrMaxIPConnectionsReached if the per-IP limit is exceeded (for anonymous)
-func (m *Manager) AddConnection(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}) (*Connection, error) {
+func (m *Manager) AddConnection(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, tenantID string) (*Connection, error) {
 	// Get remote IP for tracking
 	remoteIP := ""
 	if conn != nil {
@@ -252,12 +252,12 @@ func (m *Manager) AddConnection(id string, conn *websocket.Conn, userID *string,
 		}
 	}
 
-	return m.AddConnectionWithIP(id, conn, userID, role, claims, remoteIP)
+	return m.AddConnectionWithIP(id, conn, userID, role, claims, tenantID, remoteIP)
 }
 
 // AddConnectionWithIP adds a new WebSocket connection with explicit IP address
 // This is useful when the IP is already known (e.g., from X-Forwarded-For header)
-func (m *Manager) AddConnectionWithIP(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, remoteIP string) (*Connection, error) {
+func (m *Manager) AddConnectionWithIP(id string, conn *websocket.Conn, userID *string, role string, claims map[string]interface{}, tenantID string, remoteIP string) (*Connection, error) {
 	m.mu.Lock()
 
 	// Check global connection limit before adding
@@ -313,9 +313,9 @@ func (m *Manager) AddConnectionWithIP(id string, conn *websocket.Conn, userID *s
 	// Create and track the connection with configured queue size
 	var connection *Connection
 	if m.clientMessageQueueSize > 0 {
-		connection = NewConnectionWithQueueSize(id, conn, userID, role, claims, m.clientMessageQueueSize, m.ctx)
+		connection = NewConnectionWithQueueSize(id, conn, userID, role, claims, tenantID, m.clientMessageQueueSize, m.ctx)
 	} else {
-		connection = NewConnection(id, conn, userID, role, claims, m.ctx)
+		connection = NewConnection(id, conn, userID, role, claims, tenantID, m.ctx)
 	}
 	m.connections[id] = connection
 

--- a/internal/realtime/manager_test.go
+++ b/internal/realtime/manager_test.go
@@ -78,7 +78,7 @@ func TestManager_AddConnection(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(ctx)
 
-	connection, err := manager.AddConnection("conn1", nil, nil, "anon", nil)
+	connection, err := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, connection)
@@ -90,9 +90,9 @@ func TestManager_AddMultipleConnections(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(ctx)
 
-	manager.AddConnection("conn1", nil, nil, "anon", nil)
-	manager.AddConnection("conn2", nil, nil, "anon", nil)
-	manager.AddConnection("conn3", nil, nil, "anon", nil)
+	manager.AddConnection("conn1", nil, nil, "anon", nil, "")
+	manager.AddConnection("conn2", nil, nil, "anon", nil, "")
+	manager.AddConnection("conn3", nil, nil, "anon", nil, "")
 
 	assert.Equal(t, 3, manager.GetConnectionCount())
 }
@@ -102,7 +102,7 @@ func TestManager_AddConnectionWithUserID(t *testing.T) {
 	manager := NewManager(ctx)
 	userID := "user123"
 
-	connection, err := manager.AddConnection("conn1", nil, &userID, "authenticated", nil)
+	connection, err := manager.AddConnection("conn1", nil, &userID, "authenticated", nil, "")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, connection.UserID)
@@ -113,7 +113,7 @@ func TestManager_RemoveConnection(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(ctx)
 
-	manager.AddConnection("conn1", nil, nil, "anon", nil)
+	manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 	assert.Equal(t, 1, manager.GetConnectionCount())
 
 	manager.RemoveConnection("conn1")
@@ -135,10 +135,10 @@ func TestManager_GetConnectionCount(t *testing.T) {
 
 	assert.Equal(t, 0, manager.GetConnectionCount())
 
-	manager.AddConnection("conn1", nil, nil, "anon", nil)
+	manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 	assert.Equal(t, 1, manager.GetConnectionCount())
 
-	manager.AddConnection("conn2", nil, nil, "anon", nil)
+	manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 	assert.Equal(t, 2, manager.GetConnectionCount())
 
 	manager.RemoveConnection("conn1")
@@ -159,7 +159,7 @@ func TestManager_ConcurrentAddConnection(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			manager.AddConnection("conn"+string(rune(n)), nil, nil, "anon", nil)
+			manager.AddConnection("conn"+string(rune(n)), nil, nil, "anon", nil, "")
 		}(i)
 	}
 
@@ -175,7 +175,7 @@ func TestManager_ConcurrentRemoveConnection(t *testing.T) {
 	// Add connections first
 	numConnections := 100
 	for i := 0; i < numConnections; i++ {
-		manager.AddConnection("conn"+string(rune(i)), nil, nil, "anon", nil)
+		manager.AddConnection("conn"+string(rune(i)), nil, nil, "anon", nil, "")
 	}
 
 	assert.Equal(t, numConnections, manager.GetConnectionCount())
@@ -199,8 +199,8 @@ func TestManager_Shutdown(t *testing.T) {
 	ctx := context.Background()
 	manager := NewManager(ctx)
 
-	manager.AddConnection("conn1", nil, nil, "anon", nil)
-	manager.AddConnection("conn2", nil, nil, "anon", nil)
+	manager.AddConnection("conn1", nil, nil, "anon", nil, "")
+	manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 
 	manager.Shutdown()
 
@@ -224,7 +224,7 @@ func TestManager_MixedConcurrentOperations(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			manager.AddConnection("conn"+string(rune(n%20)), nil, nil, "anon", nil)
+			manager.AddConnection("conn"+string(rune(n%20)), nil, nil, "anon", nil, "")
 		}(i)
 
 		// Remove connection
@@ -252,16 +252,16 @@ func TestManager_PerUserConnectionLimit(t *testing.T) {
 	userID := "user123"
 
 	// First two connections should succeed
-	conn1, err := manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "192.168.1.1")
+	conn1, err := manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.NoError(t, err)
 	assert.NotNil(t, conn1)
 
-	conn2, err := manager.AddConnectionWithIP("conn2", nil, &userID, "authenticated", nil, "192.168.1.1")
+	conn2, err := manager.AddConnectionWithIP("conn2", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.NoError(t, err)
 	assert.NotNil(t, conn2)
 
 	// Third connection should fail
-	conn3, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "192.168.1.1")
+	conn3, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.Error(t, err)
 	assert.Equal(t, ErrMaxUserConnectionsReached, err)
 	assert.Nil(t, conn3)
@@ -281,18 +281,18 @@ func TestManager_PerUserConnectionLimit_DifferentUsers(t *testing.T) {
 	user2 := "user2"
 
 	// User1 can have 2 connections
-	manager.AddConnectionWithIP("conn1", nil, &user1, "authenticated", nil, "192.168.1.1")
-	manager.AddConnectionWithIP("conn2", nil, &user1, "authenticated", nil, "192.168.1.1")
+	manager.AddConnectionWithIP("conn1", nil, &user1, "authenticated", nil, "", "192.168.1.1")
+	manager.AddConnectionWithIP("conn2", nil, &user1, "authenticated", nil, "", "192.168.1.1")
 
 	// User2 can also have 2 connections
-	manager.AddConnectionWithIP("conn3", nil, &user2, "authenticated", nil, "192.168.1.2")
-	manager.AddConnectionWithIP("conn4", nil, &user2, "authenticated", nil, "192.168.1.2")
+	manager.AddConnectionWithIP("conn3", nil, &user2, "authenticated", nil, "", "192.168.1.2")
+	manager.AddConnectionWithIP("conn4", nil, &user2, "authenticated", nil, "", "192.168.1.2")
 
 	// Both users should be at their limits
-	_, err1 := manager.AddConnectionWithIP("conn5", nil, &user1, "authenticated", nil, "192.168.1.1")
+	_, err1 := manager.AddConnectionWithIP("conn5", nil, &user1, "authenticated", nil, "", "192.168.1.1")
 	assert.Equal(t, ErrMaxUserConnectionsReached, err1)
 
-	_, err2 := manager.AddConnectionWithIP("conn6", nil, &user2, "authenticated", nil, "192.168.1.2")
+	_, err2 := manager.AddConnectionWithIP("conn6", nil, &user2, "authenticated", nil, "", "192.168.1.2")
 	assert.Equal(t, ErrMaxUserConnectionsReached, err2)
 
 	assert.Equal(t, 4, manager.GetConnectionCount())
@@ -307,20 +307,20 @@ func TestManager_PerIPConnectionLimit(t *testing.T) {
 	ip := "192.168.1.100"
 
 	// First three anonymous connections from same IP should succeed
-	conn1, err := manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, ip)
+	conn1, err := manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, "", ip)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn1)
 
-	conn2, err := manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, ip)
+	conn2, err := manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, "", ip)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn2)
 
-	conn3, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, ip)
+	conn3, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, "", ip)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn3)
 
 	// Fourth connection should fail
-	conn4, err := manager.AddConnectionWithIP("conn4", nil, nil, "anon", nil, ip)
+	conn4, err := manager.AddConnectionWithIP("conn4", nil, nil, "anon", nil, "", ip)
 	assert.Error(t, err)
 	assert.Equal(t, ErrMaxIPConnectionsReached, err)
 	assert.Nil(t, conn4)
@@ -340,12 +340,12 @@ func TestManager_PerIPConnectionLimit_DifferentIPs(t *testing.T) {
 	ip2 := "192.168.1.2"
 
 	// IP1 can have 2 connections
-	manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, ip1)
-	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, ip1)
+	manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, "", ip1)
+	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, "", ip1)
 
 	// IP2 can also have 2 connections
-	manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, ip2)
-	manager.AddConnectionWithIP("conn4", nil, nil, "anon", nil, ip2)
+	manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, "", ip2)
+	manager.AddConnectionWithIP("conn4", nil, nil, "anon", nil, "", ip2)
 
 	assert.Equal(t, 4, manager.GetConnectionCount())
 	assert.Equal(t, 2, manager.GetIPConnectionCount(ip1))
@@ -364,7 +364,7 @@ func TestManager_PerIPLimitNotAppliedToAuthenticatedUsers(t *testing.T) {
 
 	// Authenticated users should not be limited by IP
 	for i := 0; i < 5; i++ {
-		conn, err := manager.AddConnectionWithIP("conn"+string(rune('a'+i)), nil, &userID, "authenticated", nil, ip)
+		conn, err := manager.AddConnectionWithIP("conn"+string(rune('a'+i)), nil, &userID, "authenticated", nil, "", ip)
 		assert.NoError(t, err)
 		assert.NotNil(t, conn)
 	}
@@ -384,18 +384,18 @@ func TestManager_RemoveConnection_DecrementsUserCount(t *testing.T) {
 	userID := "user123"
 
 	// Add two connections
-	manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "192.168.1.1")
-	manager.AddConnectionWithIP("conn2", nil, &userID, "authenticated", nil, "192.168.1.1")
+	manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "", "192.168.1.1")
+	manager.AddConnectionWithIP("conn2", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 
 	// Verify at limit
-	_, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "192.168.1.1")
+	_, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.Equal(t, ErrMaxUserConnectionsReached, err)
 
 	// Remove one connection
 	manager.RemoveConnection("conn1")
 
 	// Should be able to add a new connection
-	conn3, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "192.168.1.1")
+	conn3, err := manager.AddConnectionWithIP("conn3", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.NoError(t, err)
 	assert.NotNil(t, conn3)
 }
@@ -409,18 +409,18 @@ func TestManager_RemoveConnection_DecrementsIPCount(t *testing.T) {
 	ip := "192.168.1.100"
 
 	// Add two connections
-	manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, ip)
-	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, ip)
+	manager.AddConnectionWithIP("conn1", nil, nil, "anon", nil, "", ip)
+	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, "", ip)
 
 	// Verify at limit
-	_, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, ip)
+	_, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, "", ip)
 	assert.Equal(t, ErrMaxIPConnectionsReached, err)
 
 	// Remove one connection
 	manager.RemoveConnection("conn1")
 
 	// Should be able to add a new connection
-	conn3, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, ip)
+	conn3, err := manager.AddConnectionWithIP("conn3", nil, nil, "anon", nil, "", ip)
 	assert.NoError(t, err)
 	assert.NotNil(t, conn3)
 }
@@ -436,8 +436,8 @@ func TestManager_Shutdown_ClearsTrackingMaps(t *testing.T) {
 	ip := "192.168.1.1"
 
 	// Add some connections
-	manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, ip)
-	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, ip)
+	manager.AddConnectionWithIP("conn1", nil, &userID, "authenticated", nil, "", ip)
+	manager.AddConnectionWithIP("conn2", nil, nil, "anon", nil, "", ip)
 
 	// Shutdown
 	manager.Shutdown()
@@ -460,14 +460,14 @@ func TestManager_SetConnectionLimits(t *testing.T) {
 
 	// Add 5 connections
 	for i := 0; i < 5; i++ {
-		manager.AddConnectionWithIP("conn"+string(rune('a'+i)), nil, &userID, "authenticated", nil, "192.168.1.1")
+		manager.AddConnectionWithIP("conn"+string(rune('a'+i)), nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	}
 
 	// Reduce limit - existing connections remain but no new ones allowed
 	manager.SetConnectionLimits(3, 3)
 
 	// New connection should fail
-	_, err := manager.AddConnectionWithIP("conn_new", nil, &userID, "authenticated", nil, "192.168.1.1")
+	_, err := manager.AddConnectionWithIP("conn_new", nil, &userID, "authenticated", nil, "", "192.168.1.1")
 	assert.Equal(t, ErrMaxUserConnectionsReached, err)
 }
 
@@ -483,12 +483,12 @@ func TestManager_GlobalLimitTakesPrecedence(t *testing.T) {
 	user2 := "user2"
 
 	// Add 3 connections (global limit)
-	manager.AddConnectionWithIP("conn1", nil, &user1, "authenticated", nil, "192.168.1.1")
-	manager.AddConnectionWithIP("conn2", nil, &user1, "authenticated", nil, "192.168.1.1")
-	manager.AddConnectionWithIP("conn3", nil, &user2, "authenticated", nil, "192.168.1.2")
+	manager.AddConnectionWithIP("conn1", nil, &user1, "authenticated", nil, "", "192.168.1.1")
+	manager.AddConnectionWithIP("conn2", nil, &user1, "authenticated", nil, "", "192.168.1.1")
+	manager.AddConnectionWithIP("conn3", nil, &user2, "authenticated", nil, "", "192.168.1.2")
 
 	// Fourth connection should fail due to global limit
-	_, err := manager.AddConnectionWithIP("conn4", nil, &user2, "authenticated", nil, "192.168.1.2")
+	_, err := manager.AddConnectionWithIP("conn4", nil, &user2, "authenticated", nil, "", "192.168.1.2")
 	assert.Equal(t, ErrMaxConnectionsReached, err)
 }
 
@@ -591,7 +591,7 @@ func TestManager_BroadcastGlobal(t *testing.T) {
 		manager := NewManager(ctx)
 
 		// Add a connection with subscription
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 		conn.Subscribe("test-channel")
 
 		// Broadcast should work without pubsub
@@ -677,7 +677,7 @@ func TestManager_handleGlobalMessage(t *testing.T) {
 		manager := NewManager(ctx)
 
 		// Add connection with subscription
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 		conn.Subscribe("test-channel")
 
 		// Simulate a global broadcast message
@@ -707,7 +707,7 @@ func TestManager_handleGlobalMessage(t *testing.T) {
 		manager := NewManager(ctx)
 
 		// Add connection WITHOUT subscription
-		_, _ = manager.AddConnection("conn1", nil, nil, "anon", nil)
+		_, _ = manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		// Simulate a global broadcast message
 		broadcast := GlobalBroadcast{
@@ -776,8 +776,8 @@ func TestManager_updateMetrics(t *testing.T) {
 	t.Run("counts active connections", func(t *testing.T) {
 		manager := NewManager(context.Background())
 
-		manager.AddConnection("conn1", nil, nil, "anon", nil)
-		manager.AddConnection("conn2", nil, nil, "anon", nil)
+		manager.AddConnection("conn1", nil, nil, "anon", nil, "")
+		manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 
 		// Should not panic
 		manager.updateMetrics()
@@ -786,11 +786,11 @@ func TestManager_updateMetrics(t *testing.T) {
 	t.Run("counts unique channels", func(t *testing.T) {
 		manager := NewManager(context.Background())
 
-		conn1, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn1, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 		conn1.Subscribe("channel1")
 		conn1.Subscribe("channel2")
 
-		conn2, _ := manager.AddConnection("conn2", nil, nil, "anon", nil)
+		conn2, _ := manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 		conn2.Subscribe("channel1") // Same channel
 		conn2.Subscribe("channel3") // Different channel
 
@@ -817,7 +817,7 @@ func TestManager_GetDetailedStats(t *testing.T) {
 		manager := NewManager(context.Background())
 
 		userID := "user123"
-		manager.AddConnection("conn1", nil, &userID, "authenticated", nil)
+		manager.AddConnection("conn1", nil, &userID, "authenticated", nil, "")
 
 		stats := manager.GetDetailedStats()
 
@@ -835,7 +835,7 @@ func TestManager_GetDetailedStats(t *testing.T) {
 	t.Run("includes connected timestamp", func(t *testing.T) {
 		manager := NewManager(context.Background())
 
-		manager.AddConnection("conn1", nil, nil, "anon", nil)
+		manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		stats := manager.GetDetailedStats()
 		connections := stats["connections"].([]ConnectionInfo)
@@ -858,8 +858,8 @@ func TestManager_GetConnectionsForStats(t *testing.T) {
 		manager := NewManager(context.Background())
 
 		userID := "user123"
-		manager.AddConnection("conn1", nil, &userID, "authenticated", nil)
-		manager.AddConnection("conn2", nil, nil, "anon", nil)
+		manager.AddConnection("conn1", nil, &userID, "authenticated", nil, "")
+		manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 
 		connections := manager.GetConnectionsForStats()
 
@@ -889,7 +889,7 @@ func TestManager_BroadcastConnectionEvent(t *testing.T) {
 
 		manager.SetPubSub(mockPubSub)
 
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		event := NewConnectionEvent(ConnectionEventConnected, conn, nil, nil)
 
@@ -904,7 +904,7 @@ func TestManager_BroadcastConnectionEvent(t *testing.T) {
 	t.Run("works without pubsub configured", func(t *testing.T) {
 		manager := NewManager(context.Background())
 
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		event := NewConnectionEvent(ConnectionEventConnected, conn, nil, nil)
 
@@ -931,11 +931,11 @@ func TestManager_SetMaxConnections(t *testing.T) {
 		manager.SetMaxConnections(2)
 
 		// Add 2 connections
-		manager.AddConnection("conn1", nil, nil, "anon", nil)
-		manager.AddConnection("conn2", nil, nil, "anon", nil)
+		manager.AddConnection("conn1", nil, nil, "anon", nil, "")
+		manager.AddConnection("conn2", nil, nil, "anon", nil, "")
 
 		// Third should fail
-		_, err := manager.AddConnection("conn3", nil, nil, "anon", nil)
+		_, err := manager.AddConnection("conn3", nil, nil, "anon", nil, "")
 		assert.Equal(t, ErrMaxConnectionsReached, err)
 	})
 
@@ -945,7 +945,7 @@ func TestManager_SetMaxConnections(t *testing.T) {
 
 		// Should allow many connections
 		for i := 0; i < 100; i++ {
-			_, err := manager.AddConnection("conn"+string(rune(i)), nil, nil, "anon", nil)
+			_, err := manager.AddConnection("conn"+string(rune(i)), nil, nil, "anon", nil, "")
 			assert.NoError(t, err)
 		}
 	})
@@ -963,7 +963,7 @@ func TestManager_checkAndDisconnectSlowClients(t *testing.T) {
 			SlowClientTimeout:   1 * time.Second,
 		})
 
-		_, _ = manager.AddConnection("conn1", nil, nil, "anon", nil)
+		_, _ = manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		// Run check - should not disconnect
 		manager.checkAndDisconnectSlowClients()
@@ -979,7 +979,7 @@ func TestManager_checkAndDisconnectSlowClients(t *testing.T) {
 			SlowClientTimeout:      1 * time.Second,
 		})
 
-		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil)
+		conn, _ := manager.AddConnection("conn1", nil, nil, "anon", nil, "")
 
 		// Cancel the connection context to stop the writer goroutine from draining the queue
 		conn.cancel()

--- a/internal/rpc/storage.go
+++ b/internal/rpc/storage.go
@@ -61,7 +61,8 @@ func (s *Storage) CreateProcedureWithTenant(ctx context.Context, tenantID string
 	proc.UpdatedAt = time.Now()
 
 	err := database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			proc.ID, proc.Name, proc.Namespace, proc.Description, proc.SQLQuery, proc.OriginalCode,
 			proc.InputSchema, proc.OutputSchema, proc.AllowedTables, proc.AllowedSchemas,
 			proc.MaxExecutionTimeSeconds, proc.RequireRoles, proc.IsPublic, proc.DisableExecutionLogs, proc.Schedule,
@@ -113,7 +114,8 @@ func (s *Storage) UpdateProcedureForSync(ctx context.Context, tenantID string, p
 	proc.UpdatedAt = time.Now()
 
 	return database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query,
+		_, err := tx.Exec(
+			ctx, query,
 			proc.ID,
 			proc.Description,
 			proc.SQLQuery,
@@ -161,7 +163,8 @@ func (s *Storage) UpdateProcedureWithTenant(ctx context.Context, tenantID string
 	var result pgconn.CommandTag
 	err := database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
 		var execErr error
-		result, execErr = tx.Exec(ctx, query,
+		result, execErr = tx.Exec(
+			ctx, query,
 			proc.ID,
 			proc.Description,
 			proc.SQLQuery,
@@ -592,7 +595,8 @@ func (s *Storage) CreateExecution(ctx context.Context, exec *Execution) error {
 	}
 
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
-		_, execErr := tx.Exec(ctx, query,
+		_, execErr := tx.Exec(
+			ctx, query,
 			exec.ID, exec.ProcedureID, exec.ProcedureName, exec.Namespace, exec.Status,
 			exec.InputParams, exec.Result, exec.ErrorMessage, exec.RowsReturned, exec.DurationMs,
 			exec.UserID, exec.UserRole, exec.UserEmail, exec.IsAsync,
@@ -624,7 +628,8 @@ func (s *Storage) UpdateExecution(ctx context.Context, exec *Execution) error {
 	var result pgconn.CommandTag
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
 		var execErr error
-		result, execErr = tx.Exec(ctx, query,
+		result, execErr = tx.Exec(
+			ctx, query,
 			exec.ID,
 			exec.Status,
 			exec.Result,

--- a/internal/runtime/tokens_integration_test.go
+++ b/internal/runtime/tokens_integration_test.go
@@ -26,10 +26,12 @@ const testJWTSecret = "integration-test-jwt-secret-minimum-32-chars!!"
 
 func getDefaultTenantID(t *testing.T, pool interface {
 	QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row
-}) string {
+},
+) string {
 	t.Helper()
 	var tenantID string
-	err := pool.QueryRow(context.Background(),
+	err := pool.QueryRow(
+		context.Background(),
 		"SELECT id FROM platform.tenants WHERE is_default = true LIMIT 1",
 	).Scan(&tenantID)
 	require.NoError(t, err, "Failed to get default tenant ID")

--- a/internal/secrets/storage.go
+++ b/internal/secrets/storage.go
@@ -89,7 +89,8 @@ func (s *Storage) CreateSecretWithTenant(ctx context.Context, tenantID string, s
 	`
 
 	err = database.WrapWithServiceRoleAndTenant(ctx, s.db, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			secret.Name, secret.Scope, secret.Namespace, encryptedValue,
 			secret.Description, secret.ExpiresAt, userID,
 		).Scan(&secret.ID, &secret.Version, &secret.CreatedAt, &secret.UpdatedAt)

--- a/internal/storage/log_local.go
+++ b/internal/storage/log_local.go
@@ -76,14 +76,16 @@ func (s *LocalLogStorage) Write(ctx context.Context, entries []*LogEntry) error 
 		var groupKey string
 		if entry.Category == LogCategoryExecution && entry.ExecutionID != "" {
 			// Group execution logs by execution ID
-			groupKey = fmt.Sprintf("%s/%s/exec_%s",
+			groupKey = fmt.Sprintf(
+				"%s/%s/exec_%s",
 				string(entry.Category),
 				entry.Timestamp.Format("2006/01/02"),
 				entry.ExecutionID,
 			)
 		} else {
 			// Group other logs by category and date with a batch UUID
-			groupKey = fmt.Sprintf("%s/%s/batch",
+			groupKey = fmt.Sprintf(
+				"%s/%s/batch",
 				string(entry.Category),
 				entry.Timestamp.Format("2006/01/02"),
 			)

--- a/internal/storage/log_postgres.go
+++ b/internal/storage/log_postgres.go
@@ -106,7 +106,8 @@ func (s *PostgresLogStorage) Write(ctx context.Context, entries []*LogEntry) err
 			}
 		}
 
-		args = append(args,
+		args = append(
+			args,
 			entry.ID,
 			entry.Timestamp,
 			string(entry.Category),

--- a/internal/storage/log_s3.go
+++ b/internal/storage/log_s3.go
@@ -61,14 +61,16 @@ func (s *S3LogStorage) Write(ctx context.Context, entries []*LogEntry) error {
 		var groupKey string
 		if entry.Category == LogCategoryExecution && entry.ExecutionID != "" {
 			// Group execution logs by execution ID
-			groupKey = fmt.Sprintf("%s/%s/exec_%s",
+			groupKey = fmt.Sprintf(
+				"%s/%s/exec_%s",
 				string(entry.Category),
 				entry.Timestamp.Format("2006/01/02"),
 				entry.ExecutionID,
 			)
 		} else {
 			// Group other logs by category and date with a batch UUID
-			groupKey = fmt.Sprintf("%s/%s/batch",
+			groupKey = fmt.Sprintf(
+				"%s/%s/batch",
 				string(entry.Category),
 				entry.Timestamp.Format("2006/01/02"),
 			)

--- a/internal/tenantdb/fdw_integration_test.go
+++ b/internal/tenantdb/fdw_integration_test.go
@@ -44,7 +44,8 @@ func setupFDWTest(t *testing.T) (mainPool, tenantPool *pgxpool.Pool, cfg FDWConf
 
 	// Build admin URL for creating databases and bootstrapping (needs superuser)
 	testCfg := dbhelpers.GetTestConfig()
-	adminDBURL := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=%s",
+	adminDBURL := fmt.Sprintf(
+		"postgresql://%s:%s@%s:%d/%s?sslmode=%s",
 		testCfg.Database.AdminUser,
 		testCfg.Database.AdminPassword,
 		testCfg.Database.Host,

--- a/internal/tenantdb/manager_integration_test.go
+++ b/internal/tenantdb/manager_integration_test.go
@@ -36,7 +36,8 @@ func setupManagerTest(t *testing.T) *managerTestEnv {
 
 	// Build admin URL for creating databases (needs superuser)
 	cfg := dbhelpers.GetTestConfig()
-	adminDBURL := fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=disable",
+	adminDBURL := fmt.Sprintf(
+		"postgresql://%s:%s@%s:%d/%s?sslmode=disable",
 		cfg.Database.AdminUser,
 		cfg.Database.AdminPassword,
 		cfg.Database.Host,
@@ -146,7 +147,8 @@ func TestManager_CreateTenantDatabase_FullPipeline(t *testing.T) {
 
 	// Verify the database actually exists
 	var dbExists bool
-	err = env.adminPool.QueryRow(ctx,
+	err = env.adminPool.QueryRow(
+		ctx,
 		"SELECT EXISTS(SELECT datname FROM pg_database WHERE datname = $1)",
 		*stored.DBName,
 	).Scan(&dbExists)
@@ -257,7 +259,8 @@ func TestManager_DeleteTenantDatabase_CleansUp(t *testing.T) {
 
 	// Verify database is dropped
 	var dbExists bool
-	err = env.adminPool.QueryRow(ctx,
+	err = env.adminPool.QueryRow(
+		ctx,
 		"SELECT EXISTS(SELECT datname FROM pg_database WHERE datname = $1)",
 		dbName,
 	).Scan(&dbExists)

--- a/internal/tenantdb/storage.go
+++ b/internal/tenantdb/storage.go
@@ -221,7 +221,8 @@ func (s *Storage) CreateTenant(ctx context.Context, tenant *Tenant) error {
 		RETURNING id, created_at, updated_at
 	`
 
-	err = s.db.QueryRow(ctx, query,
+	err = s.db.QueryRow(
+		ctx, query,
 		tenant.Slug,
 		tenant.Name,
 		tenant.DBName,

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -70,7 +70,8 @@ func SetupTestDB(t *testing.T) *pgxpool.Pool {
 
 // buildConnectionURL constructs a PostgreSQL connection URL from config.
 func buildConnectionURL(cfg config.DatabaseConfig) string {
-	return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=disable",
+	return fmt.Sprintf(
+		"postgresql://%s:%s@%s:%d/%s?sslmode=disable",
 		cfg.User,
 		cfg.Password,
 		cfg.Host,

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -339,7 +339,8 @@ func (s *WebhookService) Create(ctx context.Context, webhook *Webhook) error {
 		tenantIDVal = uuid.MustParse(tenantID)
 	}
 	err = database.WrapWithServiceRoleAndTenant(ctx, s.db, tenantID, func(tx pgx.Tx) error {
-		return tx.QueryRow(ctx, query,
+		return tx.QueryRow(
+			ctx, query,
 			webhook.Name,
 			webhook.Description,
 			webhook.URL,
@@ -584,7 +585,8 @@ func (s *WebhookService) Update(ctx context.Context, id uuid.UUID, webhook *Webh
 
 	tenantID := database.TenantFromContext(ctx)
 	err = database.WrapWithServiceRoleAndTenant(ctx, s.db, tenantID, func(tx pgx.Tx) error {
-		result, err := tx.Exec(ctx, query,
+		result, err := tx.Exec(
+			ctx, query,
 			webhook.Name,
 			webhook.Description,
 			webhook.URL,

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,0 +1,191 @@
+Bug fixes and maintenance improvements have been made, including fixes for tenant isolation, settings defaults, and various other issues. Additionally, some features such as multi-tenancy, declarative schemas, and tenant-scoped impersonation have been improved or introduced.
+
+## What's Changed
+
+## Multi-Tenancy
+
+Full tenant isolation with per-tenant databases and Row Level Security across all modules.
+
+- platform schema — tenants, service keys, tenant admin assignments, invitation tokens
+- Per-tenant databases via postgres_fdw — isolated public schema with shared services (auth, storage, jobs, etc.) accessed through foreign tables
+- Pool priority chain — branch > tenant > main, resolved per-request via X-FB-Tenant header
+- Tenant middleware wired across all route groups (REST, GraphQL, storage, auth, DDL, webhooks, RPC, jobs, functions)
+- Tenant-scoped branching — branches clone from the tenant's database (not main) with automatic FDW repair
+- Tenant admin roles with scoped impersonation and JWT claims
+- Tenant management API and admin UI for CRUD, members, service keys, and schema management
+
+## Declarative Database Schemas
+
+Internal schemas managed declaratively instead of via imperative migrations.
+
+- internal/database/schema/schemas/ — one SQL file per schema (auth, storage, jobs, functions, branching, ai, logging, mcp, platform, rpc, realtime)
+- Bootstrap system — creates schemas, extensions, roles, and default privileges
+- pgschema integration — diff-based plan/apply/dump
+- Per-tenant declarative schemas — {schema_dir}/{tenant-slug}/public.sql with on-create, on-startup, or on-demand application
+- Tenant Schema API — upload, diff, and apply schema content per tenant
+
+## API Route Registry
+
+Centralized route registration replacing scattered handler wiring.
+
+- internal/api/routes/ — 30+ route definition files organized by feature
+- Structured definitions with middleware stacking, path parameters, and validation
+- Tenant middleware enforced at the registry level
+
+## Playwright E2E Tests for Admin UI
+
+Full browser-based test suite with dedicated infrastructure.
+
+- 30+ spec files — setup, login, tenant CRUD/isolation, service keys, impersonation, edge functions, jobs, chatbots, SSO
+- 3-phase pipeline — setup > provisioning > E2E against a dedicated fluxbase_playwright database
+- Rich test helpers — API, DB, mailhog, selectors, shared fixtures
+- make test-e2e-ui and variants (headed, debug, dev)
+
+## Security & Reliability
+
+- Adaptive Trust System — risk-based CAPTCHA verification
+- Service key revocation and rotation
+- OAuth state persistence for multi-instance deployments
+- Idempotency keys for mutations
+- Per-endpoint body size limits
+- Per-user TOTP rate limiting with encrypted secrets
+- Security hardening — OTP/invitation hashing, sensitive env var blocking in edge functions, pool mutex, advisory locks on migrations
+
+## AI & Knowledge Bases
+
+- Knowledge graph with document relationships and graph-based retrieval
+- Chatbot MCP tool integration — chatbots invoke custom MCP tools
+- Custom MCP tools with full SDK access and @fluxbase:namespace annotations
+- MCP tools management page in admin dashboard
+- ReAct reasoning for chatbots
+- Knowledge base namespaces
+
+## Multi-Backend Logging
+
+- PostgreSQL, TimescaleDB (with compression), S3/MinIO, Loki, Elasticsearch, Clickhouse
+- Configurable batching, flush intervals, and retention policies
+
+## Codebase
+
+- Fiber v2 → v3 migration
+- npm → bun migration for all TypeScript packages
+- Centralized packages — internal/errors/, internal/sync/, internal/scheduler/, internal/keys/, internal/loader/, internal/util/
+- Astro v6 migration for docs site
+- Go 1.25 → 1.26
+- Pre-commit hooks enforcing go fmt, golangci-lint, and TypeScript type-check
+
+### Pull Requests
+
+- fix: Update settings defaults (#206) @bartcode
+- fix: add viper config fallback to settings cache so features default to enabled (#205) @bartcode
+- docs: fix middleware ordering, feature grid, CLI tenant flag, and cleanup (#204) @bartcode
+- fix(tenancy): harden FDW schema import against transient connection failures (#203) @bartcode
+- chore(deps): update module github.com/gofiber/fiber/v3 to v3.2.0 [security] (#202) @app/renovate
+- docs: comprehensive documentation overhaul (#201) @bartcode
+- fix: admin redirect, tenant repair, extension deps, schema graph, instance-level OAuth/SAML (#200) @bartcode
+- refactor: simplify Go codebase for security and maintainability (#199) @bartcode
+- refactor: centralize error handling, validation, scheduling, and storage patterns (#198) @bartcode
+- chore(deps): update module github.com/jackc/pgx/v5 to v5.9.2 [security] (#197) @app/renovate
+- chore(deps): update dependency astro to ^6.1.6 [security] (#196) @app/renovate
+- fix: Resolve tenant isolation bugs. (#195) @bartcode
+- fix: Enforce tenant isolation across all handlers and add repair endpoint (#194) @bartcode
+- fix: Wire settings cache to fix email provider switcher not persisting (#193) @bartcode
+- fix: Reorder jobs routes and fix RPC executions infinite loop (#192) @bartcode
+- Fix tenant_service role authorization across all modules (#191) @bartcode
+- Improve tenant-scoped impersonation for tenant admins (#190) @bartcode
+- Add more UI tests and fix encountered bugs (#189) @bartcode
+- fix: Wire tenant middleware into Jobs, Webhooks, RPC, and GraphQL routes (#188) @bartcode
+- chore(deps): update dependency axios to ^1.15.0 [security] (#187) @app/renovate
+- feat: Introduce Playwright testing and fix storage handler bug. (#186) @bartcode
+- chore(deps): update dependency go to v1.26.1 (#185) @app/renovate
+- Refactor API routes, use declarative schemas, add multi-tenancy, testing improvements, etc. (#183) @bartcode
+- chore(deps): update go dependencies (#182) @app/renovate
+- chore(deps): update module google.golang.org/grpc to v1.79.3 [security] (#181) @app/renovate
+- chore(deps): update all dependencies (#180) @app/renovate
+- chore(deps): update all dependencies (#175) @app/renovate
+- chore(deps): update go dependencies (#174) @app/renovate
+
+### Commits
+
+**Features:**
+
+- 5db3de0a fix: add viper config fallback to settings cache so features default to enabled (#205)
+- ecaded60 feat: Introduce Playwright testing and fix storage handler bug. (#186)
+
+**Bug Fixes:**
+
+- b4304d16 fix: Update settings defaults (#206)
+- 5db3de0a fix: add viper config fallback to settings cache so features default to enabled (#205)
+- 1726ee44 fix(tenancy): harden FDW schema import against transient connection failures (#203)
+- 9776aa70 fix: admin redirect, tenant repair, extension deps, schema graph, instance-level OAuth/SAML (#200)
+- f781812a fix: Resolve tenant isolation bugs. (#195)
+- 32073a6e fix: Enforce tenant isolation across all handlers and add repair endpoint (#194)
+- 93f98693 fix: Wire settings cache to fix email provider switcher not persisting (#193)
+- c290c38d fix: Reorder jobs routes and fix RPC executions infinite loop (#192)
+- b58e9643 fix: Ensure routes for secrest are the same as before.
+- 87d830a9 fix: Wire tenant middleware into Jobs, Webhooks, RPC, and GraphQL routes (#188)
+- fb370921 fix: Add e2e tests and tenant_id column.
+- 55f6cb1e fix: Resolve edge cases for multi-tenancy.
+- e0c32e6c fix: Update service key middleware.
+- 4d7cb1c5 fix: Resolve issues with declarative schemas.
+- cdfc976a fix: Update renovate.json to use a minimum release age.
+
+**Other Changes:**
+
+- f949482a docs: fix voice, middleware ordering, feature grid, CLI tenant flag, and cleanup (#204)
+- 4b44e727 docs: comprehensive documentation overhaul (#201)
+- 8bd23fc1 refactor: simplify Go codebase for security and maintainability (#199)
+- cee3f703 refactor: centralize error handling, validation, scheduling, and storage patterns (#198)
+- f183d813 Fix tenant_service role authorization across all modules (#191)
+- d7f64ce5 Improve tenant-scoped impersonation for tenant admins (#190)
+- 6bae9992 docs: More alignment between docs and code.
+- f8f2260a docs: Update docs to match the codebase.
+- 7ed68f71 Add more UI tests and fix encountered bugs (#189)
+- 46f37057 ci: Upgrade Helm setup.
+
+### Stats
+
+- **55** commits
+- **3** contributors
+
+## Installation
+
+**Docker:**
+
+```bash
+docker pull ghcr.io/nimbleflux/fluxbase:2026.5.1
+```
+
+**NPM SDK:**
+
+```bash
+npm install @nimbleflux/fluxbase-sdk@2026.5.1
+```
+
+**Helm:**
+
+```bash
+helm install fluxbase oci://ghcr.io/nimbleflux/charts/fluxbase --version 2026.5.1
+```
+
+**CLI:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/nimbleflux/fluxbase/main/install-cli.sh | bash -s -- v2026.5.1
+```
+
+---
+
+_Release automatically generated by GitHub Actions_
+
+---
+
+## Smoke Test Results
+
+| Component     | Status      |
+| ------------- | ----------- |
+| Docker Image  | ✅ Verified |
+| NPM SDK       | ✅ Verified |
+| NPM React SDK | ✅ Verified |
+
+_Smoke tests completed at 2026-05-01 09:11:13 UTC_

--- a/test/dbhelpers/dbhelpers.go
+++ b/test/dbhelpers/dbhelpers.go
@@ -163,7 +163,8 @@ func connectPoolWithRetry(connURL string, maxAttempts int) (*pgxpool.Pool, error
 
 // buildConnectionURL builds a PostgreSQL connection URL from config.
 func buildConnectionURL(cfg config.DatabaseConfig) string {
-	return fmt.Sprintf("postgresql://%s:%s@%s:%d/%s?sslmode=%s",
+	return fmt.Sprintf(
+		"postgresql://%s:%s@%s:%d/%s?sslmode=%s",
 		cfg.User,
 		cfg.Password,
 		cfg.Host,

--- a/test/e2e/functions_execution_test.go
+++ b/test/e2e/functions_execution_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -365,6 +366,22 @@ func TestFunctionExecution_ServiceClientQueriesUserTable(t *testing.T) {
 	defer tc.Close()
 	tc.EnsureAuthSchema()
 	tc.EnsureSystemSettings()
+
+	// Start a real HTTP server so the Deno runtime can call back via _fluxbaseService.
+	// App.Test() only does in-process dispatch, but the Deno subprocess needs a real
+	// TCP listener to connect to.
+	go func() {
+		if err := tc.Server.Start(); err != nil {
+			t.Logf("Server stopped: %v", err)
+		}
+	}()
+	// Give the server a moment to bind the port
+	time.Sleep(500 * time.Millisecond)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = tc.Server.Shutdown(ctx)
+	}()
 
 	timestamp := time.Now().UnixNano()
 	email := fmt.Sprintf("admin-svc-query-%d@test.com", timestamp)

--- a/test/e2e/functions_execution_test.go
+++ b/test/e2e/functions_execution_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -370,6 +369,7 @@ func TestFunctionExecution_ServiceClientQueriesUserTable(t *testing.T) {
 	// Start a real HTTP server so the Deno runtime can call back via _fluxbaseService.
 	// App.Test() only does in-process dispatch, but the Deno subprocess needs a real
 	// TCP listener to connect to.
+	// tc.Close() will shut down the server via Server.Shutdown(), so we only start it here.
 	go func() {
 		if err := tc.Server.Start(); err != nil {
 			t.Logf("Server stopped: %v", err)
@@ -377,11 +377,6 @@ func TestFunctionExecution_ServiceClientQueriesUserTable(t *testing.T) {
 	}()
 	// Give the server a moment to bind the port
 	time.Sleep(500 * time.Millisecond)
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = tc.Server.Shutdown(ctx)
-	}()
 
 	timestamp := time.Now().UnixNano()
 	email := fmt.Sprintf("admin-svc-query-%d@test.com", timestamp)

--- a/test/e2e/functions_execution_test.go
+++ b/test/e2e/functions_execution_test.go
@@ -400,6 +400,11 @@ func TestFunctionExecution_ServiceClientQueriesUserTable(t *testing.T) {
 
 	tc.ExecuteSQL(fmt.Sprintf(`INSERT INTO public.%s (name) VALUES ('hello'), ('world');`, tableName))
 
+	// Invalidate schema cache so the REST API discovers the new table
+	if cache := tc.Server.SchemaCache(); cache != nil {
+		cache.Invalidate()
+	}
+
 	functionName := fmt.Sprintf("test_svc_from_%d", timestamp)
 	createTestFunction(t, tc, adminToken, functionName, fmt.Sprintf(`export default async function handler(req) {
 		try {

--- a/test/e2e/storage_rls_admin_test.go
+++ b/test/e2e/storage_rls_admin_test.go
@@ -79,7 +79,8 @@ func TestStorageRLS_AdminAccess(t *testing.T) {
 	// Verify the file has owner_id set to regular user
 	results := tc.QuerySQLAsSuperuser(
 		"SELECT owner_id FROM storage.objects WHERE bucket_id = $1 AND path = $2",
-		bucketName, fileName)
+		bucketName, fileName,
+	)
 	require.Len(t, results, 1, "File should exist in database")
 	require.Equal(t, userID, results[0]["owner_id"], "File should be owned by regular user")
 
@@ -131,7 +132,8 @@ func TestStorageRLS_AdminAccess(t *testing.T) {
 
 	// Verify bucket is now public
 	results = tc.QuerySQLAsSuperuser(
-		"SELECT public FROM storage.buckets WHERE id = $1", bucketName)
+		"SELECT public FROM storage.buckets WHERE id = $1", bucketName,
+	)
 	require.Len(t, results, 1, "Bucket should exist")
 	require.True(t, results[0]["public"].(bool), "Bucket should now be public")
 

--- a/test/e2e/storage_rls_bucket_settings_test.go
+++ b/test/e2e/storage_rls_bucket_settings_test.go
@@ -37,7 +37,8 @@ func TestStorageRLS_BucketVisibilityToggle(t *testing.T) {
 
 	// Verify bucket is private by default
 	results := tc.QuerySQLAsSuperuser(
-		"SELECT public FROM storage.buckets WHERE id = $1", bucketName)
+		"SELECT public FROM storage.buckets WHERE id = $1", bucketName,
+	)
 	require.Len(t, results, 1, "Bucket should exist")
 	require.False(t, results[0]["public"].(bool), "Bucket should be private by default")
 	t.Logf("✅ Bucket created as private by default")
@@ -87,7 +88,8 @@ func TestStorageRLS_BucketVisibilityToggle(t *testing.T) {
 
 	// Verify bucket is now public
 	results = tc.QuerySQLAsSuperuser(
-		"SELECT public FROM storage.buckets WHERE id = $1", bucketName)
+		"SELECT public FROM storage.buckets WHERE id = $1", bucketName,
+	)
 	require.Len(t, results, 1, "Bucket should exist")
 	require.True(t, results[0]["public"].(bool), "Bucket should now be public")
 
@@ -115,7 +117,8 @@ func TestStorageRLS_BucketVisibilityToggle(t *testing.T) {
 
 	// Verify bucket is private again
 	results = tc.QuerySQLAsSuperuser(
-		"SELECT public FROM storage.buckets WHERE id = $1", bucketName)
+		"SELECT public FROM storage.buckets WHERE id = $1", bucketName,
+	)
 	require.Len(t, results, 1, "Bucket should exist")
 	require.False(t, results[0]["public"].(bool), "Bucket should be private again")
 
@@ -142,7 +145,8 @@ func TestStorageRLS_BucketVisibilityToggle(t *testing.T) {
 
 	// Verify bucket is still private (not changed by non-admin attempt)
 	results = tc.QuerySQLAsSuperuser(
-		"SELECT public FROM storage.buckets WHERE id = $1", bucketName)
+		"SELECT public FROM storage.buckets WHERE id = $1", bucketName,
+	)
 	require.Len(t, results, 1, "Bucket should exist")
 	require.False(t, results[0]["public"].(bool), "Bucket should still be private")
 

--- a/test/e2e/storage_rls_isolation_test.go
+++ b/test/e2e/storage_rls_isolation_test.go
@@ -101,7 +101,8 @@ func TestStorageRLS_UserIsolation(t *testing.T) {
 	results := tc.QuerySQLAsRLSUser(
 		"SELECT COUNT(*) as count FROM storage.objects WHERE bucket_id = $1",
 		user2ID, // Set RLS context as user2
-		bucketName)
+		bucketName,
+	)
 
 	require.Len(t, results, 1, "Query should return result")
 	count, ok := results[0]["count"].(int64)
@@ -113,7 +114,8 @@ func TestStorageRLS_UserIsolation(t *testing.T) {
 	results = tc.QuerySQLAsRLSUser(
 		"SELECT COUNT(*) as count FROM storage.objects WHERE bucket_id = $1",
 		user1ID, // Set RLS context as user1
-		bucketName)
+		bucketName,
+	)
 
 	require.Len(t, results, 1, "Query should return result")
 	count, ok = results[0]["count"].(int64)
@@ -124,7 +126,8 @@ func TestStorageRLS_UserIsolation(t *testing.T) {
 	// Verify superuser can see all files (bypasses RLS)
 	results = tc.QuerySQLAsSuperuser(
 		"SELECT COUNT(*) as count FROM storage.objects WHERE bucket_id = $1",
-		bucketName)
+		bucketName,
+	)
 
 	require.Len(t, results, 1, "Query should return result")
 	count, ok = results[0]["count"].(int64)

--- a/test/e2e/storage_rls_ownership_test.go
+++ b/test/e2e/storage_rls_ownership_test.go
@@ -148,7 +148,8 @@ func TestStorageRLS_FileOwnership(t *testing.T) {
 	// Verify file still exists (using superuser query to bypass RLS)
 	results := tc.QuerySQLAsSuperuser(
 		"SELECT owner_id FROM storage.objects WHERE bucket_id = $1 AND path = $2",
-		bucketName, fileName)
+		bucketName, fileName,
+	)
 	require.Len(t, results, 1, "File should still exist after user2's failed delete")
 	require.Equal(t, user1ID, results[0]["owner_id"], "File should still be owned by user1")
 

--- a/test/e2e/storage_rls_providers_test.go
+++ b/test/e2e/storage_rls_providers_test.go
@@ -113,7 +113,8 @@ func TestStorageRLS_StorageProviders(t *testing.T) {
 			// Verify metadata is in database
 			results := tc.QuerySQLAsSuperuser(
 				"SELECT owner_id, bucket_id, path FROM storage.objects WHERE path = $1 AND bucket_id = $2",
-				fileName, bucketName)
+				fileName, bucketName,
+			)
 
 			require.Len(t, results, 1, "File metadata should exist in database")
 			require.Equal(t, user1ID, results[0]["owner_id"], "owner_id should be set to user1")
@@ -126,7 +127,8 @@ func TestStorageRLS_StorageProviders(t *testing.T) {
 			user2Results := tc.QuerySQLAsRLSUser(
 				"SELECT COUNT(*) as count FROM storage.objects WHERE bucket_id = $1",
 				user2ID, // Query as user2
-				bucketName)
+				bucketName,
+			)
 
 			require.Len(t, user2Results, 1, "Query should return result")
 			count, ok := user2Results[0]["count"].(int64)
@@ -149,7 +151,8 @@ func TestStorageRLS_StorageProviders(t *testing.T) {
 			// Verify file is deleted from database
 			results = tc.QuerySQLAsSuperuser(
 				"SELECT COUNT(*) as count FROM storage.objects WHERE path = $1 AND bucket_id = $2",
-				fileName, bucketName)
+				fileName, bucketName,
+			)
 
 			require.Len(t, results, 1, "Query should return result")
 			count, ok = results[0]["count"].(int64)

--- a/test/e2e/storage_rls_service_key_test.go
+++ b/test/e2e/storage_rls_service_key_test.go
@@ -112,7 +112,8 @@ func TestStorageRLS_ServiceKeyBypass(t *testing.T) {
 	// Verify file is deleted
 	results := tc.QuerySQLAsSuperuser(
 		"SELECT COUNT(*) as count FROM storage.objects WHERE bucket_id = $1 AND path = $2",
-		bucketName, fileName)
+		bucketName, fileName,
+	)
 
 	require.Len(t, results, 1, "Query should return result")
 	count, ok := results[0]["count"].(int64)

--- a/test/e2e/tenant_deletion_cascade_test.go
+++ b/test/e2e/tenant_deletion_cascade_test.go
@@ -54,7 +54,8 @@ func TestTenantDeletion_CascadeCleanup(t *testing.T) {
 
 	// Verify data exists before deletion
 	rowsBefore := tc.QuerySQLAsSuperuser(
-		"SELECT count(*) as cnt FROM jobs.functions WHERE tenant_id = $1::uuid", tenantID)
+		"SELECT count(*) as cnt FROM jobs.functions WHERE tenant_id = $1::uuid", tenantID,
+	)
 	assert.Equal(t, int64(1), rowsBefore[0]["cnt"].(int64), "job function should exist before deletion")
 
 	// Delete the tenant via API
@@ -66,12 +67,14 @@ func TestTenantDeletion_CascadeCleanup(t *testing.T) {
 
 	// Verify data is cleaned up
 	rowsAfterJobs := tc.QuerySQLAsSuperuser(
-		"SELECT count(*) as cnt FROM jobs.functions WHERE tenant_id = $1::uuid", tenantID)
+		"SELECT count(*) as cnt FROM jobs.functions WHERE tenant_id = $1::uuid", tenantID,
+	)
 	assert.Equal(t, int64(0), rowsAfterJobs[0]["cnt"].(int64),
 		"job functions should be deleted when tenant is deleted")
 
 	rowsAfterRPC := tc.QuerySQLAsSuperuser(
-		"SELECT count(*) as cnt FROM rpc.procedures WHERE tenant_id = $1::uuid", tenantID)
+		"SELECT count(*) as cnt FROM rpc.procedures WHERE tenant_id = $1::uuid", tenantID,
+	)
 	assert.Equal(t, int64(0), rowsAfterRPC[0]["cnt"].(int64),
 		"rpc procedures should be deleted when tenant is deleted")
 }

--- a/test/e2e/tenant_isolation_test.go
+++ b/test/e2e/tenant_isolation_test.go
@@ -93,7 +93,8 @@ func TestTenantIsolation_AuthUsers(t *testing.T) {
 
 	// Verify superuser sees both
 	allUsers := tc.QuerySQLAsSuperuser(
-		`SELECT email FROM auth.users WHERE email LIKE 'tenant-test-%' ORDER BY email`)
+		`SELECT email FROM auth.users WHERE email LIKE 'tenant-test-%' ORDER BY email`,
+	)
 	require.Len(t, allUsers, 2, "Superuser should see all users")
 }
 
@@ -559,13 +560,15 @@ func TestTenantIsolation_JobsAPI(t *testing.T) {
 		`INSERT INTO jobs.functions (id, name, namespace, code, enabled, tenant_id)
 		 VALUES ($1, 'tenant1-job-api-test', 'isolation-test', 'export default function() {}', true, $2::uuid)
 		 ON CONFLICT (id) DO NOTHING`,
-		"10000000-0000-0000-0000-000000000001", tenantTestID1)
+		"10000000-0000-0000-0000-000000000001", tenantTestID1,
+	)
 
 	tc.ExecuteSQLAsSuperuser(
 		`INSERT INTO jobs.functions (id, name, namespace, code, enabled, tenant_id)
 		 VALUES ($1, 'tenant2-job-api-test', 'isolation-test', 'export default function() {}', true, $2::uuid)
 		 ON CONFLICT (id) DO NOTHING`,
-		"10000000-0000-0000-0000-000000000002", tenantTestID2)
+		"10000000-0000-0000-0000-000000000002", tenantTestID2,
+	)
 
 	// Query as tenant1 - should only see tenant1's job function
 	rows1 := tc.QuerySQLAsTenant(tenantTestID1,
@@ -591,7 +594,8 @@ func TestTenantIsolation_JobsAPI(t *testing.T) {
 
 	// Superuser should see both
 	rowsAll := tc.QuerySQLAsSuperuser(
-		"SELECT name FROM jobs.functions WHERE namespace = 'isolation-test'")
+		"SELECT name FROM jobs.functions WHERE namespace = 'isolation-test'",
+	)
 	require.Len(t, rowsAll, 2, "superuser should see both tenants' job functions")
 }
 

--- a/test/e2e/tenant_migration_schema_isolation_test.go
+++ b/test/e2e/tenant_migration_schema_isolation_test.go
@@ -37,9 +37,11 @@ func TestTenantMigrations_SchemaIsolation(t *testing.T) {
 
 	// Enable RLS on the table
 	tc.ExecuteSQLAsSuperuser(
-		`ALTER TABLE public.schema_isolation_test ENABLE ROW LEVEL SECURITY`)
+		`ALTER TABLE public.schema_isolation_test ENABLE ROW LEVEL SECURITY`,
+	)
 	tc.ExecuteSQLAsSuperuser(
-		`ALTER TABLE public.schema_isolation_test FORCE ROW LEVEL SECURITY`)
+		`ALTER TABLE public.schema_isolation_test FORCE ROW LEVEL SECURITY`,
+	)
 
 	// Create tenant isolation policy
 	tc.ExecuteSQLAsSuperuser(`

--- a/test/e2e_helpers.go
+++ b/test/e2e_helpers.go
@@ -1319,7 +1319,8 @@ func (r *APIRequest) WithDefaultTenant() *APIRequest {
 func (tc *TestContext) GetDefaultTenantID() string {
 	tc.defaultTenantOnce.Do(func() {
 		var id string
-		err := tc.DB.Pool().QueryRow(context.Background(),
+		err := tc.DB.Pool().QueryRow(
+			context.Background(),
 			"SELECT id::text FROM platform.tenants WHERE is_default = true LIMIT 1",
 		).Scan(&id)
 		if err == nil {
@@ -1328,7 +1329,8 @@ func (tc *TestContext) GetDefaultTenantID() string {
 		}
 
 		// No default tenant exists — create one (CI doesn't seed default tenant)
-		require.NoError(tc.T, tc.DB.Pool().QueryRow(context.Background(),
+		require.NoError(tc.T, tc.DB.Pool().QueryRow(
+			context.Background(),
 			"INSERT INTO platform.tenants (slug, name, is_default) VALUES ('default', 'Default', true) RETURNING id::text",
 		).Scan(&id), "Failed to create default tenant")
 
@@ -2887,7 +2889,8 @@ func (tc *TestContext) CreateServiceKey(name string) string {
 	`
 
 	var keyID uuid.UUID
-	err = tc.DB.QueryRow(ctx, query,
+	err = tc.DB.QueryRow(
+		ctx, query,
 		name,
 		"Test service key for "+name,
 		string(keyHash),
@@ -2900,7 +2903,8 @@ func (tc *TestContext) CreateServiceKey(name string) string {
 		if poolErr != nil {
 			require.NoError(tc.T, err, "Failed to insert service key (superuser fallback also failed: %v)", poolErr)
 		}
-		err = pool.QueryRow(ctx, query,
+		err = pool.QueryRow(
+			ctx, query,
 			name,
 			"Test service key for "+name,
 			string(keyHash),


### PR DESCRIPTION
Tenant context was lost when WebSocket connections created context.Background() without propagating tenant_id from Fiber Locals. This caused non-default tenant users to get CHATBOT_NOT_FOUND errors on the AI chat WebSocket and left the realtime module completely tenant-unaware.