### PR TITLE
refactor: eliminate Server.Shutdown god-method, clean up module system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ docs/plans/
 **/test-results/
 admin/playwright-report/
 .tanstack/
+fluxbase

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,10 +13,12 @@ Fluxbase is a single-binary Backend-as-a-Service (BaaS). PostgreSQL is the only 
 
 ```
 cmd/fluxbase/main.go     # Server entry point (setup + server creation)
-internal/api/module.go   # Module interface + ServiceRegistry (dependency injection)
-internal/api/module_*.go # 19 business logic modules (one per domain)
+ internal/api/module.go   # Module interface + ServiceRegistry (dependency injection)
+internal/api/module_*.go # 20 business logic modules (one per domain)
 internal/api/server.go   # Server struct, NewServer, module wiring
-internal/api/server_init.go # Infrastructure: initCore, setupMiddlewares, setupRoutes
+internal/api/server_init.go # Infrastructure: initCore
+internal/api/server_middlewares.go # Middleware setup
+internal/api/server_routes.go # Route setup
 internal/database/retry.go      # ConnectWithRetry extracted from main.go
 internal/tenantdb/bootstrap_keys.go # EnsureDefaultTenantAndKeys, EnsureServiceKey
 internal/tenantdb/backfill.go   # BackfillTenantIDToDefault
@@ -71,12 +73,16 @@ test/e2e/                # End-to-end tests
 Server initialization uses a module-based dependency injection system:
 
 - **`Module` interface** — `Name()` + `Init(ctx, *ServiceRegistry) error`
-- **`ServiceRegistry`** — stores config, DB, PubSub, and registered services; modules read dependencies via `GetService[T]()`
-- **19 modules** in dependency order: Email → Secrets → Storage → Logging → Auth → Webhook → Extensions → Tenancy → Settings → Schema → Functions → Jobs → RPC → AI → Realtime → Branching → GraphQL → MCP → Metrics
+- **`Shutdowner` interface** — optional `Shutdown(ctx context.Context) error`; modules with stoppable resources implement this for clean teardown
+- **`ServiceRegistry`** — stores config, DB, PubSub, RateLimiter, and registered services; modules read dependencies via `GetService[T]()`
+- **20 modules** in dependency order: Email → Secrets → Storage → Logging → Auth → Webhook → Extensions → Tenancy → Settings → Schema → Functions → Jobs → RPC → AI → Realtime → Branching → GraphQL → MCP → Metrics → BackgroundServices
+- Modules shut down in reverse order via `ShutdownModules()`
 - `GetService[T]()` uses `reflect.TypeOf` — only works with concrete pointer types (e.g., `*auth.Service`), not interfaces. Use `registry.PubSub` field for `pubsub.PubSub`
 - Modules register outputs via `registry.Register()` so downstream modules can find them
 
-**Key files:** `module.go` (interface + registry), `module_*.go` (one per module), `server.go` (wiring), `server_init.go` (remaining infrastructure: initCore, initBackgroundServices, setupMiddlewares, setupRoutes)
+**Two-phase wiring:** After `InitModules()` completes, `NewServer()` copies module outputs to `Server` struct fields (handler groups). This bridge is manual boilerplate — each new sub-handler requires both a module field and a Server field assignment.
+
+**Key files:** `module.go` (interface + registry), `module_*.go` (one per module), `server.go` (wiring + Shutdown), `server_init.go` (initCore), `server_middlewares.go` (middleware setup), `server_routes.go` (route setup)
 
 ## Database Schemas
 
@@ -756,7 +762,6 @@ func TestFunctionName_Scenario_ExpectedBehavior(t *testing.T)
 - Feature guides: `docs/src/content/docs/guides/<feature>.md`
 - API reference: `docs/src/content/docs/api/` (auto-generated from SDK)
 - Project overview: `CLAUDE.md` (this file)
-- Implementation notes: `IMPLEMENTATION_ANALYSIS.md`
 
 **Documentation checklist:**
 

--- a/internal/api/module.go
+++ b/internal/api/module.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"sync"
 
+	"github.com/rs/zerolog"
+
 	"github.com/nimbleflux/fluxbase/internal/config"
 	"github.com/nimbleflux/fluxbase/internal/database"
 	"github.com/nimbleflux/fluxbase/internal/pubsub"
@@ -14,6 +16,10 @@ import (
 type Module interface {
 	Name() string
 	Init(ctx context.Context, registry *ServiceRegistry) error
+}
+
+type Shutdowner interface {
+	Shutdown(ctx context.Context) error
 }
 
 type ServiceRegistry struct {
@@ -61,4 +67,14 @@ func InitModules(ctx context.Context, registry *ServiceRegistry, mods []Module) 
 		}
 	}
 	return nil
+}
+
+func ShutdownModules(ctx context.Context, mods []Module) {
+	for i := len(mods) - 1; i >= 0; i-- {
+		if s, ok := mods[i].(Shutdowner); ok {
+			if err := s.Shutdown(ctx); err != nil {
+				zerolog.Ctx(ctx).Error().Err(err).Str("module", mods[i].Name()).Msg("Module shutdown failed")
+			}
+		}
+	}
 }

--- a/internal/api/module_ai.go
+++ b/internal/api/module_ai.go
@@ -199,7 +199,6 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		}
 	}
 
-	registry.Register(aiStorage)
 	if vectorHandler != nil {
 		registry.Register(vectorHandler)
 	}
@@ -208,6 +207,13 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 	}
 	if kbStorage != nil {
 		registry.Register(kbStorage)
+	}
+	return nil
+}
+
+func (m *AIModule) Shutdown(ctx context.Context) error {
+	if m.Conversations != nil {
+		m.Conversations.Close()
 	}
 	return nil
 }

--- a/internal/api/module_auth.go
+++ b/internal/api/module_auth.go
@@ -138,10 +138,13 @@ func (m *AuthModule) Init(ctx context.Context, registry *ServiceRegistry) error 
 	registry.Register(m.SystemSettingsService)
 	registry.Register(m.UserMgmtService)
 	registry.Register(m.InvitationService)
-	registry.Register(m.Handlers)
-	registry.Register(m.SQLHandler)
-	registry.Register(m.RequireAuth)
-	registry.Register(m.OptionalAuth)
 
+	return nil
+}
+
+func (m *AuthModule) Shutdown(ctx context.Context) error {
+	if m.Handlers != nil && m.Handlers.OAuth != nil {
+		m.Handlers.OAuth.Stop()
+	}
 	return nil
 }

--- a/internal/api/module_background.go
+++ b/internal/api/module_background.go
@@ -127,3 +127,19 @@ func leaderElect(db *database.Connection, cfg *config.ScalingConfig, name string
 	startFn()
 	return nil
 }
+
+func (m *BackgroundServicesModule) Shutdown(ctx context.Context) error {
+	if m.FunctionsLeader != nil {
+		log.Info().Msg("Stopping functions scheduler leader election")
+		m.FunctionsLeader.Stop()
+	}
+	if m.JobsLeader != nil {
+		log.Info().Msg("Stopping jobs scheduler leader election")
+		m.JobsLeader.Stop()
+	}
+	if m.RPCLeader != nil {
+		log.Info().Msg("Stopping RPC scheduler leader election")
+		m.RPCLeader.Stop()
+	}
+	return nil
+}

--- a/internal/api/module_branching.go
+++ b/internal/api/module_branching.go
@@ -97,3 +97,18 @@ type branchFDWRepairer struct {
 func (r *branchFDWRepairer) RepairFDWForBranch(ctx context.Context, branchDBURL string, tenantID uuid.UUID) error {
 	return r.manager.RepairFDWForBranch(ctx, branchDBURL, tenantID)
 }
+
+func (m *BranchingModule) Shutdown(ctx context.Context) error {
+	if m.Scheduler != nil {
+		m.Scheduler.Stop()
+	}
+	if m.Router != nil {
+		log.Info().Msg("Closing branch connection pools")
+		m.Router.CloseAllPools()
+	}
+	if m.Manager != nil {
+		log.Info().Msg("Closing branch manager")
+		m.Manager.Close()
+	}
+	return nil
+}

--- a/internal/api/module_email.go
+++ b/internal/api/module_email.go
@@ -17,6 +17,5 @@ func (m *EmailModule) Init(ctx context.Context, registry *ServiceRegistry) error
 	m.Manager = email.NewManager(&registry.Config.Email, nil, nil, registry.Config)
 	m.Service = m.Manager.WrapAsService()
 	registry.Register(m.Manager)
-	registry.Register(m.Service)
 	return nil
 }

--- a/internal/api/module_extensions.go
+++ b/internal/api/module_extensions.go
@@ -14,6 +14,5 @@ func (m *ExtensionsModule) Name() string { return "extensions" }
 
 func (m *ExtensionsModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 	m.Handler = extensions.NewHandler(extensions.NewService(registry.DB))
-	registry.Register(m.Handler)
 	return nil
 }

--- a/internal/api/module_functions.go
+++ b/internal/api/module_functions.go
@@ -51,3 +51,10 @@ func (m *FunctionsModule) Init(ctx context.Context, registry *ServiceRegistry) e
 	registry.Register(functionsScheduler)
 	return nil
 }
+
+func (m *FunctionsModule) Shutdown(ctx context.Context) error {
+	if m.Scheduler != nil {
+		m.Scheduler.Stop()
+	}
+	return nil
+}

--- a/internal/api/module_graphql.go
+++ b/internal/api/module_graphql.go
@@ -40,6 +40,5 @@ func (m *GraphQLModule) Init(ctx context.Context, registry *ServiceRegistry) err
 		log.Warn().Msg("GraphQL introspection is enabled — consider setting graphql.introspection to false in production")
 	}
 
-	registry.Register(m.Handler)
 	return nil
 }

--- a/internal/api/module_jobs.go
+++ b/internal/api/module_jobs.go
@@ -59,7 +59,16 @@ func (m *JobsModule) Init(ctx context.Context, registry *ServiceRegistry) error 
 	m.Scheduler = jobsScheduler
 
 	registry.Register(jobsManager)
-	registry.Register(jobsHandler)
 	registry.Register(jobsScheduler)
+	return nil
+}
+
+func (m *JobsModule) Shutdown(ctx context.Context) error {
+	if m.Scheduler != nil {
+		m.Scheduler.Stop()
+	}
+	if m.Manager != nil {
+		m.Manager.Stop()
+	}
 	return nil
 }

--- a/internal/api/module_logging.go
+++ b/internal/api/module_logging.go
@@ -54,3 +54,17 @@ func (m *LoggingModule) Init(ctx context.Context, registry *ServiceRegistry) err
 	registry.Register(loggingService)
 	return nil
 }
+
+func (m *LoggingModule) Shutdown(ctx context.Context) error {
+	if m.Retention != nil {
+		log.Info().Msg("Stopping log retention cleanup service")
+		m.Retention.Stop()
+	}
+	if m.Service != nil {
+		log.Info().Msg("Closing central logging service")
+		if err := m.Service.Close(); err != nil {
+			log.Warn().Err(err).Msg("Failed to close logging service")
+		}
+	}
+	return nil
+}

--- a/internal/api/module_metrics.go
+++ b/internal/api/module_metrics.go
@@ -70,3 +70,15 @@ func (m *MetricsModule) Init(ctx context.Context, registry *ServiceRegistry) err
 
 	return nil
 }
+
+func (m *MetricsModule) Shutdown(ctx context.Context) error {
+	if m.StopChan != nil {
+		close(m.StopChan)
+	}
+	if m.Server != nil {
+		if err := m.Server.Shutdown(ctx); err != nil {
+			log.Warn().Err(err).Msg("Failed to shutdown metrics server")
+		}
+	}
+	return nil
+}

--- a/internal/api/module_realtime.go
+++ b/internal/api/module_realtime.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/nimbleflux/fluxbase/internal/auth"
 	"github.com/nimbleflux/fluxbase/internal/logging"
 	"github.com/nimbleflux/fluxbase/internal/realtime"
@@ -79,7 +81,18 @@ func (m *RealtimeModule) Init(ctx context.Context, registry *ServiceRegistry) er
 	m.Monitor = monitoringHandler
 
 	registry.Register(realtimeManager)
-	registry.Register(realtimeHandler)
 	registry.Register(realtimeListener)
+	return nil
+}
+
+func (m *RealtimeModule) Shutdown(ctx context.Context) error {
+	if m.Listener != nil {
+		log.Info().Msg("Stopping realtime listener")
+		m.Listener.Stop()
+	}
+	if m.Manager != nil {
+		log.Info().Msg("Closing WebSocket connections")
+		m.Manager.Shutdown()
+	}
 	return nil
 }

--- a/internal/api/module_rpc.go
+++ b/internal/api/module_rpc.go
@@ -49,3 +49,13 @@ func (m *RPCModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		Msg("RPC components initialized")
 	return nil
 }
+
+func (m *RPCModule) Shutdown(ctx context.Context) error {
+	if m.Scheduler != nil {
+		m.Scheduler.Stop()
+	}
+	if m.Handler != nil {
+		m.Handler.GetExecutor().Stop()
+	}
+	return nil
+}

--- a/internal/api/module_schema.go
+++ b/internal/api/module_schema.go
@@ -62,3 +62,10 @@ func (m *SchemaModule) Init(ctx context.Context, registry *ServiceRegistry) erro
 	registry.Register(ddlHandler)
 	return nil
 }
+
+func (m *SchemaModule) Shutdown(ctx context.Context) error {
+	if m.Cache != nil {
+		m.Cache.Close()
+	}
+	return nil
+}

--- a/internal/api/module_secrets.go
+++ b/internal/api/module_secrets.go
@@ -17,6 +17,5 @@ func (m *SecretsModule) Init(ctx context.Context, registry *ServiceRegistry) err
 	m.Storage = secrets.NewStorage(registry.DB, registry.Config.EncryptionKeyBytes)
 	m.Handler = secrets.NewHandler(m.Storage)
 	registry.Register(m.Storage)
-	registry.Register(m.Handler)
 	return nil
 }

--- a/internal/api/module_storage.go
+++ b/internal/api/module_storage.go
@@ -37,8 +37,6 @@ func (m *StorageModule) Init(ctx context.Context, registry *ServiceRegistry) err
 
 	m.Handler = NewStorageHandler(storageManager, db, cfg, &cfg.Storage.Transforms)
 
-	registry.Register(storageManager)
 	registry.Register(m.Service)
-	registry.Register(m.Handler)
 	return nil
 }

--- a/internal/api/module_tenancy.go
+++ b/internal/api/module_tenancy.go
@@ -135,3 +135,10 @@ func (m *TenancyModule) Init(ctx context.Context, registry *ServiceRegistry) err
 	registry.Register(tenantStorage)
 	return nil
 }
+
+func (m *TenancyModule) Shutdown(ctx context.Context) error {
+	if m.Manager != nil && m.Manager.GetRouter() != nil {
+		m.Manager.GetRouter().Close()
+	}
+	return nil
+}

--- a/internal/api/module_webhook.go
+++ b/internal/api/module_webhook.go
@@ -29,6 +29,12 @@ func (m *WebhookModule) Init(ctx context.Context, registry *ServiceRegistry) err
 	m.Trigger = webhookTriggerService
 	m.Handler = NewWebhookHandler(webhookService)
 	registry.Register(webhookTriggerService)
-	registry.Register(m.Handler)
+	return nil
+}
+
+func (m *WebhookModule) Shutdown(ctx context.Context) error {
+	if m.Trigger != nil {
+		m.Trigger.Stop()
+	}
 	return nil
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -82,6 +82,7 @@ type Server struct {
 
 	// Service registry for module-based initialization
 	registry *ServiceRegistry
+	modules  []Module
 }
 
 // NewServer creates a new HTTP server
@@ -154,7 +155,7 @@ func NewServer(cfg *config.Config, db *database.Connection, version string) *Ser
 	metricsMod := &MetricsModule{Metrics: metricsObj, StartTime: metricsStart}
 	bgMod := &BackgroundServicesModule{}
 
-	if err := InitModules(context.Background(), s.registry, []Module{
+	mods := []Module{
 		emailMod,
 		secretsMod,
 		storageMod,
@@ -175,9 +176,12 @@ func NewServer(cfg *config.Config, db *database.Connection, version string) *Ser
 		mcpMod,
 		metricsMod,
 		bgMod,
-	}); err != nil {
+	}
+
+	if err := InitModules(context.Background(), s.registry, mods); err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize modules")
 	}
+	s.modules = mods
 
 	s.Secrets.Storage = secretsMod.Storage
 	s.Secrets.Handler = secretsMod.Handler
@@ -571,107 +575,16 @@ func (s *Server) Start() error {
 
 // Shutdown gracefully shuts down the server
 func (s *Server) Shutdown(ctx context.Context) error {
-	if s.Scaling.FunctionsLeader != nil {
-		log.Info().Msg("Stopping functions scheduler leader election")
-		s.Scaling.FunctionsLeader.Stop()
-	}
-	if s.Scaling.JobsLeader != nil {
-		log.Info().Msg("Stopping jobs scheduler leader election")
-		s.Scaling.JobsLeader.Stop()
-	}
-	if s.Scaling.RPCLeader != nil {
-		log.Info().Msg("Stopping RPC scheduler leader election")
-		s.Scaling.RPCLeader.Stop()
-	}
-
-	if s.Realtime.Listener != nil {
-		log.Info().Msg("Stopping realtime listener")
-		s.Realtime.Listener.Stop()
-	}
-
-	if s.Realtime.Manager != nil {
-		log.Info().Msg("Closing WebSocket connections")
-		s.Realtime.Manager.Shutdown()
-	}
-
-	if s.Functions.Scheduler != nil {
-		s.Functions.Scheduler.Stop()
-	}
-
-	if s.Jobs.Scheduler != nil {
-		s.Jobs.Scheduler.Stop()
-	}
-	if s.Jobs.Manager != nil {
-		s.Jobs.Manager.Stop()
-	}
-
-	if s.RPC.Scheduler != nil {
-		s.RPC.Scheduler.Stop()
-	}
-
-	if s.RPC.Handler != nil {
-		s.RPC.Handler.GetExecutor().Stop()
-	}
-
-	if s.Webhook.Trigger != nil {
-		s.Webhook.Trigger.Stop()
-	}
-
-	if s.AI.Conversations != nil {
-		s.AI.Conversations.Close()
-	}
+	ShutdownModules(ctx, s.modules)
 
 	if s.Middleware.Idempotency != nil {
 		s.Middleware.Idempotency.Stop()
-	}
-
-	if s.Auth.OAuth != nil {
-		s.Auth.OAuth.Stop()
-	}
-
-	if s.Branching.Scheduler != nil {
-		s.Branching.Scheduler.Stop()
-	}
-
-	if s.Branching.Router != nil {
-		log.Info().Msg("Closing branch connection pools")
-		s.Branching.Router.CloseAllPools()
-	}
-	if s.Branching.Manager != nil {
-		log.Info().Msg("Closing branch manager")
-		s.Branching.Manager.Close()
-	}
-
-	if s.Metrics.StopChan != nil {
-		close(s.Metrics.StopChan)
-	}
-
-	if s.Metrics.Server != nil {
-		if err := s.Metrics.Server.Shutdown(ctx); err != nil {
-			log.Warn().Err(err).Msg("Failed to shutdown metrics server")
-		}
 	}
 
 	if s.tracer != nil {
 		if err := s.tracer.Shutdown(ctx); err != nil {
 			log.Warn().Err(err).Msg("Failed to shutdown OpenTelemetry tracer")
 		}
-	}
-
-	if s.Logging.Retention != nil {
-		log.Info().Msg("Stopping log retention cleanup service")
-		s.Logging.Retention.Stop()
-	}
-
-	if s.Logging.Service != nil {
-		log.Info().Msg("Closing central logging service")
-		if err := s.Logging.Service.Close(); err != nil {
-			log.Warn().Err(err).Msg("Failed to close logging service")
-		}
-	}
-
-	if s.Schema.Cache != nil {
-		s.Schema.Cache.Close()
 	}
 
 	if s.pubSub != nil {


### PR DESCRIPTION
## Summary

- **WS1:** Add `Shutdowner` interface to the module system — 13 modules now own their own teardown, reducing `Server.Shutdown()` from 120 lines to ~25 lines of core infrastructure cleanup only. Modules shut down in reverse initialization order.
- **WS2:** Remove 10 dead `registry.Register()` calls for services never retrieved via `GetService`, including a `fiber.Handler` overwrite bug where `OptionalAuth` silently overwrote `RequireAuth`.
- **WS3:** Update CLAUDE.md — fix module count (19→20), update dependency chain, fix stale file descriptions, document `Shutdowner` and two-phase wiring, remove dead reference.

## Changes

### WS1: Shutdowner Interface
- New `Shutdowner` interface in `module.go` with `Shutdown(ctx context.Context) error`
- `ShutdownModules()` helper iterates modules in reverse order
- `Server` stores module slice for lifecycle management
- 13 modules implement `Shutdown()`: BackgroundServices, Realtime, Functions, Jobs, RPC, Webhook, AI, Auth, Branching, Metrics, Logging, Schema, Tenancy
- `Server.Shutdown()` now only handles core infra (idempotency, tracer, pubsub, rate limiter, HTTP server)

### WS2: Dead Registration Cleanup
- Removed registrations that were never retrieved via `GetService`: `email.Service`, `*secrets.Handler`, `*extensions.Handler`, `*WebhookHandler`, `*StorageHandler`, `*AuthHandlers`, `*SQLHandler`, `*ai.Storage`, `*GraphQLHandler`, `*realtime.RealtimeHandler`, `*jobs.Handler`, `*storage.Manager`
- Fixed `fiber.Handler` double-registration in `module_auth.go` (RequireAuth was silently overwritten by OptionalAuth)

### WS3: Documentation
- Module count: 19 → 20 (added BackgroundServicesModule)
- Updated dependency chain with all 20 modules
- Fixed `server_init.go` description (setupMiddlewares/setupRoutes moved to separate files)
- Added `RateLimiter` to ServiceRegistry description
- Documented `Shutdowner` interface and reverse-order teardown
- Documented two-phase wiring pattern explicitly
- Removed stale `IMPLEMENTATION_ANALYSIS.md` reference

## Note for Future PR

The 91-line manual wiring bridge (copying module outputs to Server fields) and side-mutation patterns (settings/metrics modules reaching into other services post-init) are deferred to a separate PR due to higher risk.