### PR TITLE
refactor: eliminate wiring bridge — modules own their handler groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Server initialization uses a module-based dependency injection system:
 - `GetService[T]()` uses `reflect.TypeOf` — only works with concrete pointer types (e.g., `*auth.Service`), not interfaces. Use `registry.PubSub` field for `pubsub.PubSub`
 - Modules register outputs via `registry.Register()` so downstream modules can find them
 
-**Two-phase wiring:** After `InitModules()` completes, `NewServer()` copies module outputs to `Server` struct fields (handler groups). This bridge is manual boilerplate — each new sub-handler requires both a module field and a Server field assignment.
+**Handler group wiring:** Each module creates its handler group struct during `Init()` and stores it in `m.Handlers`. After `InitModules()`, `NewServer()` assigns `s.X = xMod.Handlers` for each module (~20 lines). Modules with cross-group outputs (Settings→Email/Captcha, AI→Quota, Realtime→Monitoring, Tenancy→Middleware) populate additional handler groups. A few modules have direct Server fields (Auth→`sqlHandler`/`requireAuth`/`optionalAuth`, Schema→`rest`).
 
 **Key files:** `module.go` (interface + registry), `module_*.go` (one per module), `server.go` (wiring + Shutdown), `server_init.go` (initCore), `server_middlewares.go` (middleware setup), `server_routes.go` (route setup)
 

--- a/internal/api/handler_groups.go
+++ b/internal/api/handler_groups.go
@@ -207,6 +207,5 @@ type QuotaHandlers struct {
 type MiddlewareComponents struct {
 	Tenant      fiber.Handler
 	TenantDB    fiber.Handler
-	Branch      fiber.Handler
 	Idempotency *middleware.IdempotencyMiddleware
 }

--- a/internal/api/module_ai.go
+++ b/internal/api/module_ai.go
@@ -15,18 +15,8 @@ import (
 )
 
 type AIModule struct {
-	Handler         *ai.Handler
-	Chat            *ai.ChatHandler
-	Conversations   *ai.ConversationManager
-	Metrics         *observability.Metrics
-	KnowledgeBase   *ai.KnowledgeBaseHandler
-	KBStorage       *ai.KnowledgeBaseStorage
-	DocProcessor    *ai.DocumentProcessor
-	TableExportSync *ai.TableExportSyncService
-	VectorManager   *VectorManager
-	VectorHandler   *VectorHandler
-	Internal        *InternalAIHandler
-	QuotaHandler    *QuotaHandler
+	Handlers *AIHandlers
+	Quota    *QuotaHandlers
 }
 
 func (m *AIModule) Name() string { return "ai" }
@@ -178,18 +168,20 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 			Msg("Internal AI handler initialized for MCP tools/functions/jobs")
 	}
 
-	m.Handler = aiHandler
-	m.Chat = aiChatHandler
-	m.Conversations = aiConversations
-	m.Metrics = aiMetrics
-	m.KnowledgeBase = knowledgeBaseHandler
-	m.KBStorage = kbStorage
-	m.DocProcessor = docProcessor
-	m.TableExportSync = tableExportSyncService
-	m.VectorManager = vectorManager
-	m.VectorHandler = vectorHandler
-	m.Internal = internalAIHandler
-	m.QuotaHandler = quotaHandler
+	m.Handlers = &AIHandlers{
+		Handler:         aiHandler,
+		Chat:            aiChatHandler,
+		Conversations:   aiConversations,
+		Metrics:         aiMetrics,
+		KnowledgeBase:   knowledgeBaseHandler,
+		KBStorage:       kbStorage,
+		DocProcessor:    docProcessor,
+		TableExportSync: tableExportSyncService,
+		VectorManager:   vectorManager,
+		VectorHandler:   vectorHandler,
+		Internal:        internalAIHandler,
+	}
+	m.Quota = &QuotaHandlers{Handler: quotaHandler}
 
 	if cfg.AI.Enabled && cfg.AI.AutoLoadOnBoot && aiHandler != nil {
 		if err := aiHandler.AutoLoadChatbots(ctx); err != nil {
@@ -212,8 +204,8 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 }
 
 func (m *AIModule) Shutdown(ctx context.Context) error {
-	if m.Conversations != nil {
-		m.Conversations.Close()
+	if m.Handlers != nil && m.Handlers.Conversations != nil {
+		m.Handlers.Conversations.Close()
 	}
 	return nil
 }

--- a/internal/api/module_background.go
+++ b/internal/api/module_background.go
@@ -15,9 +15,7 @@ import (
 )
 
 type BackgroundServicesModule struct {
-	FunctionsLeader *scaling.LeaderElector
-	JobsLeader      *scaling.LeaderElector
-	RPCLeader       *scaling.LeaderElector
+	Handlers *ScalingHandlers
 }
 
 func (m *BackgroundServicesModule) Name() string { return "background-services" }
@@ -42,7 +40,8 @@ func (m *BackgroundServicesModule) Init(ctx context.Context, registry *ServiceRe
 
 	functionsScheduler := GetService[*functions.Scheduler](registry)
 	if functionsScheduler != nil {
-		m.FunctionsLeader = leaderElect(
+		m.Handlers = &ScalingHandlers{}
+		m.Handlers.FunctionsLeader = leaderElect(
 			db, &cfg.Scaling,
 			"functions-scheduler", scaling.FunctionsSchedulerLockID,
 			func() {
@@ -73,7 +72,7 @@ func (m *BackgroundServicesModule) Init(ctx context.Context, registry *ServiceRe
 
 		jobsScheduler := GetService[*jobs.Scheduler](registry)
 		if jobsScheduler != nil {
-			m.JobsLeader = leaderElect(
+			m.Handlers.JobsLeader = leaderElect(
 				db, &cfg.Scaling,
 				"jobs-scheduler", scaling.JobsSchedulerLockID,
 				func() {
@@ -92,7 +91,7 @@ func (m *BackgroundServicesModule) Init(ctx context.Context, registry *ServiceRe
 
 	rpcScheduler := GetService[*rpc.Scheduler](registry)
 	if cfg.RPC.Enabled && rpcScheduler != nil {
-		m.RPCLeader = leaderElect(
+		m.Handlers.RPCLeader = leaderElect(
 			db, &cfg.Scaling,
 			"rpc-scheduler", scaling.RPCSchedulerLockID,
 			func() {
@@ -129,17 +128,20 @@ func leaderElect(db *database.Connection, cfg *config.ScalingConfig, name string
 }
 
 func (m *BackgroundServicesModule) Shutdown(ctx context.Context) error {
-	if m.FunctionsLeader != nil {
+	if m.Handlers == nil {
+		return nil
+	}
+	if m.Handlers.FunctionsLeader != nil {
 		log.Info().Msg("Stopping functions scheduler leader election")
-		m.FunctionsLeader.Stop()
+		m.Handlers.FunctionsLeader.Stop()
 	}
-	if m.JobsLeader != nil {
+	if m.Handlers.JobsLeader != nil {
 		log.Info().Msg("Stopping jobs scheduler leader election")
-		m.JobsLeader.Stop()
+		m.Handlers.JobsLeader.Stop()
 	}
-	if m.RPCLeader != nil {
+	if m.Handlers.RPCLeader != nil {
 		log.Info().Msg("Stopping RPC scheduler leader election")
-		m.RPCLeader.Stop()
+		m.Handlers.RPCLeader.Stop()
 	}
 	return nil
 }

--- a/internal/api/module_branching.go
+++ b/internal/api/module_branching.go
@@ -13,11 +13,7 @@ import (
 )
 
 type BranchingModule struct {
-	Manager   *branching.Manager
-	Router    *branching.Router
-	Handler   *BranchHandler
-	GitHub    *GitHubWebhookHandler
-	Scheduler *branching.CleanupScheduler
+	Handlers *BranchingHandlers
 }
 
 func (m *BranchingModule) Name() string { return "branching" }
@@ -38,10 +34,11 @@ func (m *BranchingModule) Init(ctx context.Context, registry *ServiceRegistry) e
 	}
 	branchRouter := branching.NewRouter(branchStorage, cfg.Branching, db.Pool(), dbURL)
 
-	m.Manager = branchManager
-	m.Router = branchRouter
-	m.Handler = NewBranchHandler(branchManager, branchRouter, cfg.Branching)
-	m.GitHub = NewGitHubWebhookHandler(branchManager, branchRouter, cfg.Branching)
+	m.Handlers = &BranchingHandlers{}
+	m.Handlers.Manager = branchManager
+	m.Handlers.Router = branchRouter
+	m.Handlers.Handler = NewBranchHandler(branchManager, branchRouter, cfg.Branching)
+	m.Handlers.GitHub = NewGitHubWebhookHandler(branchManager, branchRouter, cfg.Branching)
 
 	tenantManager := GetService[*tenantdb.Manager](registry)
 	if tenantManager != nil {
@@ -54,7 +51,7 @@ func (m *BranchingModule) Init(ctx context.Context, registry *ServiceRegistry) e
 		if cleanupInterval < time.Hour {
 			cleanupInterval = time.Hour
 		}
-		m.Scheduler = branching.NewCleanupScheduler(branchManager, branchRouter, cleanupInterval)
+		m.Handlers.Scheduler = branching.NewCleanupScheduler(branchManager, branchRouter, cleanupInterval)
 		log.Info().
 			Dur("interval", cleanupInterval).
 			Dur("auto_delete_after", cfg.Branching.AutoDeleteAfter).
@@ -99,16 +96,19 @@ func (r *branchFDWRepairer) RepairFDWForBranch(ctx context.Context, branchDBURL 
 }
 
 func (m *BranchingModule) Shutdown(ctx context.Context) error {
-	if m.Scheduler != nil {
-		m.Scheduler.Stop()
+	if m.Handlers == nil {
+		return nil
 	}
-	if m.Router != nil {
+	if m.Handlers.Scheduler != nil {
+		m.Handlers.Scheduler.Stop()
+	}
+	if m.Handlers.Router != nil {
 		log.Info().Msg("Closing branch connection pools")
-		m.Router.CloseAllPools()
+		m.Handlers.Router.CloseAllPools()
 	}
-	if m.Manager != nil {
+	if m.Handlers.Manager != nil {
 		log.Info().Msg("Closing branch manager")
-		m.Manager.Close()
+		m.Handlers.Manager.Close()
 	}
 	return nil
 }

--- a/internal/api/module_branching.go
+++ b/internal/api/module_branching.go
@@ -19,6 +19,7 @@ type BranchingModule struct {
 func (m *BranchingModule) Name() string { return "branching" }
 
 func (m *BranchingModule) Init(ctx context.Context, registry *ServiceRegistry) error {
+	m.Handlers = &BranchingHandlers{}
 	cfg := registry.Config
 	db := registry.DB
 

--- a/internal/api/module_extensions.go
+++ b/internal/api/module_extensions.go
@@ -7,12 +7,12 @@ import (
 )
 
 type ExtensionsModule struct {
-	Handler *extensions.Handler
+	Handlers *ExtensionsHandlers
 }
 
 func (m *ExtensionsModule) Name() string { return "extensions" }
 
 func (m *ExtensionsModule) Init(ctx context.Context, registry *ServiceRegistry) error {
-	m.Handler = extensions.NewHandler(extensions.NewService(registry.DB))
+	m.Handlers.Handler = extensions.NewHandler(extensions.NewService(registry.DB))
 	return nil
 }

--- a/internal/api/module_extensions.go
+++ b/internal/api/module_extensions.go
@@ -13,6 +13,7 @@ type ExtensionsModule struct {
 func (m *ExtensionsModule) Name() string { return "extensions" }
 
 func (m *ExtensionsModule) Init(ctx context.Context, registry *ServiceRegistry) error {
+	m.Handlers = &ExtensionsHandlers{}
 	m.Handlers.Handler = extensions.NewHandler(extensions.NewService(registry.DB))
 	return nil
 }

--- a/internal/api/module_functions.go
+++ b/internal/api/module_functions.go
@@ -11,8 +11,7 @@ import (
 )
 
 type FunctionsModule struct {
-	Handler   *functions.Handler
-	Scheduler *functions.Scheduler
+	Handlers *FunctionsHandlers
 }
 
 func (m *FunctionsModule) Name() string { return "functions" }
@@ -44,8 +43,10 @@ func (m *FunctionsModule) Init(ctx context.Context, registry *ServiceRegistry) e
 		functionsHandler.SetRateLimiter(registry.RateLimiter)
 	}
 
-	m.Handler = functionsHandler
-	m.Scheduler = functionsScheduler
+	m.Handlers = &FunctionsHandlers{
+		Handler:   functionsHandler,
+		Scheduler: functionsScheduler,
+	}
 
 	registry.Register(functionsHandler)
 	registry.Register(functionsScheduler)
@@ -53,8 +54,8 @@ func (m *FunctionsModule) Init(ctx context.Context, registry *ServiceRegistry) e
 }
 
 func (m *FunctionsModule) Shutdown(ctx context.Context) error {
-	if m.Scheduler != nil {
-		m.Scheduler.Stop()
+	if m.Handlers != nil && m.Handlers.Scheduler != nil {
+		m.Handlers.Scheduler.Stop()
 	}
 	return nil
 }

--- a/internal/api/module_graphql.go
+++ b/internal/api/module_graphql.go
@@ -15,6 +15,7 @@ type GraphQLModule struct {
 func (m *GraphQLModule) Name() string { return "graphql" }
 
 func (m *GraphQLModule) Init(ctx context.Context, registry *ServiceRegistry) error {
+	m.Handlers = &GraphQLHandlers{}
 	cfg := registry.Config
 	db := registry.DB
 

--- a/internal/api/module_graphql.go
+++ b/internal/api/module_graphql.go
@@ -9,7 +9,7 @@ import (
 )
 
 type GraphQLModule struct {
-	Handler *GraphQLHandler
+	Handlers *GraphQLHandlers
 }
 
 func (m *GraphQLModule) Name() string { return "graphql" }
@@ -24,11 +24,11 @@ func (m *GraphQLModule) Init(ctx context.Context, registry *ServiceRegistry) err
 
 	schemaCache := GetService[*database.SchemaCache](registry)
 
-	m.Handler = NewGraphQLHandler(db, schemaCache, &cfg.GraphQL, cfg)
+	m.Handlers.Handler = NewGraphQLHandler(db, schemaCache, &cfg.GraphQL, cfg)
 
 	ddlHandler := GetService[*DDLHandler](registry)
-	if ddlHandler != nil && m.Handler != nil {
-		ddlHandler.SetGraphQLInvalidator(m.Handler.InvalidateSchema)
+	if ddlHandler != nil && m.Handlers.Handler != nil {
+		ddlHandler.SetGraphQLInvalidator(m.Handlers.Handler.InvalidateSchema)
 	}
 
 	log.Info().

--- a/internal/api/module_jobs.go
+++ b/internal/api/module_jobs.go
@@ -19,6 +19,7 @@ type JobsModule struct {
 func (m *JobsModule) Name() string { return "jobs" }
 
 func (m *JobsModule) Init(ctx context.Context, registry *ServiceRegistry) error {
+	m.Handlers = &JobsHandlers{}
 	cfg := registry.Config
 	db := registry.DB
 

--- a/internal/api/module_jobs.go
+++ b/internal/api/module_jobs.go
@@ -13,9 +13,7 @@ import (
 )
 
 type JobsModule struct {
-	Manager   *jobs.Manager
-	Handler   *jobs.Handler
-	Scheduler *jobs.Scheduler
+	Handlers *JobsHandlers
 }
 
 func (m *JobsModule) Name() string { return "jobs" }
@@ -46,17 +44,19 @@ func (m *JobsModule) Init(ctx context.Context, registry *ServiceRegistry) error 
 	if settingsSecrets != nil {
 		jobsManager.SetSettingsSecretsService(settingsSecrets)
 	}
-	m.Manager = jobsManager
-
 	jobsHandler, err := jobs.NewHandler(db, &cfg.Jobs, jobsManager, authService, loggingService, cfg.Deno.NpmRegistry, cfg.Deno.JsrRegistry)
 	if err != nil {
 		return err
 	}
-	m.Handler = jobsHandler
 
 	jobsScheduler := jobs.NewScheduler(db)
 	jobsHandler.SetScheduler(jobsScheduler)
-	m.Scheduler = jobsScheduler
+
+	m.Handlers = &JobsHandlers{
+		Manager:   jobsManager,
+		Handler:   jobsHandler,
+		Scheduler: jobsScheduler,
+	}
 
 	registry.Register(jobsManager)
 	registry.Register(jobsScheduler)
@@ -64,11 +64,13 @@ func (m *JobsModule) Init(ctx context.Context, registry *ServiceRegistry) error 
 }
 
 func (m *JobsModule) Shutdown(ctx context.Context) error {
-	if m.Scheduler != nil {
-		m.Scheduler.Stop()
-	}
-	if m.Manager != nil {
-		m.Manager.Stop()
+	if m.Handlers != nil {
+		if m.Handlers.Scheduler != nil {
+			m.Handlers.Scheduler.Stop()
+		}
+		if m.Handlers.Manager != nil {
+			m.Handlers.Manager.Stop()
+		}
 	}
 	return nil
 }

--- a/internal/api/module_logging.go
+++ b/internal/api/module_logging.go
@@ -10,9 +10,7 @@ import (
 )
 
 type LoggingModule struct {
-	Service   *logging.Service
-	Handler   *LoggingHandler
-	Retention *logging.RetentionService
+	Handlers *LoggingHandlers
 }
 
 func (m *LoggingModule) Name() string { return "logging" }
@@ -36,7 +34,7 @@ func (m *LoggingModule) Init(ctx context.Context, registry *ServiceRegistry) err
 		log.Warn().Err(err).Msg("Failed to initialize central logging service, continuing with default logging")
 		return nil
 	}
-	m.Service = loggingService
+	m.Handlers.Service = loggingService
 
 	log.Logger = log.Output(loggingService.Writer())
 	log.Info().
@@ -45,10 +43,10 @@ func (m *LoggingModule) Init(ctx context.Context, registry *ServiceRegistry) err
 		Int("batch_size", cfg.Logging.BatchSize).
 		Msg("Central logging service initialized")
 
-	m.Handler = NewLoggingHandler(loggingService)
+	m.Handlers.Handler = NewLoggingHandler(loggingService)
 
 	if cfg.Logging.RetentionEnabled {
-		m.Retention = logging.NewRetentionService(&cfg.Logging, loggingService.Storage())
+		m.Handlers.Retention = logging.NewRetentionService(&cfg.Logging, loggingService.Storage())
 	}
 
 	registry.Register(loggingService)
@@ -56,13 +54,13 @@ func (m *LoggingModule) Init(ctx context.Context, registry *ServiceRegistry) err
 }
 
 func (m *LoggingModule) Shutdown(ctx context.Context) error {
-	if m.Retention != nil {
+	if m.Handlers.Retention != nil {
 		log.Info().Msg("Stopping log retention cleanup service")
-		m.Retention.Stop()
+		m.Handlers.Retention.Stop()
 	}
-	if m.Service != nil {
+	if m.Handlers.Service != nil {
 		log.Info().Msg("Closing central logging service")
-		if err := m.Service.Close(); err != nil {
+		if err := m.Handlers.Service.Close(); err != nil {
 			log.Warn().Err(err).Msg("Failed to close logging service")
 		}
 	}

--- a/internal/api/module_logging.go
+++ b/internal/api/module_logging.go
@@ -16,6 +16,7 @@ type LoggingModule struct {
 func (m *LoggingModule) Name() string { return "logging" }
 
 func (m *LoggingModule) Init(ctx context.Context, registry *ServiceRegistry) error {
+	m.Handlers = &LoggingHandlers{}
 	cfg := registry.Config
 	db := registry.DB
 

--- a/internal/api/module_mcp.go
+++ b/internal/api/module_mcp.go
@@ -22,10 +22,7 @@ import (
 )
 
 type MCPModule struct {
-	Handler       *mcp.Handler
-	OAuth         *MCPOAuthHandler
-	CustomManager *custom.Manager
-	CustomHandler *CustomMCPHandler
+	Handlers *MCPHandlers
 }
 
 func (m *MCPModule) Name() string { return "mcp" }
@@ -36,8 +33,9 @@ func (m *MCPModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 
 	authService := GetService[*auth.Service](registry)
 
-	m.Handler = mcp.NewHandler(&cfg.MCP, db)
-	m.OAuth = NewMCPOAuthHandler(db, &cfg.MCP, authService, cfg.BaseURL, cfg.GetPublicBaseURL())
+	m.Handlers = &MCPHandlers{}
+	m.Handlers.Handler = mcp.NewHandler(&cfg.MCP, db)
+	m.Handlers.OAuth = NewMCPOAuthHandler(db, &cfg.MCP, authService, cfg.BaseURL, cfg.GetPublicBaseURL())
 
 	if !cfg.MCP.Enabled {
 		return nil
@@ -54,7 +52,7 @@ func (m *MCPModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		vectorHandler = vh
 	}
 
-	mcpServer := m.Handler.Server()
+	mcpServer := m.Handlers.Handler.Server()
 	toolRegistry := mcpServer.ToolRegistry()
 
 	toolRegistry.Register(mcptools.NewThinkTool())
@@ -195,12 +193,12 @@ func (m *MCPModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		mcpInternalURL = "http://localhost" + cfg.Server.Address
 	}
 	customExecutor := custom.NewExecutor(cfg.Auth.JWTSecret, mcpInternalURL, nil)
-	m.CustomManager = custom.NewManager(customStorage, customExecutor, toolRegistry, resourceRegistry)
-	m.CustomHandler = NewCustomMCPHandler(customStorage, m.CustomManager, &cfg.MCP)
+	m.Handlers.CustomManager = custom.NewManager(customStorage, customExecutor, toolRegistry, resourceRegistry)
+	m.Handlers.CustomHandler = NewCustomMCPHandler(customStorage, m.Handlers.CustomManager, &cfg.MCP)
 
 	loadCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := m.CustomManager.LoadAndRegisterAll(loadCtx); err != nil {
+	if err := m.Handlers.CustomManager.LoadAndRegisterAll(loadCtx); err != nil {
 		log.Warn().Err(err).Msg("Failed to load some custom MCP tools/resources")
 	}
 
@@ -209,8 +207,8 @@ func (m *MCPModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		Int("resources", len(resourceRegistry.ListResources(&mcp.AuthContext{IsServiceRole: true}))).
 		Msg("MCP Server initialized with tools and resources")
 
-	if cfg.MCP.Enabled && cfg.MCP.AutoLoadOnBoot && m.CustomManager != nil {
-		if err := m.CustomManager.AutoLoadFromDir(context.Background(), cfg.MCP.ToolsDir); err != nil {
+	if cfg.MCP.Enabled && cfg.MCP.AutoLoadOnBoot && m.Handlers.CustomManager != nil {
+		if err := m.Handlers.CustomManager.AutoLoadFromDir(context.Background(), cfg.MCP.ToolsDir); err != nil {
 			log.Error().Err(err).Msg("Failed to auto-load custom MCP tools")
 		} else {
 			log.Info().Msg("Custom MCP tools auto-loaded successfully")

--- a/internal/api/module_metrics.go
+++ b/internal/api/module_metrics.go
@@ -14,10 +14,7 @@ import (
 )
 
 type MetricsModule struct {
-	Metrics   *observability.Metrics
-	Server    *observability.MetricsServer
-	StopChan  chan struct{}
-	StartTime time.Time
+	Handlers *MetricsComponents
 }
 
 func (m *MetricsModule) Name() string { return "metrics" }
@@ -30,39 +27,39 @@ func (m *MetricsModule) Init(ctx context.Context, registry *ServiceRegistry) err
 		return nil
 	}
 
-	m.Server = observability.NewMetricsServer(cfg.Metrics.Port, cfg.Metrics.Path)
-	if err := m.Server.Start(); err != nil {
+	m.Handlers.Server = observability.NewMetricsServer(cfg.Metrics.Port, cfg.Metrics.Path)
+	if err := m.Handlers.Server.Start(); err != nil {
 		log.Error().Err(err).Msg("Failed to start metrics server")
 	}
 
-	db.SetMetrics(m.Metrics)
+	db.SetMetrics(m.Handlers.Metrics)
 
 	storageSvc := GetService[*storage.Service](registry)
 	if storageSvc != nil {
-		storageSvc.SetMetrics(m.Metrics)
+		storageSvc.SetMetrics(m.Handlers.Metrics)
 	}
 
 	authService := GetService[*auth.Service](registry)
 	if authService != nil {
-		authService.SetMetrics(m.Metrics)
+		authService.SetMetrics(m.Handlers.Metrics)
 	}
 
 	realtimeManager := GetService[*realtime.Manager](registry)
 	if realtimeManager != nil {
-		realtimeManager.SetMetrics(m.Metrics)
+		realtimeManager.SetMetrics(m.Handlers.Metrics)
 	}
 
-	middleware.SetRateLimiterMetrics(m.Metrics)
+	middleware.SetRateLimiterMetrics(m.Handlers.Metrics)
 
-	m.StopChan = make(chan struct{})
+	m.Handlers.StopChan = make(chan struct{})
 	go func() {
 		ticker := time.NewTicker(15 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				m.Metrics.UpdateUptime(m.StartTime)
-			case <-m.StopChan:
+				m.Handlers.Metrics.UpdateUptime(m.Handlers.StartTime)
+			case <-m.Handlers.StopChan:
 				return
 			}
 		}
@@ -72,12 +69,14 @@ func (m *MetricsModule) Init(ctx context.Context, registry *ServiceRegistry) err
 }
 
 func (m *MetricsModule) Shutdown(ctx context.Context) error {
-	if m.StopChan != nil {
-		close(m.StopChan)
-	}
-	if m.Server != nil {
-		if err := m.Server.Shutdown(ctx); err != nil {
-			log.Warn().Err(err).Msg("Failed to shutdown metrics server")
+	if m.Handlers != nil {
+		if m.Handlers.StopChan != nil {
+			close(m.Handlers.StopChan)
+		}
+		if m.Handlers.Server != nil {
+			if err := m.Handlers.Server.Shutdown(ctx); err != nil {
+				log.Warn().Err(err).Msg("Failed to shutdown metrics server")
+			}
 		}
 	}
 	return nil

--- a/internal/api/module_realtime.go
+++ b/internal/api/module_realtime.go
@@ -12,11 +12,8 @@ import (
 )
 
 type RealtimeModule struct {
-	Admin    *RealtimeAdminHandler
-	Manager  *realtime.Manager
-	Handler  *realtime.RealtimeHandler
-	Listener *realtime.ListenerPool
-	Monitor  *MonitoringHandler
+	Handlers   *RealtimeHandlers
+	Monitoring *MonitoringHandlers
 }
 
 func (m *RealtimeModule) Name() string { return "realtime" }
@@ -25,7 +22,8 @@ func (m *RealtimeModule) Init(ctx context.Context, registry *ServiceRegistry) er
 	cfg := registry.Config
 	db := registry.DB
 
-	m.Admin = NewRealtimeAdminHandler(db)
+	m.Handlers = &RealtimeHandlers{}
+	m.Handlers.Admin = NewRealtimeAdminHandler(db)
 
 	realtimeManager := realtime.NewManagerWithConfig(ctx, realtime.ManagerConfig{
 		MaxConnections:         cfg.Realtime.MaxConnections,
@@ -63,9 +61,9 @@ func (m *RealtimeModule) Init(ctx context.Context, registry *ServiceRegistry) er
 		},
 	)
 
-	m.Manager = realtimeManager
-	m.Handler = realtimeHandler
-	m.Listener = realtimeListener
+	m.Handlers.Manager = realtimeManager
+	m.Handlers.Handler = realtimeHandler
+	m.Handlers.Listener = realtimeListener
 
 	storageSvc := GetService[*storage.Service](registry)
 	var storageProvider storage.Provider
@@ -78,7 +76,7 @@ func (m *RealtimeModule) Init(ctx context.Context, registry *ServiceRegistry) er
 	if loggingSvc != nil {
 		monitoringHandler.SetLoggingService(loggingSvc)
 	}
-	m.Monitor = monitoringHandler
+	m.Monitoring = &MonitoringHandlers{Handler: monitoringHandler}
 
 	registry.Register(realtimeManager)
 	registry.Register(realtimeListener)
@@ -86,13 +84,15 @@ func (m *RealtimeModule) Init(ctx context.Context, registry *ServiceRegistry) er
 }
 
 func (m *RealtimeModule) Shutdown(ctx context.Context) error {
-	if m.Listener != nil {
-		log.Info().Msg("Stopping realtime listener")
-		m.Listener.Stop()
-	}
-	if m.Manager != nil {
-		log.Info().Msg("Closing WebSocket connections")
-		m.Manager.Shutdown()
+	if m.Handlers != nil {
+		if m.Handlers.Listener != nil {
+			log.Info().Msg("Stopping realtime listener")
+			m.Handlers.Listener.Stop()
+		}
+		if m.Handlers.Manager != nil {
+			log.Info().Msg("Closing WebSocket connections")
+			m.Handlers.Manager.Shutdown()
+		}
 	}
 	return nil
 }

--- a/internal/api/module_rpc.go
+++ b/internal/api/module_rpc.go
@@ -18,6 +18,7 @@ type RPCModule struct {
 func (m *RPCModule) Name() string { return "rpc" }
 
 func (m *RPCModule) Init(ctx context.Context, registry *ServiceRegistry) error {
+	m.Handlers = &RPCHandlers{}
 	cfg := registry.Config
 	db := registry.DB
 

--- a/internal/api/module_rpc.go
+++ b/internal/api/module_rpc.go
@@ -12,8 +12,7 @@ import (
 )
 
 type RPCModule struct {
-	Handler   *rpc.Handler
-	Scheduler *rpc.Scheduler
+	Handlers *RPCHandlers
 }
 
 func (m *RPCModule) Name() string { return "rpc" }
@@ -37,8 +36,10 @@ func (m *RPCModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 	rpcScheduler := rpc.NewScheduler(rpcStorage, rpcHandler.GetExecutor())
 	rpcHandler.SetScheduler(rpcScheduler)
 
-	m.Handler = rpcHandler
-	m.Scheduler = rpcScheduler
+	m.Handlers = &RPCHandlers{
+		Handler:   rpcHandler,
+		Scheduler: rpcScheduler,
+	}
 
 	registry.Register(rpcHandler)
 	registry.Register(rpcScheduler)
@@ -51,11 +52,13 @@ func (m *RPCModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 }
 
 func (m *RPCModule) Shutdown(ctx context.Context) error {
-	if m.Scheduler != nil {
-		m.Scheduler.Stop()
-	}
-	if m.Handler != nil {
-		m.Handler.GetExecutor().Stop()
+	if m.Handlers != nil {
+		if m.Handlers.Scheduler != nil {
+			m.Handlers.Scheduler.Stop()
+		}
+		if m.Handlers.Handler != nil {
+			m.Handlers.Handler.GetExecutor().Stop()
+		}
 	}
 	return nil
 }

--- a/internal/api/module_schema.go
+++ b/internal/api/module_schema.go
@@ -12,11 +12,7 @@ import (
 )
 
 type SchemaModule struct {
-	DDL         *DDLHandler
-	Cache       *database.SchemaCache
-	Migrations  *migrations.Handler
-	Export      *SchemaExportHandler
-	Internal    *InternalSchemaHandler
+	Handlers    *SchemaHandlers
 	RESTHandler *RESTHandler
 }
 
@@ -26,8 +22,9 @@ func (m *SchemaModule) Init(ctx context.Context, registry *ServiceRegistry) erro
 	cfg := registry.Config
 	db := registry.DB
 
+	m.Handlers = &SchemaHandlers{}
 	ddlHandler := NewDDLHandler(db, nil)
-	m.DDL = ddlHandler
+	m.Handlers.DDL = ddlHandler
 
 	schemaCache := database.NewSchemaCache(db.Inspector(), 5*time.Minute)
 	if registry.PubSub != nil {
@@ -39,7 +36,7 @@ func (m *SchemaModule) Init(ctx context.Context, registry *ServiceRegistry) erro
 	} else {
 		log.Info().Int("tables", schemaCache.TableCount()).Int("views", schemaCache.ViewCount()).Msg("Schema cache populated")
 	}
-	m.Cache = schemaCache
+	m.Handlers.Cache = schemaCache
 	ddlHandler.SetSchemaCache(schemaCache)
 
 	migrationsHandler := migrations.NewHandler(db, schemaCache)
@@ -47,13 +44,13 @@ func (m *SchemaModule) Init(ctx context.Context, registry *ServiceRegistry) erro
 	if tenantManager != nil && tenantManager.GetRouter() != nil {
 		migrationsHandler.SetTenantPoolProvider(tenantManager.GetRouter())
 	}
-	m.Migrations = migrationsHandler
+	m.Handlers.Migrations = migrationsHandler
 
-	m.Export = NewSchemaExportHandler(schemaCache, db.Inspector())
+	m.Handlers.Export = NewSchemaExportHandler(schemaCache, db.Inspector())
 
 	internalSchemaHandler := NewInternalSchemaHandler()
 	internalSchemaHandler.Initialize(cfg, db)
-	m.Internal = internalSchemaHandler
+	m.Handlers.InternalSchema = internalSchemaHandler
 	log.Info().Msg("Internal schema handler initialized")
 
 	m.RESTHandler = NewRESTHandler(db, NewQueryParser(cfg), schemaCache, cfg)
@@ -64,8 +61,8 @@ func (m *SchemaModule) Init(ctx context.Context, registry *ServiceRegistry) erro
 }
 
 func (m *SchemaModule) Shutdown(ctx context.Context) error {
-	if m.Cache != nil {
-		m.Cache.Close()
+	if m.Handlers != nil && m.Handlers.Cache != nil {
+		m.Handlers.Cache.Close()
 	}
 	return nil
 }

--- a/internal/api/module_secrets.go
+++ b/internal/api/module_secrets.go
@@ -7,15 +7,14 @@ import (
 )
 
 type SecretsModule struct {
-	Storage *secrets.Storage
-	Handler *secrets.Handler
+	Handlers *SecretsHandlers
 }
 
 func (m *SecretsModule) Name() string { return "secrets" }
 
 func (m *SecretsModule) Init(ctx context.Context, registry *ServiceRegistry) error {
-	m.Storage = secrets.NewStorage(registry.DB, registry.Config.EncryptionKeyBytes)
-	m.Handler = secrets.NewHandler(m.Storage)
-	registry.Register(m.Storage)
+	m.Handlers.Storage = secrets.NewStorage(registry.DB, registry.Config.EncryptionKeyBytes)
+	m.Handlers.Handler = secrets.NewHandler(m.Handlers.Storage)
+	registry.Register(m.Handlers.Storage)
 	return nil
 }

--- a/internal/api/module_secrets.go
+++ b/internal/api/module_secrets.go
@@ -13,6 +13,7 @@ type SecretsModule struct {
 func (m *SecretsModule) Name() string { return "secrets" }
 
 func (m *SecretsModule) Init(ctx context.Context, registry *ServiceRegistry) error {
+	m.Handlers = &SecretsHandlers{}
 	m.Handlers.Storage = secrets.NewStorage(registry.DB, registry.Config.EncryptionKeyBytes)
 	m.Handlers.Handler = secrets.NewHandler(m.Handlers.Storage)
 	registry.Register(m.Handlers.Storage)

--- a/internal/api/module_settings.go
+++ b/internal/api/module_settings.go
@@ -12,18 +12,9 @@ import (
 )
 
 type SettingsModule struct {
-	Unified         *settings.UnifiedService
-	Instance        *InstanceSettingsHandler
-	Tenant          *TenantSettingsHandler
-	System          *SystemSettingsHandler
-	Custom          *CustomSettingsHandler
-	Service         *settings.SecretsService
-	User            *UserSettingsHandler
-	App             *AppSettingsHandler
-	Handler         *SettingsHandler
-	EmailTemplate   *EmailTemplateHandler
-	EmailSettings   *EmailSettingsHandler
-	CaptchaSettings *CaptchaSettingsHandler
+	Handlers *SettingsHandlers
+	Email    *EmailHandlers
+	Captcha  *CaptchaHandlers
 }
 
 func (m *SettingsModule) Name() string { return "settings" }
@@ -37,37 +28,40 @@ func (m *SettingsModule) Init(ctx context.Context, registry *ServiceRegistry) er
 	captchaService := GetService[*auth.CaptchaService](registry)
 
 	unifiedSettingsService := settings.NewUnifiedService(db, cfg, cfg.EncryptionKeyBytes)
-	m.Unified = unifiedSettingsService
-	m.Instance = NewInstanceSettingsHandler(unifiedSettingsService)
+	m.Handlers = &SettingsHandlers{}
+	m.Handlers.Unified = unifiedSettingsService
+	m.Handlers.Instance = NewInstanceSettingsHandler(unifiedSettingsService)
 
 	var tenantStorage *tenantdb.Repository
 	if ts := GetService[*tenantdb.Repository](registry); ts != nil {
 		tenantStorage = ts
 	}
-	m.Tenant = NewTenantSettingsHandler(unifiedSettingsService, tenantStorage)
+	m.Handlers.Tenant = NewTenantSettingsHandler(unifiedSettingsService, tenantStorage)
 
 	tenantConfigResolver := NewTenantConfigResolver(db, cfg, unifiedSettingsService)
 	registry.Register(tenantConfigResolver)
 	log.Info().Msg("Tenant config resolver initialized for dynamic settings")
 
-	m.System = NewSystemSettingsHandler(systemSettingsService, authService.GetSettingsCache())
+	m.Handlers.System = NewSystemSettingsHandler(systemSettingsService, authService.GetSettingsCache())
 
 	customSettingsService := settings.NewCustomSettingsService(db, cfg.EncryptionKeyBytes)
-	m.Custom = NewCustomSettingsHandler(customSettingsService)
+	m.Handlers.Custom = NewCustomSettingsHandler(customSettingsService)
 
 	secretsService := settings.NewSecretsService(db, cfg.EncryptionKeyBytes)
-	m.Service = secretsService
+	m.Handlers.Service = secretsService
 
 	userSettingsHandler := NewUserSettingsHandler(db, customSettingsService)
 	userSettingsHandler.SetSecretsService(secretsService)
-	m.User = userSettingsHandler
+	m.Handlers.User = userSettingsHandler
 
-	m.App = NewAppSettingsHandler(systemSettingsService, authService.GetSettingsCache(), cfg)
-	m.Handler = NewSettingsHandler(db)
+	m.Handlers.App = NewAppSettingsHandler(systemSettingsService, authService.GetSettingsCache(), cfg)
+	m.Handlers.Handler = NewSettingsHandler(db)
 
-	m.EmailTemplate = NewEmailTemplateHandler(db, emailManager.WrapAsService())
+	m.Email = &EmailHandlers{
+		Template: NewEmailTemplateHandler(db, emailManager.WrapAsService()),
+	}
 
-	m.EmailSettings = NewEmailSettingsHandler(
+	m.Email.Settings = NewEmailSettingsHandler(
 		systemSettingsService,
 		authService.GetSettingsCache(),
 		emailManager,
@@ -82,13 +76,15 @@ func (m *SettingsModule) Init(ctx context.Context, registry *ServiceRegistry) er
 		log.Warn().Err(err).Msg("Failed to refresh email service from settings on startup")
 	}
 
-	m.CaptchaSettings = NewCaptchaSettingsHandler(
-		systemSettingsService,
-		authService.GetSettingsCache(),
-		secretsService,
-		&cfg.Security,
-		captchaService,
-	)
+	m.Captcha = &CaptchaHandlers{
+		Settings: NewCaptchaSettingsHandler(
+			systemSettingsService,
+			authService.GetSettingsCache(),
+			secretsService,
+			&cfg.Security,
+			captchaService,
+		),
+	}
 
 	if captchaService != nil {
 		if err := captchaService.ReloadFromSettings(ctx, authService.GetSettingsCache(), &cfg.Security); err != nil {

--- a/internal/api/module_storage.go
+++ b/internal/api/module_storage.go
@@ -9,9 +9,9 @@ import (
 )
 
 type StorageModule struct {
-	Manager *storage.Manager
-	Service *storage.Service
-	Handler *StorageHandler
+	Handlers *StorageHandlers
+	Manager  *storage.Manager
+	Service  *storage.Service
 }
 
 func (m *StorageModule) Name() string { return "storage" }
@@ -35,7 +35,9 @@ func (m *StorageModule) Init(ctx context.Context, registry *ServiceRegistry) err
 		log.Warn().Err(err).Msg("Failed to ensure default bucket DB records")
 	}
 
-	m.Handler = NewStorageHandler(storageManager, db, cfg, &cfg.Storage.Transforms)
+	m.Handlers = &StorageHandlers{
+		Handler: NewStorageHandler(storageManager, db, cfg, &cfg.Storage.Transforms),
+	}
 
 	registry.Register(m.Service)
 	return nil

--- a/internal/api/module_tenancy.go
+++ b/internal/api/module_tenancy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gofiber/fiber/v3"
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/auth"
@@ -14,11 +13,8 @@ import (
 )
 
 type TenancyModule struct {
-	Manager  *tenantdb.Manager
-	Storage  *tenantdb.Repository
-	Tenant   *TenantHandler
-	Key      *ServiceKeyHandler
-	TenantDB fiber.Handler
+	Handlers   *TenancyHandlers
+	Middleware *MiddlewareComponents
 }
 
 func (m *TenancyModule) Name() string { return "tenancy" }
@@ -27,10 +23,11 @@ func (m *TenancyModule) Init(ctx context.Context, registry *ServiceRegistry) err
 	cfg := registry.Config
 	db := registry.DB
 
-	m.Key = NewServiceKeyHandler(db)
+	m.Handlers = &TenancyHandlers{}
+	m.Handlers.ServiceKey = NewServiceKeyHandler(db)
 
 	if !cfg.Tenants.Enabled {
-		m.Tenant = NewTenantHandler(db, nil, nil, nil, nil, cfg)
+		m.Handlers.Tenant = NewTenantHandler(db, nil, nil, nil, nil, cfg)
 		return nil
 	}
 
@@ -113,8 +110,8 @@ func (m *TenancyModule) Init(ctx context.Context, registry *ServiceRegistry) err
 		}
 	}
 
-	m.Manager = tenantManager
-	m.Storage = tenantStorage
+	m.Handlers.Manager = tenantManager
+	m.Handlers.Storage = tenantStorage
 
 	invitationService := GetService[*auth.InvitationService](registry)
 	emailService := GetService[*email.Manager](registry)
@@ -122,13 +119,15 @@ func (m *TenancyModule) Init(ctx context.Context, registry *ServiceRegistry) err
 	if emailService != nil {
 		emailSvc = emailService.WrapAsService()
 	}
-	m.Tenant = NewTenantHandler(db, tenantManager, tenantStorage, invitationService, emailSvc, cfg)
+	m.Handlers.Tenant = NewTenantHandler(db, tenantManager, tenantStorage, invitationService, emailSvc, cfg)
 
 	if tenantManager.GetRouter() != nil {
-		m.TenantDB = middleware.TenantDBMiddleware(middleware.TenantDBConfig{
-			Router:     tenantManager.GetRouter(),
-			Repository: tenantStorage,
-		})
+		m.Middleware = &MiddlewareComponents{
+			TenantDB: middleware.TenantDBMiddleware(middleware.TenantDBConfig{
+				Router:     tenantManager.GetRouter(),
+				Repository: tenantStorage,
+			}),
+		}
 	}
 
 	registry.Register(tenantManager)
@@ -137,8 +136,8 @@ func (m *TenancyModule) Init(ctx context.Context, registry *ServiceRegistry) err
 }
 
 func (m *TenancyModule) Shutdown(ctx context.Context) error {
-	if m.Manager != nil && m.Manager.GetRouter() != nil {
-		m.Manager.GetRouter().Close()
+	if m.Handlers != nil && m.Handlers.Manager != nil && m.Handlers.Manager.GetRouter() != nil {
+		m.Handlers.Manager.GetRouter().Close()
 	}
 	return nil
 }

--- a/internal/api/module_webhook.go
+++ b/internal/api/module_webhook.go
@@ -9,8 +9,7 @@ import (
 )
 
 type WebhookModule struct {
-	Handler *WebhookHandler
-	Trigger *webhook.TriggerService
+	Handlers *WebhookHandlers
 }
 
 func (m *WebhookModule) Name() string { return "webhook" }
@@ -26,15 +25,15 @@ func (m *WebhookModule) Init(ctx context.Context, registry *ServiceRegistry) err
 	}
 	webhookTriggerService := webhook.NewTriggerService(db, webhookService, 4)
 
-	m.Trigger = webhookTriggerService
-	m.Handler = NewWebhookHandler(webhookService)
+	m.Handlers.Trigger = webhookTriggerService
+	m.Handlers.Handler = NewWebhookHandler(webhookService)
 	registry.Register(webhookTriggerService)
 	return nil
 }
 
 func (m *WebhookModule) Shutdown(ctx context.Context) error {
-	if m.Trigger != nil {
-		m.Trigger.Stop()
+	if m.Handlers.Trigger != nil {
+		m.Handlers.Trigger.Stop()
 	}
 	return nil
 }

--- a/internal/api/module_webhook.go
+++ b/internal/api/module_webhook.go
@@ -15,6 +15,7 @@ type WebhookModule struct {
 func (m *WebhookModule) Name() string { return "webhook" }
 
 func (m *WebhookModule) Init(ctx context.Context, registry *ServiceRegistry) error {
+	m.Handlers = &WebhookHandlers{}
 	cfg := registry.Config
 	db := registry.DB
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -123,10 +123,6 @@ func NewServer(cfg *config.Config, db *database.Connection, version string) *Ser
 
 	metricsObj := observability.NewMetrics()
 	metricsStart := time.Now()
-	s.Metrics = &MetricsComponents{
-		Metrics:   metricsObj,
-		StartTime: metricsStart,
-	}
 
 	s.initCore()
 
@@ -152,7 +148,7 @@ func NewServer(cfg *config.Config, db *database.Connection, version string) *Ser
 	branchingMod := &BranchingModule{}
 	graphqlMod := &GraphQLModule{}
 	mcpMod := &MCPModule{}
-	metricsMod := &MetricsModule{Metrics: metricsObj, StartTime: metricsStart}
+	metricsMod := &MetricsModule{Handlers: &MetricsComponents{Metrics: metricsObj, StartTime: metricsStart}}
 	bgMod := &BackgroundServicesModule{}
 
 	mods := []Module{
@@ -183,98 +179,49 @@ func NewServer(cfg *config.Config, db *database.Connection, version string) *Ser
 	}
 	s.modules = mods
 
-	s.Secrets.Storage = secretsMod.Storage
-	s.Secrets.Handler = secretsMod.Handler
-	s.Storage.Handler = storageMod.Handler
-	s.Logging.Service = loggingMod.Service
-	s.Logging.Handler = loggingMod.Handler
-	s.Logging.Retention = loggingMod.Retention
+	s.Secrets = secretsMod.Handlers
+	s.Storage = storageMod.Handlers
+	s.Logging = loggingMod.Handlers
 	s.Auth = authMod.Handlers
 	s.sqlHandler = authMod.SQLHandler
 	s.requireAuth = authMod.RequireAuth
 	s.optionalAuth = authMod.OptionalAuth
-	s.Webhook.Handler = webhookMod.Handler
-	s.Webhook.Trigger = webhookMod.Trigger
-	s.Extensions.Handler = extensionsMod.Handler
+	s.Webhook = webhookMod.Handlers
+	s.Extensions = extensionsMod.Handlers
 
-	s.Tenancy.ServiceKey = tenancyMod.Key
-	s.Tenancy.Manager = tenancyMod.Manager
-	s.Tenancy.Storage = tenancyMod.Storage
-	s.Tenancy.Tenant = tenancyMod.Tenant
-	if tenancyMod.TenantDB != nil {
-		s.Middleware.TenantDB = tenancyMod.TenantDB
+	s.Tenancy = tenancyMod.Handlers
+	if tenancyMod.Middleware != nil && tenancyMod.Middleware.TenantDB != nil {
+		s.Middleware.TenantDB = tenancyMod.Middleware.TenantDB
 	}
 
-	s.Settings.Unified = settingsMod.Unified
-	s.Settings.Instance = settingsMod.Instance
-	s.Settings.Tenant = settingsMod.Tenant
-	s.Settings.System = settingsMod.System
-	s.Settings.Custom = settingsMod.Custom
-	s.Settings.Service = settingsMod.Service
-	s.Settings.User = settingsMod.User
-	s.Settings.App = settingsMod.App
-	s.Settings.Handler = settingsMod.Handler
-	s.Email.Template = settingsMod.EmailTemplate
-	s.Email.Settings = settingsMod.EmailSettings
-	s.Captcha.Settings = settingsMod.CaptchaSettings
+	s.Settings = settingsMod.Handlers
+	s.Email = settingsMod.Email
+	s.Captcha = settingsMod.Captcha
 
-	s.Schema.DDL = schemaMod.DDL
-	s.Schema.Cache = schemaMod.Cache
-	s.Schema.Migrations = schemaMod.Migrations
-	s.Schema.Export = schemaMod.Export
-	s.Schema.InternalSchema = schemaMod.Internal
+	s.Schema = schemaMod.Handlers
 	s.rest = schemaMod.RESTHandler
 
-	s.Functions.Handler = functionsMod.Handler
-	s.Functions.Scheduler = functionsMod.Scheduler
+	s.Functions = functionsMod.Handlers
 
-	s.Jobs.Manager = jobsMod.Manager
-	s.Jobs.Handler = jobsMod.Handler
-	s.Jobs.Scheduler = jobsMod.Scheduler
+	s.Jobs = jobsMod.Handlers
 
-	s.RPC.Handler = rpcMod.Handler
-	s.RPC.Scheduler = rpcMod.Scheduler
+	s.RPC = rpcMod.Handlers
 
-	s.AI = &AIHandlers{
-		Handler:         aiMod.Handler,
-		Chat:            aiMod.Chat,
-		Conversations:   aiMod.Conversations,
-		Metrics:         aiMod.Metrics,
-		KnowledgeBase:   aiMod.KnowledgeBase,
-		KBStorage:       aiMod.KBStorage,
-		DocProcessor:    aiMod.DocProcessor,
-		TableExportSync: aiMod.TableExportSync,
-		VectorManager:   aiMod.VectorManager,
-		VectorHandler:   aiMod.VectorHandler,
-		Internal:        aiMod.Internal,
-	}
-	s.Quota.Handler = aiMod.QuotaHandler
+	s.AI = aiMod.Handlers
+	s.Quota = aiMod.Quota
 
-	s.Realtime.Admin = realtimeMod.Admin
-	s.Realtime.Manager = realtimeMod.Manager
-	s.Realtime.Handler = realtimeMod.Handler
-	s.Realtime.Listener = realtimeMod.Listener
-	s.Monitoring.Handler = realtimeMod.Monitor
+	s.Realtime = realtimeMod.Handlers
+	s.Monitoring = realtimeMod.Monitoring
 
-	s.Branching.Manager = branchingMod.Manager
-	s.Branching.Router = branchingMod.Router
-	s.Branching.Handler = branchingMod.Handler
-	s.Branching.GitHub = branchingMod.GitHub
-	s.Branching.Scheduler = branchingMod.Scheduler
+	s.Branching = branchingMod.Handlers
 
-	s.GraphQL.Handler = graphqlMod.Handler
+	s.GraphQL = graphqlMod.Handlers
 
-	s.MCP.Handler = mcpMod.Handler
-	s.MCP.OAuth = mcpMod.OAuth
-	s.MCP.CustomManager = mcpMod.CustomManager
-	s.MCP.CustomHandler = mcpMod.CustomHandler
+	s.MCP = mcpMod.Handlers
 
-	s.Metrics.Server = metricsMod.Server
-	s.Metrics.StopChan = metricsMod.StopChan
+	s.Metrics = metricsMod.Handlers
 
-	s.Scaling.FunctionsLeader = bgMod.FunctionsLeader
-	s.Scaling.JobsLeader = bgMod.JobsLeader
-	s.Scaling.RPCLeader = bgMod.RPCLeader
+	s.Scaling = bgMod.Handlers
 
 	if err := s.Webhook.Trigger.Start(context.Background()); err != nil {
 		log.Error().Err(err).Msg("Failed to start webhook trigger service")

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -223,16 +223,18 @@ func NewServer(cfg *config.Config, db *database.Connection, version string) *Ser
 
 	s.Scaling = bgMod.Handlers
 
-	if err := s.Webhook.Trigger.Start(context.Background()); err != nil {
-		log.Error().Err(err).Msg("Failed to start webhook trigger service")
+	if s.Webhook != nil && s.Webhook.Trigger != nil {
+		if err := s.Webhook.Trigger.Start(context.Background()); err != nil {
+			log.Error().Err(err).Msg("Failed to start webhook trigger service")
+		}
 	}
-	if s.Logging.Retention != nil {
+	if s.Logging != nil && s.Logging.Retention != nil {
 		s.Logging.Retention.Start()
 		log.Info().
 			Dur("interval", s.config.Logging.RetentionCheckInterval).
 			Msg("Log retention cleanup service started")
 	}
-	if s.Branching.Scheduler != nil {
+	if s.Branching != nil && s.Branching.Scheduler != nil {
 		s.Branching.Scheduler.Start()
 	}
 


### PR DESCRIPTION
## Summary

Eliminate the 75-line manual wiring bridge in `NewServer()`. Each module now creates and populates its own handler group struct during `Init()`, stored in `m.Handlers`. `NewServer()` assigns the completed handler groups with ~20 simple lines.

### Before (75 lines of boilerplate)
```go
s.Secrets.Storage = secretsMod.Storage
s.Secrets.Handler = secretsMod.Handler
s.Logging.Service = loggingMod.Service
s.Logging.Handler = loggingMod.Handler
s.Logging.Retention = loggingMod.Retention
s.AI = &AIHandlers{
    Handler: aiMod.Handler,
    Chat: aiMod.Chat,
    Conversations: aiMod.Conversations,
    // ... 8 more fields
}
// ... 60 more lines
```

### After (~20 lines)
```go
s.Secrets = secretsMod.Handlers
s.Logging = loggingMod.Handlers
s.AI = aiMod.Handlers
s.Quota = aiMod.Quota
// ... one line per module
```

## Changes

### Module struct changes (19 of 20 modules)
- Each module replaces individual output fields with a single `Handlers *XxxHandlers` pointer
- `Init()` creates the handler group and writes directly to `m.Handlers.xxx`
- `Shutdown()` reads from `m.Handlers.xxx`

### Cross-group outputs (4 modules)
- `SettingsModule` gets `Email *EmailHandlers` and `Captcha *CaptchaHandlers`
- `AIModule` gets `Quota *QuotaHandlers`
- `RealtimeModule` gets `Monitoring *MonitoringHandlers`
- `TenancyModule` gets `Middleware *MiddlewareComponents`

### Direct Server fields (2 modules)
- `AuthModule` retains `sqlHandler`, `requireAuth`, `optionalAuth` (used directly by Server)
- `SchemaModule` retains `RESTHandler` (core REST handler, stored on `s.rest`)

### Cleanup
- Removed dead `Middleware.Branch` field (never set anywhere)
- Updated CLAUDE.md wiring documentation

## Stats
- **21 files changed, 246 insertions, 313 deletions** (net -67 lines)
- Wiring bridge: 75 → ~43 lines (mostly one-liner assignments)
- Adding a new handler now requires changes in only 2 places (module + handler_groups), down from 3 (module + handler_groups + server wiring)