### PR TITLE
feat: DX/UX consistency improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,22 +577,21 @@ jobs:
           go tool cover -html=coverage.out -o coverage.html
 
       - name: Check coverage thresholds
-        continue-on-error: true
         run: |
           go install github.com/vladopajic/go-test-coverage/v2@latest
           # Check thresholds against combined (unit + e2e) coverage
           go-test-coverage --config=.testcoverage.yml
 
-      # - name: Upload coverage to Codecov
-      #   uses: codecov/codecov-action@v5
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
-      #     files: ./coverage.out
-      #     flags: unittests
-      #     name: go-codecov
-      #     fail_ci_if_error: true
-      #     verbose: true
-      #     slug: nimbleflux/fluxbase
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out
+          flags: unittests
+          name: go-codecov
+          fail_ci_if_error: false
+          verbose: true
+          slug: nimbleflux/fluxbase
 
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v7

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -100,6 +100,7 @@ exclude:
     # Infrastructure code (requires system dependencies, tested via E2E)
     - ^internal/scaling/leader\.go$
     - ^internal/database/connection\.go$
+    - ^internal/database/schema/
     - ^internal/ai/ocr_tesseract\.go$
 
     # Entry points and embedded assets

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -4,7 +4,7 @@
 profile: coverage.out
 
 threshold:
-  file: 0       # Individual files (not enforced yet)
+  file: -1      # Individual files (not enforced)
   package: 0    # Per-package minimum (enforced via overrides below)
   total: 25     # Overall project target
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Fluxbase is a single-binary Backend-as-a-Service (BaaS). PostgreSQL is the only 
 
 - **Backend:** Go 1.25+, Fiber v3, pgx/v5, golang-migrate, TimescaleDB
 - **Admin UI:** React 19, Vite, TanStack Router/Query, Tailwind v4, shadcn/ui
-- **SDKs:** TypeScript (`sdk/`), React hooks (`sdk-react/`), Go (`pkg/client/`)
+- **SDKs:** TypeScript (`sdk/`), React hooks (`sdk-react/`)
 - **Functions Runtime:** Deno (JavaScript/TypeScript edge functions)
 
 ## Directory Structure

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 > **Beta Software**: Fluxbase is currently in beta. While we're working hard to stabilize the API and features, you may encounter breaking changes between versions. We welcome feedback and contributions!
 
-Run `make test-full` to validate all critical flows.
-
 A lightweight, single-binary Backend-as-a-Service (BaaS) alternative to Supabase. Fluxbase provides essential backend services including auto-generated REST APIs, authentication, realtime subscriptions, file storage, and edge functions - all in a single Go binary with PostgreSQL as the only dependency.
 
 ## Features
@@ -22,7 +20,10 @@ A lightweight, single-binary Backend-as-a-Service (BaaS) alternative to Supabase
 - **RPC/Procedures**: SQL-based serverless procedures with scheduling and RBAC
 - **Webhooks**: Event-driven webhook delivery for database changes with retries and HMAC signing
 - **Vector Search**: pgvector-powered semantic search with automatic embeddings
+- **AI/RAG**: Knowledge bases, chatbots, and entity extraction
 - **MCP Server**: Model Context Protocol for AI assistant integration
+- **Multi-Tenancy**: Tenant isolation with RLS, separate databases, and per-tenant config
+- **Database Branching**: Isolated dev/test environments with GitHub PR integration
 
 ### Key Highlights
 
@@ -30,19 +31,65 @@ A lightweight, single-binary Backend-as-a-Service (BaaS) alternative to Supabase
 - PostgreSQL as the only external dependency
 - Automatic REST endpoint generation
 - Row Level Security (RLS) support
-- TypeScript SDK
-- Database branching for dev/test environments
+- TypeScript SDK + React hooks
 - Built-in observability (Prometheus metrics, OpenTelemetry tracing)
 - Horizontal scaling with leader election
 
 ## Quick Start
 
-For more information about Fluxbase, look into [the docs](https://fluxbase.eu/getting-started/quick-start/).
+### Prerequisites
+
+- [Go](https://go.dev/) 1.25+
+- [PostgreSQL](https://www.postgresql.org/) 16+ (with [pgvector](https://github.com/pgvector/pgvector))
+- [Node.js](https://nodejs.org/) 20+ / [Bun](https://bun.sh/) (for admin UI and SDKs)
+- [Deno](https://deno.land/) (for edge functions runtime)
+
+### Build & Run
+
+```bash
+# Clone the repository
+git clone https://github.com/nimbleflux/fluxbase.git
+cd fluxbase
+
+# Build the binary
+make build
+
+# Or run in development mode (backend + admin UI)
+make dev
+```
+
+For Docker-based deployment, see the [deployment guide](https://fluxbase.eu/deployment/overview/).
+
+### SDKs
+
+```bash
+# TypeScript SDK
+cd sdk && bun install && bun run build
+
+# React SDK
+cd sdk-react && bun install && bun run build
+```
+
+For more information, see the [quick start guide](https://fluxbase.eu/getting-started/quick-start/).
+
+## Development
+
+```bash
+make setup-dev    # Install dependencies + git hooks
+make test         # Unit tests
+make test-full    # All tests including E2E
+make lint-go      # Go linting
+make cli-install  # Build and install CLI
+```
+
+See [CLAUDE.md](CLAUDE.md) for a detailed codebase guide and architecture overview.
 
 ## Support
-
-For issues, questions, and discussions:
 
 - GitHub Issues: [github.com/nimbleflux/fluxbase/issues](https://github.com/nimbleflux/fluxbase/issues)
 - Documentation: [fluxbase.eu](https://fluxbase.eu)
 - Discord: [discord.gg/BXPRHkQzkA](https://discord.gg/BXPRHkQzkA)
+
+## License
+
+This project is licensed under the terms described in [docs/src/content/docs/intro.md](docs/src/content/docs/intro.md).

--- a/admin/src/components/chatbots/delete-chatbot-dialog.tsx
+++ b/admin/src/components/chatbots/delete-chatbot-dialog.tsx
@@ -1,0 +1,45 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface DeleteChatbotDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export function DeleteChatbotDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: DeleteChatbotDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Chatbot</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete this chatbot? This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/admin/src/components/chatbots/use-chatbots.ts
+++ b/admin/src/components/chatbots/use-chatbots.ts
@@ -1,0 +1,68 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { chatbotsApi, type AIChatbotSummary } from "@/lib/api";
+import { useTenantStore } from "@/stores/tenant-store";
+
+export function useChatbots() {
+  const queryClient = useQueryClient();
+  const currentTenantId = useTenantStore((state) => state.currentTenant?.id);
+
+  const query = useQuery({
+    queryKey: ["chatbots", currentTenantId],
+    queryFn: async () => {
+      const data = await chatbotsApi.list();
+      return data || [];
+    },
+  });
+
+  const syncMutation = useMutation({
+    mutationFn: () => chatbotsApi.sync(),
+    onSuccess: (result) => {
+      const { created, updated, deleted, errors } = result.summary;
+
+      if (created > 0 || updated > 0 || deleted > 0) {
+        const messages: string[] = [];
+        if (created > 0) messages.push(`${created} created`);
+        if (updated > 0) messages.push(`${updated} updated`);
+        if (deleted > 0) messages.push(`${deleted} deleted`);
+        toast.success(`Chatbots synced: ${messages.join(", ")}`);
+      } else if (errors > 0) {
+        toast.error(`Failed to sync chatbots: ${errors} errors`);
+      } else {
+        toast.info("No changes detected");
+      }
+      queryClient.invalidateQueries({ queryKey: ["chatbots"] });
+    },
+    onError: () => toast.error("Failed to sync chatbots from filesystem"),
+  });
+
+  const toggleMutation = useMutation({
+    mutationFn: ({ chatbot }: { chatbot: AIChatbotSummary }) =>
+      chatbotsApi.toggle(chatbot.id, !chatbot.enabled),
+    onSuccess: (_data, { chatbot }) => {
+      toast.success(`Chatbot ${!chatbot.enabled ? "enabled" : "disabled"}`);
+      queryClient.invalidateQueries({ queryKey: ["chatbots"] });
+    },
+    onError: () => toast.error("Failed to toggle chatbot"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => chatbotsApi.delete(id),
+    onSuccess: () => {
+      toast.success("Chatbot deleted successfully");
+      queryClient.invalidateQueries({ queryKey: ["chatbots"] });
+    },
+    onError: () => toast.error("Failed to delete chatbot"),
+  });
+
+  return {
+    chatbots: query.data || [],
+    loading: query.isLoading,
+    reloading: syncMutation.isPending,
+    sync: syncMutation.mutate,
+    toggle: (chatbot: AIChatbotSummary) =>
+      toggleMutation.mutate({ chatbot }),
+    deleteChatbot: deleteMutation.mutate,
+    refetch: query.refetch,
+  };
+}

--- a/admin/src/components/layout/data/sidebar-data.ts
+++ b/admin/src/components/layout/data/sidebar-data.ts
@@ -49,6 +49,7 @@ export interface SidebarItem {
   visibility?: VisibilityLevel;
   requiresTenant?: boolean;
   badge?: string;
+  external?: boolean;
 }
 
 export interface SidebarGroup {
@@ -244,6 +245,14 @@ export const sidebarData: SidebarDataWithVisibility = {
           icon: Code2,
           visibility: "all",
           requiresTenant: false, // Override: works at both levels
+        },
+        {
+          title: "API Reference",
+          url: "/api-docs",
+          icon: ScrollText,
+          visibility: "all",
+          requiresTenant: false,
+          external: true,
         },
         {
           title: "Realtime",

--- a/admin/src/components/layout/nav-group.tsx
+++ b/admin/src/components/layout/nav-group.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode } from 'react'
 import { Link, useLocation } from '@tanstack/react-router'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, ExternalLink } from 'lucide-react'
 import {
   Collapsible,
   CollapsibleContent,
@@ -64,6 +64,25 @@ function NavBadge({ children }: { children: ReactNode }) {
 
 function SidebarMenuLink({ item, href }: { item: NavLink; href: string }) {
   const { setOpenMobile } = useSidebar()
+
+  if (item.external) {
+    return (
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          asChild
+          isActive={false}
+          tooltip={item.title}
+        >
+          <a href={item.url} target="_blank" rel="noopener noreferrer">
+            {item.icon && <item.icon />}
+            <span>{item.title}</span>
+            <ExternalLink className="ms-auto h-3 w-3 opacity-50" />
+          </a>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    )
+  }
+
   return (
     <SidebarMenuItem>
       <SidebarMenuButton

--- a/admin/src/components/layout/types.ts
+++ b/admin/src/components/layout/types.ts
@@ -16,6 +16,7 @@ type BaseNavItem = {
   title: string
   badge?: string
   icon?: React.ElementType
+  external?: boolean
 }
 
 type NavLink = BaseNavItem & {

--- a/admin/src/routes/_authenticated/ai-providers/index.tsx
+++ b/admin/src/routes/_authenticated/ai-providers/index.tsx
@@ -1,24 +1,16 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { Bot } from 'lucide-react'
 import { AIProvidersTab } from '@/components/ai-providers/ai-providers-tab'
+import { PageHeader } from '@/components/layout/page-header'
 
 const AIProvidersPage = () => {
   return (
     <div className='flex h-full flex-col'>
-      {/* Header */}
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <Bot className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>AI Providers</h1>
-            <p className='text-muted-foreground text-sm'>
-              Configure AI providers for chatbots and intelligent features
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Bot />}
+        title="AI Providers"
+        description="Configure AI providers for chatbots and intelligent features"
+      />
 
       <div className='flex-1 overflow-auto p-6'>
         <AIProvidersTab />

--- a/admin/src/routes/_authenticated/api/rest.tsx
+++ b/admin/src/routes/_authenticated/api/rest.tsx
@@ -17,6 +17,7 @@ import { toast } from "sonner";
 import { useImpersonationStore } from "@/stores/impersonation-store";
 import { getAccessToken } from "@/lib/auth";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -555,20 +556,11 @@ print(data)`;
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Play className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">REST API Explorer</h1>
-            <p className="text-muted-foreground text-sm">
-              Build and test API requests against your Fluxbase backend
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Play />}
+        title="REST API Explorer"
+        description="Build and test API requests against your Fluxbase backend"
+      />
 
       {/* Main Content */}
       <div className="flex flex-1 overflow-hidden p-6">

--- a/admin/src/routes/_authenticated/authentication/index.tsx
+++ b/admin/src/routes/_authenticated/authentication/index.tsx
@@ -1,6 +1,7 @@
 import z from "zod";
 import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import { Key, Settings, Users, Building2, Shield } from "lucide-react";
+import { PageHeader } from "@/components/layout/page-header";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   OAuthProvidersTab,
@@ -24,21 +25,15 @@ const AuthenticationPage = () => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Shield className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Authentication</h1>
-            <p className="text-muted-foreground text-sm">
-              {isInstanceLevel
-                ? "Configuring instance-level providers (available to all tenants)"
-                : `Configuring providers for "${currentTenant.name}"`}
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Shield />}
+        title="Authentication"
+        description={
+          isInstanceLevel
+            ? "Configuring instance-level providers (available to all tenants)"
+            : `Configuring providers for "${currentTenant.name}"`
+        }
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <Tabs

--- a/admin/src/routes/_authenticated/chatbots/index.tsx
+++ b/admin/src/routes/_authenticated/chatbots/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useMemo } from "react";
 import { formatDistanceToNow } from "date-fns";
 import { createFileRoute } from "@tanstack/react-router";
 import {
@@ -23,20 +23,8 @@ import {
   MessageSquare,
   History,
 } from "lucide-react";
-import { toast } from "sonner";
-import { chatbotsApi, type AIChatbotSummary } from "@/lib/api";
-import { useTenantStore } from "@/stores/tenant-store";
+import { type AIChatbotSummary } from "@/lib/api";
 import { cn } from "@/lib/utils";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -57,6 +45,8 @@ import {
 import { ChatbotSettingsDialog } from "@/components/chatbots/chatbot-settings-dialog";
 import { ChatbotTestDialog } from "@/components/chatbots/chatbot-test-dialog";
 import { ChatbotConversationsDialog } from "@/components/chatbots/chatbot-conversations-dialog";
+import { DeleteChatbotDialog } from "@/components/chatbots/delete-chatbot-dialog";
+import { useChatbots } from "@/components/chatbots/use-chatbots";
 import { PageHeader } from "@/components/layout/page-header";
 import {
   DataTablePagination,
@@ -64,94 +54,64 @@ import {
   DataTableColumnHeader,
 } from "@/components/data-table";
 
-const ChatbotsPage = () => {
-  const [chatbots, setChatbots] = useState<AIChatbotSummary[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [reloading, setReloading] = useState(false);
-  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
-  const [settingsChatbot, setSettingsChatbot] =
-    useState<AIChatbotSummary | null>(null);
-  const [testChatbot, setTestChatbot] = useState<AIChatbotSummary | null>(null);
-  const [conversationsChatbot, setConversationsChatbot] =
-    useState<AIChatbotSummary | null>(null);
+interface ChatbotActionsProps {
+  onTest: () => void;
+  onConversations: () => void;
+  onSettings: () => void;
+  onDelete: () => void;
+}
 
-  // Table state
-  const [sorting, setSorting] = useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+function ChatbotActions({
+  onTest,
+  onConversations,
+  onSettings,
+  onDelete,
+}: ChatbotActionsProps) {
+  return (
+    <div className="flex items-center justify-end gap-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button onClick={onTest} size="sm" variant="ghost" className="h-7 w-7 p-0">
+            <MessageSquare className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Test chatbot</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button onClick={onConversations} size="sm" variant="ghost" className="h-7 w-7 p-0">
+            <History className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>View conversations</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button onClick={onSettings} size="sm" variant="ghost" className="h-7 w-7 p-0">
+            <Settings className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Settings</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            onClick={onDelete}
+            size="sm"
+            variant="ghost"
+            className="text-destructive hover:text-destructive hover:bg-destructive/10 h-7 w-7 p-0"
+          >
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>Delete chatbot</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
 
-  const currentTenantId = useTenantStore((state) => state.currentTenant?.id);
-
-  const fetchChatbots = useCallback(async () => {
-    setLoading(true);
-    try {
-      const data = await chatbotsApi.list();
-      setChatbots(data || []);
-    } catch {
-      toast.error("Failed to fetch chatbots");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const handleReloadClick = async () => {
-    setReloading(true);
-    try {
-      const result = await chatbotsApi.sync();
-      const { created, updated, deleted, errors } = result.summary;
-
-      if (created > 0 || updated > 0 || deleted > 0) {
-        const messages = [];
-        if (created > 0) messages.push(`${created} created`);
-        if (updated > 0) messages.push(`${updated} updated`);
-        if (deleted > 0) messages.push(`${deleted} deleted`);
-
-        toast.success(`Chatbots synced: ${messages.join(", ")}`);
-      } else if (errors > 0) {
-        toast.error(`Failed to sync chatbots: ${errors} errors`);
-      } else {
-        toast.info("No changes detected");
-      }
-
-      await fetchChatbots();
-    } catch {
-      toast.error("Failed to sync chatbots from filesystem");
-    } finally {
-      setReloading(false);
-    }
-  };
-
-  const toggleChatbot = async (chatbot: AIChatbotSummary) => {
-    const newEnabledState = !chatbot.enabled;
-
-    try {
-      await chatbotsApi.toggle(chatbot.id, newEnabledState);
-      toast.success(`Chatbot ${newEnabledState ? "enabled" : "disabled"}`);
-      await fetchChatbots();
-    } catch {
-      toast.error("Failed to toggle chatbot");
-    }
-  };
-
-  const deleteChatbot = async (id: string) => {
-    try {
-      await chatbotsApi.delete(id);
-      toast.success("Chatbot deleted successfully");
-      await fetchChatbots();
-    } catch {
-      toast.error("Failed to delete chatbot");
-    } finally {
-      setDeleteConfirm(null);
-    }
-  };
-
-  // Get unique namespaces for filter options
-  const namespaceOptions = useMemo(() => {
-    const namespaces = [...new Set(chatbots.map((cb) => cb.namespace))];
-    return namespaces.map((ns) => ({ label: ns, value: ns }));
-  }, [chatbots]);
-
-  // Define columns
-  const columns: ColumnDef<AIChatbotSummary>[] = useMemo(
+function useChatbotColumns(toggle: (chatbot: AIChatbotSummary) => void) {
+  return useMemo<ColumnDef<AIChatbotSummary>[]>(
     () => [
       {
         accessorKey: "name",
@@ -213,7 +173,7 @@ const ChatbotsPage = () => {
         cell: ({ row }) => (
           <Switch
             checked={row.getValue("enabled")}
-            onCheckedChange={() => toggleChatbot(row.original)}
+            onCheckedChange={() => toggle(row.original)}
             className="scale-90"
           />
         ),
@@ -235,77 +195,39 @@ const ChatbotsPage = () => {
       },
       {
         id: "actions",
-        cell: ({ row }) => (
-          <div className="flex items-center justify-end gap-1">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  onClick={() => setTestChatbot(row.original)}
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 w-7 p-0"
-                >
-                  <MessageSquare className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Test chatbot</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  onClick={() => setConversationsChatbot(row.original)}
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 w-7 p-0"
-                >
-                  <History className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>View conversations</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  onClick={() => setSettingsChatbot(row.original)}
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 w-7 p-0"
-                >
-                  <Settings className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Settings</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  onClick={() => setDeleteConfirm(row.original.id)}
-                  size="sm"
-                  variant="ghost"
-                  className="text-destructive hover:text-destructive hover:bg-destructive/10 h-7 w-7 p-0"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Delete chatbot</TooltipContent>
-            </Tooltip>
-          </div>
-        ),
+        cell: ({ row }) => <ChatbotActionsCell chatbot={row.original} />,
         enableSorting: false,
         enableHiding: false,
       },
     ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [toggle],
   );
+}
+
+const ChatbotsPage = () => {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+
+  const {
+    chatbots,
+    loading,
+    reloading,
+    sync,
+    toggle,
+    refetch,
+  } = useChatbots();
+
+  const columns = useChatbotColumns(toggle);
+
+  const namespaceOptions = useMemo(() => {
+    const namespaces = [...new Set(chatbots.map((cb) => cb.namespace))];
+    return namespaces.map((ns) => ({ label: ns, value: ns }));
+  }, [chatbots]);
 
   const table = useReactTable({
     data: chatbots,
     columns,
-    state: {
-      sorting,
-      columnFilters,
-    },
+    state: { sorting, columnFilters },
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     getCoreRowModel: getCoreRowModel(),
@@ -315,10 +237,6 @@ const ChatbotsPage = () => {
     getFacetedRowModel: getFacetedRowModel(),
     getFacetedUniqueValues: getFacetedUniqueValues(),
   });
-
-  useEffect(() => {
-    fetchChatbots();
-  }, [fetchChatbots, currentTenantId]);
 
   if (loading) {
     return (
@@ -358,7 +276,7 @@ const ChatbotsPage = () => {
             </div>
             <div className="flex items-center gap-2">
               <Button
-                onClick={handleReloadClick}
+                onClick={() => sync()}
                 variant="outline"
                 size="sm"
                 disabled={reloading}
@@ -375,11 +293,7 @@ const ChatbotsPage = () => {
                   </>
                 )}
               </Button>
-              <Button
-                onClick={() => fetchChatbots()}
-                variant="outline"
-                size="sm"
-              >
+              <Button onClick={() => refetch()} variant="outline" size="sm">
                 <RefreshCw className="mr-2 h-4 w-4" />
                 Refresh
               </Button>
@@ -473,64 +387,60 @@ const ChatbotsPage = () => {
               <DataTablePagination table={table} className="mt-auto" />
             </div>
           )}
-
-          {/* Delete Confirmation Dialog */}
-          <AlertDialog
-            open={deleteConfirm !== null}
-            onOpenChange={(open) => !open && setDeleteConfirm(null)}
-          >
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Delete Chatbot</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Are you sure you want to delete this chatbot? This action
-                  cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={() => deleteConfirm && deleteChatbot(deleteConfirm)}
-                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                >
-                  Delete
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-
-          {/* Settings Dialog */}
-          {settingsChatbot && (
-            <ChatbotSettingsDialog
-              chatbot={settingsChatbot}
-              open={settingsChatbot !== null}
-              onOpenChange={(open) => !open && setSettingsChatbot(null)}
-            />
-          )}
-
-          {/* Test Dialog */}
-          {testChatbot && (
-            <ChatbotTestDialog
-              chatbot={testChatbot}
-              open={testChatbot !== null}
-              onOpenChange={(open) => !open && setTestChatbot(null)}
-            />
-          )}
-
-          {/* Conversations Dialog */}
-          {conversationsChatbot && (
-            <ChatbotConversationsDialog
-              open={conversationsChatbot !== null}
-              onOpenChange={(open) => !open && setConversationsChatbot(null)}
-              chatbotId={conversationsChatbot.id}
-              chatbotName={conversationsChatbot.name}
-            />
-          )}
         </div>
       </div>
     </div>
   );
 };
+
+function ChatbotActionsCell({ chatbot }: { chatbot: AIChatbotSummary }) {
+  const [settings, setSettings] = useState(false);
+  const [test, setTest] = useState(false);
+  const [conversations, setConversations] = useState(false);
+  const [del, setDel] = useState(false);
+  const { deleteChatbot } = useChatbots();
+
+  return (
+    <>
+      <ChatbotActions
+        onTest={() => setTest(true)}
+        onConversations={() => setConversations(true)}
+        onSettings={() => setSettings(true)}
+        onDelete={() => setDel(true)}
+      />
+      {settings && (
+        <ChatbotSettingsDialog
+          chatbot={chatbot}
+          open={settings}
+          onOpenChange={setSettings}
+        />
+      )}
+      {test && (
+        <ChatbotTestDialog
+          chatbot={chatbot}
+          open={test}
+          onOpenChange={setTest}
+        />
+      )}
+      {conversations && (
+        <ChatbotConversationsDialog
+          open={conversations}
+          onOpenChange={setConversations}
+          chatbotId={chatbot.id}
+          chatbotName={chatbot.name}
+        />
+      )}
+      <DeleteChatbotDialog
+        open={del}
+        onOpenChange={setDel}
+        onConfirm={() => {
+          deleteChatbot(chatbot.id);
+          setDel(false);
+        }}
+      />
+    </>
+  );
+}
 
 export const Route = createFileRoute("/_authenticated/chatbots/")({
   component: ChatbotsPage,

--- a/admin/src/routes/_authenticated/client-keys/index.tsx
+++ b/admin/src/routes/_authenticated/client-keys/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/api";
 import { useTenantStore } from "@/stores/tenant-store";
 import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/layout/page-header";
 import {
   Card,
   CardContent,
@@ -149,19 +150,11 @@ const ClientKeysPage = () => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Key className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Client Keys</h1>
-            <p className="text-muted-foreground text-sm">
-              Generate and manage client keys for programmatic access
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Key />}
+        title="Client Keys"
+        description="Generate and manage client keys for programmatic access"
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <div className="flex flex-col gap-6">

--- a/admin/src/routes/_authenticated/database-config/index.tsx
+++ b/admin/src/routes/_authenticated/database-config/index.tsx
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { PageHeader } from '@/components/layout/page-header'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 
@@ -44,19 +45,11 @@ const DatabaseConfigPage = () => {
   return (
     <div className='flex h-full flex-col'>
       {/* Header */}
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <Database className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>Database</h1>
-            <p className='text-muted-foreground text-sm'>
-              PostgreSQL connection settings and connection pool configuration
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Database />}
+        title="Database"
+        description="PostgreSQL connection settings and connection pool configuration"
+      />
 
       <div className='flex-1 overflow-auto p-6'>
 

--- a/admin/src/routes/_authenticated/email-settings/index.tsx
+++ b/admin/src/routes/_authenticated/email-settings/index.tsx
@@ -22,6 +22,7 @@ import { apiClient } from "@/lib/api";
 import { fluxbaseClient } from "@/lib/fluxbase-client";
 import { useTenantStore } from "@/stores/tenant-store";
 import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/layout/page-header";
 import {
   Card,
   CardContent,
@@ -425,46 +426,42 @@ function EmailSettingsPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Mail className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Email Settings</h1>
-            <p className="text-muted-foreground text-sm">
-              {showTenantLevel
-                ? `Tenant overrides for ${currentTenant?.name || "tenant"} — inherits from instance defaults`
-                : "Configure email service and customize email templates"}
-            </p>
-          </div>
-        </div>
-        {showTenantLevel && (
-          <div className="flex items-center gap-2">
-            <Badge
-              variant="outline"
-              className="border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"
-            >
-              <Building2 className="mr-1 h-3 w-3" />
-              {currentTenant?.name}
-            </Badge>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                clearTenant();
-                navigate({
-                  to: "/email-settings",
-                  search: { tab: search.tab },
-                });
-              }}
-            >
-              <ArrowLeft className="mr-1 h-4 w-4" />
-              Instance Settings
-            </Button>
-          </div>
-        )}
-      </div>
+      <PageHeader
+        icon={<Mail />}
+        title="Email Settings"
+        description={
+          showTenantLevel
+            ? `Tenant overrides for ${currentTenant?.name || "tenant"} — inherits from instance defaults`
+            : "Configure email service and customize email templates"
+        }
+        actions={
+          showTenantLevel ? (
+            <>
+              <Badge
+                variant="outline"
+                className="border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-700 dark:bg-blue-950 dark:text-blue-300"
+              >
+                <Building2 className="mr-1 h-3 w-3" />
+                {currentTenant?.name}
+              </Badge>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  clearTenant();
+                  navigate({
+                    to: "/email-settings",
+                    search: { tab: search.tab },
+                  });
+                }}
+              >
+                <ArrowLeft className="mr-1 h-4 w-4" />
+                Instance Settings
+              </Button>
+            </>
+          ) : undefined
+        }
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <Tabs

--- a/admin/src/routes/_authenticated/extensions/index.tsx
+++ b/admin/src/routes/_authenticated/extensions/index.tsx
@@ -13,6 +13,7 @@ import { getErrorMessage } from '@/lib/get-error-message'
 import { apiClient } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import { Badge } from '@/components/ui/badge'
+import { PageHeader } from '@/components/layout/page-header'
 import { Button } from '@/components/ui/button'
 import {
   Card,
@@ -215,33 +216,26 @@ function ExtensionsPage() {
   return (
     <div className='flex h-full flex-col'>
       {/* Header */}
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <Puzzle className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>Extensions</h1>
-            <p className='text-muted-foreground text-sm'>
-              Manage PostgreSQL extensions for your database
-            </p>
-          </div>
-        </div>
-
-        <Button
-          variant='outline'
-          size='sm'
-          onClick={() => syncMutation.mutate()}
-          disabled={syncMutation.isPending}
-        >
-          {syncMutation.isPending ? (
-            <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-          ) : (
-            <RefreshCw className='mr-2 h-4 w-4' />
-          )}
-          Sync from Database
-        </Button>
-      </div>
+      <PageHeader
+        icon={<Puzzle />}
+        title="Extensions"
+        description="Manage PostgreSQL extensions for your database"
+        actions={
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => syncMutation.mutate()}
+            disabled={syncMutation.isPending}
+          >
+            {syncMutation.isPending ? (
+              <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+            ) : (
+              <RefreshCw className='mr-2 h-4 w-4' />
+            )}
+            Sync from Database
+          </Button>
+        }
+      />
 
       <div className='flex-1 overflow-auto p-6'>
 

--- a/admin/src/routes/_authenticated/features/index.tsx
+++ b/admin/src/routes/_authenticated/features/index.tsx
@@ -11,6 +11,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { PageHeader } from '@/components/layout/page-header'
 import { OverridableSwitch } from '@/components/admin/overridable-switch'
 
 export const Route = createFileRoute('/_authenticated/features/')({
@@ -170,19 +171,11 @@ function FeaturesPage() {
   return (
     <div className='flex h-full flex-col'>
       {/* Header */}
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <Zap className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>Features</h1>
-            <p className='text-muted-foreground text-sm'>
-              Enable or disable platform features
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Zap />}
+        title="Features"
+        description="Enable or disable platform features"
+      />
 
       <div className='flex-1 overflow-auto p-6'>
 

--- a/admin/src/routes/_authenticated/instance-settings/index.tsx
+++ b/admin/src/routes/_authenticated/instance-settings/index.tsx
@@ -4,6 +4,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Settings, Shield, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -128,19 +129,11 @@ function InstanceSettingsPage() {
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Settings className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Instance Settings</h1>
-            <p className="text-muted-foreground text-sm">
-              Instance-level configuration for security and tenant permissions
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
+      <PageHeader
+        icon={<Settings />}
+        title="Instance Settings"
+        description="Instance-level configuration for security and tenant permissions"
+        actions={
           <Button
             variant="outline"
             size="sm"
@@ -149,8 +142,8 @@ function InstanceSettingsPage() {
             <Shield className="h-4 w-4 mr-2" />
             Manage Tenant Overrides
           </Button>
-        </div>
-      </div>
+        }
+      />
 
       {/* Main content */}
       <div className="flex-1 overflow-auto p-6">

--- a/admin/src/routes/_authenticated/jobs/index.tsx
+++ b/admin/src/routes/_authenticated/jobs/index.tsx
@@ -29,6 +29,7 @@ import { jobsApi, type JobFunction, type Job, type JobWorker } from "@/lib/api";
 import { fluxbaseClient } from "@/lib/fluxbase-client";
 import { useExecutionLogs } from "@/hooks/use-execution-logs";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -709,29 +710,23 @@ function JobsPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <ListTodo className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Background Jobs</h1>
-            <p className="text-muted-foreground text-sm">
-              Manage job functions and monitor background task execution
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <ImpersonationPopover
-            contextLabel="Running as"
-            defaultReason="Testing job submission"
-          />
-          <Button onClick={refreshAllData} variant="outline" size="sm">
-            <RefreshCw className="mr-2 h-4 w-4" />
-            Refresh
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        icon={<ListTodo />}
+        title="Background Jobs"
+        description="Manage job functions and monitor background task execution"
+        actions={
+          <>
+            <ImpersonationPopover
+              contextLabel="Running as"
+              defaultReason="Testing job submission"
+            />
+            <Button onClick={refreshAllData} variant="outline" size="sm">
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Refresh
+            </Button>
+          </>
+        }
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <Card className="!gap-0 !py-0 mb-6">

--- a/admin/src/routes/_authenticated/logs/index.tsx
+++ b/admin/src/routes/_authenticated/logs/index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ScrollText } from 'lucide-react'
 import { LogViewer } from '@/features/logs/components/log-viewer'
+import { PageHeader } from '@/components/layout/page-header'
 
 export const Route = createFileRoute('/_authenticated/logs/')({
   component: LogsPage,
@@ -9,19 +10,11 @@ export const Route = createFileRoute('/_authenticated/logs/')({
 function LogsPage() {
   return (
     <div className='flex h-full flex-col'>
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <ScrollText className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>Log Stream</h1>
-            <p className='text-muted-foreground text-sm'>
-              Real-time application logs
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<ScrollText />}
+        title="Log Stream"
+        description="Real-time application logs"
+      />
 
       <div className='min-h-0 flex-1 p-6'>
         <LogViewer />

--- a/admin/src/routes/_authenticated/mcp-tools/index.tsx
+++ b/admin/src/routes/_authenticated/mcp-tools/index.tsx
@@ -27,6 +27,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardContent } from "@/components/ui/card";
 import {
@@ -55,20 +56,11 @@ export const Route = createFileRoute("/_authenticated/mcp-tools/")({
 function MCPToolsPage() {
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Wrench className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Custom MCP Tools</h1>
-            <p className="text-muted-foreground text-sm">
-              Create and manage custom MCP tools for AI assistants
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Wrench />}
+        title="Custom MCP Tools"
+        description="Create and manage custom MCP tools for AI assistants"
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <ToolsTab />

--- a/admin/src/routes/_authenticated/monitoring/index.tsx
+++ b/admin/src/routes/_authenticated/monitoring/index.tsx
@@ -22,6 +22,7 @@ import {
   type AIMetrics,
 } from '@/lib/api'
 import { Badge } from '@/components/ui/badge'
+import { PageHeader } from '@/components/layout/page-header'
 import {
   Card,
   CardContent,
@@ -107,21 +108,11 @@ function MonitoringPage() {
 
   return (
     <div className='flex h-full flex-col'>
-      {/* Header */}
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <Activity className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>System Monitoring</h1>
-            <p className='text-muted-foreground text-sm'>
-              Real-time system metrics and health status
-            </p>
-          </div>
-        </div>
-
-        <div className='flex items-center gap-2'>
+      <PageHeader
+        icon={<Activity />}
+        title="System Monitoring"
+        description="Real-time system metrics and health status"
+        actions={
           <label className='flex items-center gap-2 text-sm'>
             <input
               type='checkbox'
@@ -131,8 +122,8 @@ function MonitoringPage() {
             />
             Auto-refresh
           </label>
-        </div>
-      </div>
+        }
+      />
 
       <div className='flex-1 overflow-auto p-6'>
         <div className='flex flex-col gap-6'>

--- a/admin/src/routes/_authenticated/realtime/index.tsx
+++ b/admin/src/routes/_authenticated/realtime/index.tsx
@@ -20,6 +20,7 @@ import api from '@/lib/api'
 import { getPageNumbers } from '@/lib/utils'
 import { useRealtimeConnections } from '@/hooks/use-realtime-connections'
 import { Badge } from '@/components/ui/badge'
+import { PageHeader } from '@/components/layout/page-header'
 import { Button } from '@/components/ui/button'
 import { Card } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
@@ -174,26 +175,17 @@ function RealtimePage() {
   return (
     <div className='flex h-full flex-col'>
       {/* Header */}
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <Radio className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>Realtime Dashboard</h1>
-            <p className='text-muted-foreground text-sm'>
-              Monitor WebSocket connections and subscriptions
-            </p>
-          </div>
-        </div>
-
-        <div className='flex items-center gap-2'>
+      <PageHeader
+        icon={<Radio />}
+        title="Realtime Dashboard"
+        description="Monitor WebSocket connections and subscriptions"
+        actions={
           <Button variant='outline' size='sm' onClick={fetchStats}>
             <RefreshCw className='mr-2 h-4 w-4' />
             Refresh
           </Button>
-        </div>
-      </div>
+        }
+      />
 
       {/* Stats Cards */}
       <div className='grid grid-cols-1 gap-4 p-6 md:grid-cols-2'>

--- a/admin/src/routes/_authenticated/schema/index.tsx
+++ b/admin/src/routes/_authenticated/schema/index.tsx
@@ -21,6 +21,7 @@ import {
   type SecurityWarning,
 } from "@/lib/api";
 import { BranchSelector } from "@/components/branch-selector";
+import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -209,38 +210,32 @@ function SchemaViewerPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <GitFork className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Schema Viewer</h1>
-            <p className="text-muted-foreground text-sm">
-              Visualize database tables and their relationships
-            </p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <BranchSelector />
-          <Button
-            variant={viewMode === "erd" ? "default" : "outline"}
-            size="sm"
-            onClick={() => setViewMode("erd")}
-          >
-            <LayoutGrid className="mr-2 h-4 w-4" />
-            ERD View
-          </Button>
-          <Button
-            variant={viewMode === "list" ? "default" : "outline"}
-            size="sm"
-            onClick={() => setViewMode("list")}
-          >
-            <List className="mr-2 h-4 w-4" />
-            List View
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        icon={<GitFork />}
+        title="Schema Viewer"
+        description="Visualize database tables and their relationships"
+        actions={
+          <>
+            <BranchSelector />
+            <Button
+              variant={viewMode === "erd" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setViewMode("erd")}
+            >
+              <LayoutGrid className="mr-2 h-4 w-4" />
+              ERD View
+            </Button>
+            <Button
+              variant={viewMode === "list" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setViewMode("list")}
+            >
+              <List className="mr-2 h-4 w-4" />
+              List View
+            </Button>
+          </>
+        }
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <div className="flex items-center gap-4">

--- a/admin/src/routes/_authenticated/security-settings/index.tsx
+++ b/admin/src/routes/_authenticated/security-settings/index.tsx
@@ -16,6 +16,7 @@ import {
   type CaptchaSettingsResponse,
   type UpdateCaptchaSettingsRequest,
 } from "@/lib/api";
+import { PageHeader } from "@/components/layout/page-header";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -195,19 +196,11 @@ function SecuritySettingsPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Shield className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Security Settings</h1>
-            <p className="text-muted-foreground text-sm">
-              Configure CAPTCHA protection for authentication endpoints
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<Shield />}
+        title="Security Settings"
+        description="Configure CAPTCHA protection for authentication endpoints"
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <div className="space-y-4">

--- a/admin/src/routes/_authenticated/service-keys/index.tsx
+++ b/admin/src/routes/_authenticated/service-keys/index.tsx
@@ -42,6 +42,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -381,20 +382,11 @@ function ServiceKeysPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <KeyRound className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Service Keys</h1>
-            <p className="text-muted-foreground text-sm">
-              Manage service keys for server-to-server API access (e.g.,
-              migrations, CLI tools)
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<KeyRound />}
+        title="Service Keys"
+        description="Manage service keys for server-to-server API access (e.g., migrations, CLI tools)"
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <div className="flex flex-col gap-6">

--- a/admin/src/routes/_authenticated/settings/index.tsx
+++ b/admin/src/routes/_authenticated/settings/index.tsx
@@ -19,6 +19,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/layout/page-header'
 import {
   Card,
   CardContent,
@@ -281,19 +282,11 @@ function SettingsPage() {
   return (
     <div className='flex h-full flex-col'>
       {/* Header */}
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <User className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>Account</h1>
-            <p className='text-muted-foreground text-sm'>
-              Manage your profile and account security settings
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<User />}
+        title="Account"
+        description="Manage your profile and account security settings"
+      />
 
       <div className='flex-1 overflow-auto p-6'>
         <Tabs

--- a/admin/src/routes/_authenticated/sql-editor/index.tsx
+++ b/admin/src/routes/_authenticated/sql-editor/index.tsx
@@ -14,6 +14,7 @@ import { Panel, Group, Separator } from "react-resizable-panels";
 import { toast } from "sonner";
 import { useImpersonationStore } from "@/stores/impersonation-store";
 import { BranchSelector } from "@/components/branch-selector";
+import { PageHeader } from "@/components/layout/page-header";
 import api from "@/lib/api";
 import { useTheme } from "@/context/theme-provider";
 import { Button } from "@/components/ui/button";
@@ -455,54 +456,44 @@ function SQLEditorPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            {editorMode === "sql" ? (
-              <Database className="text-primary h-5 w-5" />
-            ) : (
-              <Braces className="text-primary h-5 w-5" />
-            )}
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Query Editor</h1>
-            <p className="text-muted-foreground text-sm">
-              Execute {editorMode === "sql" ? "SQL" : "GraphQL"} queries on the
-              database
-            </p>
-          </div>
-        </div>
+      <PageHeader
+        icon={editorMode === "sql" ? <Database /> : <Braces />}
+        title="Query Editor"
+        description={`Execute ${editorMode === "sql" ? "SQL" : "GraphQL"} queries on the database`}
+        actions={
+          <>
+            <Tabs
+              value={editorMode}
+              onValueChange={(v) => handleModeChange(v as EditorMode)}
+            >
+              <TabsList>
+                <TabsTrigger value="sql" className="gap-2">
+                  <Database className="h-4 w-4" />
+                  SQL
+                </TabsTrigger>
+                <TabsTrigger value="graphql" className="gap-2">
+                  <Braces className="h-4 w-4" />
+                  GraphQL
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
 
-        <Tabs
-          value={editorMode}
-          onValueChange={(v) => handleModeChange(v as EditorMode)}
-        >
-          <TabsList>
-            <TabsTrigger value="sql" className="gap-2">
-              <Database className="h-4 w-4" />
-              SQL
-            </TabsTrigger>
-            <TabsTrigger value="graphql" className="gap-2">
-              <Braces className="h-4 w-4" />
-              GraphQL
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
-
-        <div className="flex items-center gap-2">
-          <BranchSelector />
-          {queryHistory.length > 0 && (
-            <Button variant="outline" size="sm" onClick={clearHistory}>
-              <Trash2 className="mr-2 h-4 w-4" />
-              Clear History
-            </Button>
-          )}
-          <Button size="sm" onClick={executeQuery} disabled={isExecuting}>
-            <Play className="mr-2 h-4 w-4" />
-            {isExecuting ? "Executing..." : "Execute (Ctrl+Enter)"}
-          </Button>
-        </div>
-      </div>
+            <div className="flex items-center gap-2">
+              <BranchSelector />
+              {queryHistory.length > 0 && (
+                <Button variant="outline" size="sm" onClick={clearHistory}>
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Clear History
+                </Button>
+              )}
+              <Button size="sm" onClick={executeQuery} disabled={isExecuting}>
+                <Play className="mr-2 h-4 w-4" />
+                {isExecuting ? "Executing..." : "Execute (Ctrl+Enter)"}
+              </Button>
+            </div>
+          </>
+        }
+      />
 
       <div className="flex flex-1 overflow-hidden p-6">
         <Group orientation="vertical" id="sql-editor-group-v2">

--- a/admin/src/routes/_authenticated/storage-config/index.tsx
+++ b/admin/src/routes/_authenticated/storage-config/index.tsx
@@ -4,6 +4,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { HardDrive, ImageIcon, Info, Lock } from "lucide-react";
 import api, { monitoringApi } from "@/lib/api";
 import { requireInstanceAdmin } from "@/lib/route-guards";
+import { PageHeader } from "@/components/layout/page-header";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -73,20 +74,11 @@ function StorageConfigPage() {
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <HardDrive className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Storage</h1>
-            <p className="text-muted-foreground text-sm">
-              File storage provider settings and upload limits
-            </p>
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={<HardDrive />}
+        title="Storage"
+        description="File storage provider settings and upload limits"
+      />
 
       <div className="flex-1 overflow-auto space-y-6 p-6">
         <Card>

--- a/admin/src/routes/_authenticated/tenants/$tenantId.tsx
+++ b/admin/src/routes/_authenticated/tenants/$tenantId.tsx
@@ -15,6 +15,7 @@ import { format } from 'date-fns'
 import { tenantsApi } from '@/lib/api'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { PageHeader } from '@/components/layout/page-header'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Separator } from '@/components/ui/separator'
 
@@ -53,8 +54,8 @@ function TenantDetailPage() {
 
   return (
     <div className='flex h-full flex-col'>
-      <div className='bg-background flex items-center justify-between border-b px-6 py-4'>
-        <div className='flex items-center gap-3'>
+      <PageHeader
+        leading={
           <Button
             variant='ghost'
             size='sm'
@@ -63,22 +64,20 @@ function TenantDetailPage() {
             <ArrowLeft className='mr-2 h-4 w-4' />
             Back
           </Button>
-          <div className='bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg'>
-            <Building2 className='text-primary h-5 w-5' />
-          </div>
-          <div>
-            <h1 className='text-xl font-semibold'>{tenant.name}</h1>
-            <p className='text-muted-foreground text-sm'>
-              <code className='text-xs'>{tenant.slug}</code>
-              {tenant.is_default && (
-                <Badge variant='default' className='ml-2'>
-                  Default
-                </Badge>
-              )}
-            </p>
-          </div>
-        </div>
-      </div>
+        }
+        icon={<Building2 />}
+        title={tenant.name}
+        description={
+          <>
+            <code className='text-xs'>{tenant.slug}</code>
+            {tenant.is_default && (
+              <Badge variant='default' className='ml-2'>
+                Default
+              </Badge>
+            )}
+          </>
+        }
+      />
 
       <div className='flex-1 overflow-auto p-6'>
         <div className='grid gap-6 md:grid-cols-2'>

--- a/admin/src/routes/_authenticated/tenants/index.tsx
+++ b/admin/src/routes/_authenticated/tenants/index.tsx
@@ -39,6 +39,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layout/page-header";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -240,23 +241,17 @@ function TenantsPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-            <Building2 className="text-primary h-5 w-5" />
-          </div>
-          <div>
-            <h1 className="text-xl font-semibold">Tenants</h1>
-            <p className="text-muted-foreground text-sm">
-              Manage multi-tenant organizations
-            </p>
-          </div>
-        </div>
-        <Button onClick={() => setCreateDialogOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" />
-          Create Tenant
-        </Button>
-      </div>
+      <PageHeader
+        icon={<Building2 />}
+        title="Tenants"
+        description="Manage multi-tenant organizations"
+        actions={
+          <Button onClick={() => setCreateDialogOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Create Tenant
+          </Button>
+        }
+      />
 
       <div className="flex-1 overflow-auto p-6">
         <div className="flex flex-col gap-6">

--- a/admin/src/routes/_authenticated/users/index.tsx
+++ b/admin/src/routes/_authenticated/users/index.tsx
@@ -6,6 +6,7 @@ import { Users, UserPlus, UserCheck, Clock, Shield } from "lucide-react";
 import { userManagementApi } from "@/lib/api";
 import { useTenantStore } from "@/stores/tenant-store";
 import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/layout/page-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UsersDialogs } from "@/features/users/components/users-dialogs";
@@ -146,27 +147,23 @@ function UsersPage() {
   return (
     <UsersProvider userType={activeTab}>
       <div className="flex h-full flex-col">
-        <div className="bg-background flex items-center justify-between border-b px-6 py-4">
-          <div className="flex items-center gap-3">
-            <div className="bg-primary/10 flex h-10 w-10 items-center justify-center rounded-lg">
-              <Users className="text-primary h-5 w-5" />
-            </div>
-            <div>
-              <h1 className="text-xl font-semibold">Users</h1>
-              <p className="text-muted-foreground text-sm">
-                {activeTab === "dashboard"
-                  ? "Manage Fluxbase dashboard administrators"
-                  : "Manage application users"}
-              </p>
-            </div>
-          </div>
-          {activeTab === "app" && (
-            <Button onClick={() => setInviteDialogOpen(true)}>
-              <UserPlus className="mr-2 h-4 w-4" />
-              Invite User
-            </Button>
-          )}
-        </div>
+        <PageHeader
+          icon={<Users />}
+          title="Users"
+          description={
+            activeTab === "dashboard"
+              ? "Manage Fluxbase dashboard administrators"
+              : "Manage application users"
+          }
+          actions={
+            activeTab === "app" ? (
+              <Button onClick={() => setInviteDialogOpen(true)}>
+                <UserPlus className="mr-2 h-4 w-4" />
+                Invite User
+              </Button>
+            ) : undefined
+          }
+        />
 
         <div className="flex-1 overflow-auto p-6">
           {isInstanceScope ? (

--- a/docs/src/content/docs/intro.md
+++ b/docs/src/content/docs/intro.md
@@ -33,7 +33,7 @@ Fluxbase is a lightweight, single-binary Backend-as-a-Service (BaaS) alternative
 
 - **PostgREST Compatible**: Use existing Supabase knowledge
 - **Auto-Generated APIs**: Database tables become REST endpoints automatically
-- **TypeScript & Go SDKs**: First-class support for modern development
+- **TypeScript SDK**: First-class support for modern development
 
 ## Core Features
 

--- a/docs/src/content/docs/sdk-react/getting-started.md
+++ b/docs/src/content/docs/sdk-react/getting-started.md
@@ -1,0 +1,212 @@
+---
+title: Getting Started
+description: React hooks for Fluxbase — provider setup, queries, mutations, and auth.
+---
+
+# React SDK Getting Started
+
+## Installation
+
+```bash
+npm install @nimbleflux/fluxbase-sdk-react @nimbleflux/fluxbase-sdk @tanstack/react-query
+# or
+bun add @nimbleflux/fluxbase-sdk-react @nimbleflux/fluxbase-sdk @tanstack/react-query
+```
+
+## Provider Setup
+
+Wrap your app with the `FluxbaseProvider` and `QueryClientProvider`:
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { FluxbaseProvider, createClient } from "@nimbleflux/fluxbase-sdk-react";
+
+const client = createClient({
+  url: "https://your-fluxbase-instance.com",
+  apiKey: "your-client-key",
+});
+
+const queryClient = new QueryClient();
+
+function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <FluxbaseProvider client={client}>
+        <YourApp />
+      </FluxbaseProvider>
+    </QueryClientProvider>
+  );
+}
+```
+
+## Data Queries
+
+### useTable — Query a Table
+
+```tsx
+import { useTable } from "@nimbleflux/fluxbase-sdk-react";
+
+function ProductList() {
+  const { data, isLoading, error } = useTable("products", {
+    select: "id, name, price",
+    gte: { price: 10 },
+    order: { column: "created_at", ascending: false },
+    limit: 20,
+  });
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <ul>
+      {data?.map((product) => (
+        <li key={product.id}>{product.name} — ${product.price}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+### useInsert, useUpdate, useDelete — Mutations
+
+```tsx
+import { useInsert, useUpdate, useDelete } from "@nimbleflux/fluxbase-sdk-react";
+
+function ProductActions() {
+  const insert = useInsert("products");
+  const update = useUpdate("products");
+  const deleteMutation = useDelete("products");
+
+  const handleCreate = async () => {
+    await insert.mutateAsync({ name: "Widget", price: 29.99 });
+  };
+
+  const handlePriceUpdate = async (id: string) => {
+    await update.mutateAsync({ id, values: { price: 24.99 } });
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteMutation.mutateAsync({ id });
+  };
+
+  return <div>{/* your UI */}</div>;
+}
+```
+
+## Authentication
+
+### useUser, useSignIn, useSignOut
+
+```tsx
+import { useUser, useSignIn, useSignOut } from "@nimbleflux/fluxbase-sdk-react";
+
+function AuthBar() {
+  const { data: user, isLoading } = useUser();
+  const signIn = useSignIn();
+  const signOut = useSignOut();
+
+  if (isLoading) return null;
+
+  if (!user) {
+    return <button onClick={() => signIn.mutateAsync({ email: "...", password: "..." })}>Sign In</button>;
+  }
+
+  return (
+    <div>
+      <span>{user.email}</span>
+      <button onClick={() => signOut.mutateAsync()}>Sign Out</button>
+    </div>
+  );
+}
+```
+
+## Realtime
+
+### useTableSubscription
+
+```tsx
+import { useTableSubscription } from "@nimbleflux/fluxbase-sdk-react";
+
+function LiveProductList() {
+  const { data, isLoading } = useTable("products");
+  useTableSubscription("products", (payload) => {
+    console.log("Realtime update:", payload);
+  });
+
+  if (isLoading) return <p>Loading...</p>;
+
+  return <ul>{data?.map((p) => <li key={p.id}>{p.name}</li>)}</ul>;
+}
+```
+
+## Storage
+
+### useStorageUpload, useStorageList
+
+```tsx
+import { useStorageUpload, useStorageList, useStorageDownload } from "@nimbleflux/fluxbase-sdk-react";
+
+function FileManager() {
+  const { data: files } = useStorageList("documents");
+  const upload = useStorageUpload("documents");
+  const download = useStorageDownload("documents");
+
+  const handleUpload = async (file: File) => {
+    await upload.mutateAsync({ path: file.name, file });
+  };
+
+  return (
+    <div>
+      <input type="file" onChange={(e) => e.target.files?.[0] && handleUpload(e.target.files[0])} />
+      {files?.map((f) => <div key={f.name}>{f.name}</div>)}
+    </div>
+  );
+}
+```
+
+## Available Hooks
+
+### Data
+- `useTable`, `useInsert`, `useUpdate`, `useUpsert`, `useDelete` — CRUD operations
+- `useGraphQLQuery`, `useGraphQLMutation` — GraphQL queries
+
+### Auth
+- `useUser`, `useSession`, `useSignIn`, `useSignUp`, `useSignOut`, `useUpdateUser`
+- `useSAMLProviders`, `useSignInWithSAML` — SAML SSO
+
+### Realtime
+- `useTableSubscription`, `useTableInserts`, `useTableUpdates`, `useTableDeletes`
+
+### Storage
+- `useStorageList`, `useStorageUpload`, `useStorageDownload`, `useStorageDelete`
+- `useStoragePublicUrl`, `useStorageSignedUrl`, `useStorageBuckets`
+
+### Functions & Jobs
+- `useInvokeFunction`, `useFunctions` — Edge functions
+- `useSubmitJob`, `useJobStatus`, `useJobs`, `useCancelJob`, `useRetryJob` — Background jobs
+
+### AI & Knowledge Bases
+- `useChatbots`, `useConversations`, `useAIChat` — AI chatbots
+- `useKnowledgeBases`, `useKBDocuments`, `useKBSearch` — Knowledge bases
+
+### Admin
+- `useAdminAuth`, `useUsers`, `useClientKeys`, `useServiceKeys`
+- `useSecrets`, `useMigrations`, `useSchemas`, `useTables` (DDL)
+- `useImpersonateUser`, `useStopImpersonation`
+- `useWebhooks`, `useAppSettings`, `useSystemSettings`
+
+### Branching
+- `useBranches`, `useCreateBranch`, `useDeleteBranch`, `useResetBranch`
+
+## Error Handling
+
+All hooks use TanStack Query — errors are available on the `error` field:
+
+```tsx
+const { data, error, isLoading } = useTable("products");
+
+if (error) {
+  // error is an Error instance
+  console.error(error.message);
+}
+```

--- a/docs/src/content/docs/sdk/getting-started.md
+++ b/docs/src/content/docs/sdk/getting-started.md
@@ -1,0 +1,153 @@
+---
+title: Getting Started
+description: Install the Fluxbase TypeScript SDK and make your first query in minutes.
+---
+
+# TypeScript SDK Getting Started
+
+## Installation
+
+```bash
+npm install @nimbleflux/fluxbase-sdk
+# or
+bun add @nimbleflux/fluxbase-sdk
+# or
+yarn add @nimbleflux/fluxbase-sdk
+```
+
+## Quick Start
+
+```typescript
+import { createClient } from "@nimbleflux/fluxbase-sdk";
+
+const client = createClient({
+  url: "https://your-fluxbase-instance.com",
+  apiKey: "your-api-key", // client key (publishable) or service key (secret)
+});
+
+// Query a table
+const { data, error } = await client
+  .from("products")
+  .select("id, name, price")
+  .gte("price", 10)
+  .order("created_at", { ascending: false })
+  .limit(20);
+
+if (error) {
+  console.error("Query failed:", error);
+} else {
+  console.log("Products:", data);
+}
+```
+
+## Authentication
+
+### Sign Up / Sign In
+
+```typescript
+// Create a new user
+const { data: signUpData, error: signUpError } = await client.auth.signUp({
+  email: "user@example.com",
+  password: "secure-password",
+});
+
+// Sign in
+const { session, error } = await client.auth.signIn({
+  email: "user@example.com",
+  password: "secure-password",
+});
+
+// Session is automatically stored and sent with subsequent requests
+```
+
+### OAuth
+
+```typescript
+// Get OAuth URL for Google
+const { data, error } = await client.auth.getOAuthUrl({
+  provider: "google",
+  redirectUrl: "http://localhost:3000/callback",
+});
+
+window.location.href = data.url;
+```
+
+## Data Operations
+
+### Insert
+
+```typescript
+const { data, error } = await client
+  .from("products")
+  .insert({ name: "Widget", price: 29.99 })
+  .select();
+```
+
+### Update
+
+```typescript
+const { data, error } = await client
+  .from("products")
+  .update({ price: 24.99 })
+  .eq("id", productId)
+  .select();
+```
+
+### Delete
+
+```typescript
+const { error } = await client
+  .from("products")
+  .delete()
+  .eq("id", productId);
+```
+
+## Realtime
+
+```typescript
+const channel = client
+  .channel("products-changes")
+  .on("postgres_changes", { table: "products" }, (payload) => {
+    console.log("Change:", payload);
+  })
+  .subscribe();
+```
+
+## Storage
+
+```typescript
+// Upload a file
+const { error } = await client.storage
+  .from("documents")
+  .upload("report.pdf", fileBlob);
+
+// Download a file
+const { data, error } = await client.storage
+  .from("documents")
+  .download("report.pdf");
+```
+
+## Error Handling
+
+All SDK methods return a `{ data, error }` result type. Check for errors explicitly:
+
+```typescript
+const { data, error } = await client.from("users").select("*");
+
+if (error) {
+  // Handle error — error is always an Error object with status/code
+  console.error(error.message);
+  return;
+}
+
+// Use data — TypeScript knows it's defined here
+console.log(data);
+```
+
+## Next Steps
+
+- [Advanced Features](./advanced-features) — Aggregations, vector search, batch operations
+- [Admin SDK](./admin) — Admin operations (users, client keys, webhooks)
+- [Management SDK](./management) — Client keys, webhooks, invitations
+- [Settings SDK](./settings) — App and system settings
+- [DDL SDK](./ddl) — Schema and table management

--- a/internal/api/admin_session_handler.go
+++ b/internal/api/admin_session_handler.go
@@ -64,13 +64,7 @@ func (h *AdminSessionHandler) ListSessions(c fiber.Ctx) error {
 		return apperrors.SendInternalError(c, "Failed to list sessions")
 	}
 
-	return c.JSON(fiber.Map{
-		"sessions":    sessions,
-		"count":       len(sessions),
-		"total_count": total,
-		"limit":       limit,
-		"offset":      offset,
-	})
+	return apperrors.SendPaginated(c, "sessions", sessions, total, limit, offset)
 }
 
 // RevokeSession revokes a specific session

--- a/internal/api/admin_session_handler_test.go
+++ b/internal/api/admin_session_handler_test.go
@@ -202,19 +202,17 @@ func TestSessionResponses_Format(t *testing.T) {
 	t.Run("list sessions response structure", func(t *testing.T) {
 		// Test expected pagination response structure
 		expectedResponse := fiber.Map{
-			"sessions":    []interface{}{},
-			"count":       0,
-			"total_count": 0,
-			"limit":       25,
-			"offset":      0,
+			"sessions": []interface{}{},
+			"total":    0,
+			"limit":    25,
+			"offset":   0,
 		}
 
 		data, err := json.Marshal(expectedResponse)
 		require.NoError(t, err)
 
 		assert.Contains(t, string(data), `"sessions"`)
-		assert.Contains(t, string(data), `"count"`)
-		assert.Contains(t, string(data), `"total_count"`)
+		assert.Contains(t, string(data), `"total"`)
 		assert.Contains(t, string(data), `"limit"`)
 		assert.Contains(t, string(data), `"offset"`)
 	})

--- a/internal/api/admin_session_integration_test.go
+++ b/internal/api/admin_session_integration_test.go
@@ -38,17 +38,16 @@ func TestAdminSession_ListSessions_Integration(t *testing.T) {
 
 	// Verify response structure
 	assert.Contains(t, result, "sessions")
-	assert.Contains(t, result, "count")
-	assert.Contains(t, result, "total_count")
+	assert.Contains(t, result, "total")
 	assert.Contains(t, result, "limit")
 	assert.Contains(t, result, "offset")
 
 	sessions := result["sessions"].([]interface{})
-	count := int(result["count"].(float64))
+	total := int(result["total"].(float64))
 
 	// Should have at least 1 session (admin)
 	// Note: User signup may not create an auth session in the same way as dashboard login
-	assert.GreaterOrEqual(t, count, 1, "Should have at least admin session")
+	assert.GreaterOrEqual(t, total, 1, "Should have at least admin session")
 	assert.GreaterOrEqual(t, len(sessions), 1, "Sessions array should have at least 1 entry")
 }
 

--- a/internal/api/branch_handler.go
+++ b/internal/api/branch_handler.go
@@ -9,8 +9,8 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/branching"
-	apperrors "github.com/nimbleflux/fluxbase/internal/errors"
 	"github.com/nimbleflux/fluxbase/internal/config"
+	apperrors "github.com/nimbleflux/fluxbase/internal/errors"
 	"github.com/nimbleflux/fluxbase/internal/middleware"
 )
 

--- a/internal/api/branch_handler.go
+++ b/internal/api/branch_handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/branching"
+	apperrors "github.com/nimbleflux/fluxbase/internal/errors"
 	"github.com/nimbleflux/fluxbase/internal/config"
 	"github.com/nimbleflux/fluxbase/internal/middleware"
 )
@@ -234,12 +235,7 @@ func (h *BranchHandler) ListBranches(c fiber.Ctx) error {
 		total = len(branches)
 	}
 
-	return c.JSON(fiber.Map{
-		"branches": branches,
-		"total":    total,
-		"limit":    filter.Limit,
-		"offset":   filter.Offset,
-	})
+	return apperrors.SendPaginated(c, "branches", branches, total, filter.Limit, filter.Offset)
 }
 
 // GetBranch handles GET /admin/branches/:id

--- a/internal/api/graphql_operators_test.go
+++ b/internal/api/graphql_operators_test.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nimbleflux/fluxbase/internal/database"
+)
+
+// TestBuildFiltersFromArgs_LogicalOperators tests _and, _or, _not
+// in GraphQL filter arguments. The resolver implementation was already
+// present but the schema never exposed these fields — now it does.
+func TestBuildFiltersFromArgs_LogicalOperators(t *testing.T) {
+	gen := NewGraphQLSchemaGenerator(nil, nil, true)
+
+	table := database.TableInfo{
+		Schema: "public",
+		Name:   "products",
+		Columns: []database.ColumnInfo{
+			{Name: "id", DataType: "integer"},
+			{Name: "name", DataType: "text"},
+			{Name: "price", DataType: "numeric"},
+			{Name: "in_stock", DataType: "boolean"},
+		},
+	}
+
+	t.Run("_and flattens conditions into AND filters", func(t *testing.T) {
+		args := map[string]interface{}{
+			"_and": []interface{}{
+				map[string]interface{}{
+					"price_gt": 10,
+				},
+				map[string]interface{}{
+					"inStock_eq": true,
+				},
+			},
+		}
+
+		filters := gen.buildFiltersFromArgs(table, args)
+		assert.Len(t, filters, 2)
+		assert.Equal(t, "price", filters[0].Column)
+		assert.Equal(t, "gt", string(filters[0].Operator))
+		assert.Equal(t, 10, filters[0].Value)
+		assert.Equal(t, "in_stock", filters[1].Column)
+		assert.Equal(t, "eq", string(filters[1].Operator))
+		assert.False(t, filters[0].IsOr)
+		assert.False(t, filters[1].IsOr)
+		// _and should not assign OR group IDs
+		assert.Equal(t, 0, filters[0].OrGroupID)
+		assert.Equal(t, 0, filters[1].OrGroupID)
+	})
+
+	t.Run("_or assigns same OrGroupID to conditions", func(t *testing.T) {
+		args := map[string]interface{}{
+			"_or": []interface{}{
+				map[string]interface{}{
+					"name_eq": "Widget",
+				},
+				map[string]interface{}{
+					"name_eq": "Gadget",
+				},
+			},
+		}
+
+		filters := gen.buildFiltersFromArgs(table, args)
+		assert.Len(t, filters, 2)
+		assert.Equal(t, "name", filters[0].Column)
+		assert.Equal(t, "name", filters[1].Column)
+		// Both should share the same non-zero OrGroupID
+		assert.NotEqual(t, 0, filters[0].OrGroupID)
+		assert.Equal(t, filters[0].OrGroupID, filters[1].OrGroupID)
+	})
+
+	t.Run("_not negates enclosed conditions", func(t *testing.T) {
+		args := map[string]interface{}{
+			"_not": map[string]interface{}{
+				"price_gt": 100,
+			},
+		}
+
+		filters := gen.buildFiltersFromArgs(table, args)
+		assert.Len(t, filters, 1)
+		// _not(price > 100) should become price <= 100
+		assert.Equal(t, "price", filters[0].Column)
+		assert.Equal(t, "lte", string(filters[0].Operator))
+	})
+
+	t.Run("nested _and inside _or", func(t *testing.T) {
+		args := map[string]interface{}{
+			"_or": []interface{}{
+				map[string]interface{}{
+					"_and": []interface{}{
+						map[string]interface{}{"price_gt": 10},
+						map[string]interface{}{"price_lt": 50},
+					},
+				},
+				map[string]interface{}{
+					"inStock_eq": true,
+				},
+			},
+		}
+
+		filters := gen.buildFiltersFromArgs(table, args)
+		assert.Len(t, filters, 3)
+
+		// First two filters (from _and) should share an OrGroupID
+		assert.Equal(t, "price", filters[0].Column)
+		assert.Equal(t, "price", filters[1].Column)
+		assert.NotEqual(t, 0, filters[0].OrGroupID)
+		assert.Equal(t, filters[0].OrGroupID, filters[1].OrGroupID)
+
+		// Third filter (inStock) should share the same OrGroupID (from _or)
+		assert.Equal(t, "in_stock", filters[2].Column)
+		assert.Equal(t, filters[0].OrGroupID, filters[2].OrGroupID)
+	})
+
+	t.Run("_not with _or inside", func(t *testing.T) {
+		args := map[string]interface{}{
+			"_not": map[string]interface{}{
+				"_or": []interface{}{
+					map[string]interface{}{"name_eq": "A"},
+					map[string]interface{}{"name_eq": "B"},
+				},
+			},
+		}
+
+		filters := gen.buildFiltersFromArgs(table, args)
+		assert.Len(t, filters, 2)
+
+		// _not(name = A OR name = B) → name != A AND name != B
+		assert.Equal(t, "name", filters[0].Column)
+		assert.Equal(t, "neq", string(filters[0].Operator))
+		assert.Equal(t, "name", filters[1].Column)
+		assert.Equal(t, "neq", string(filters[1].Operator))
+
+		// Negated OR conditions should NOT have OrGroupID (they become AND)
+		assert.Equal(t, 0, filters[0].OrGroupID)
+		assert.Equal(t, 0, filters[1].OrGroupID)
+	})
+
+	t.Run("mixed logical and column filters", func(t *testing.T) {
+		args := map[string]interface{}{
+			"inStock_eq": true,
+			"_and": []interface{}{
+				map[string]interface{}{"price_gt": 10},
+				map[string]interface{}{"price_lt": 100},
+			},
+		}
+
+		filters := gen.buildFiltersFromArgs(table, args)
+		assert.GreaterOrEqual(t, len(filters), 3)
+
+		// All should be AND conditions (no OrGroupID unless from _or)
+		for _, f := range filters {
+			assert.Equal(t, 0, f.OrGroupID, "filter on %s should not have OrGroupID", f.Column)
+		}
+	})
+}
+
+// TestGenerateFilterType_IncludesLogicalOperators verifies the generated
+// filter input type exposes _and, _or, _not fields for self-referencing.
+func TestGenerateFilterType_IncludesLogicalOperators(t *testing.T) {
+	gen := NewGraphQLSchemaGenerator(nil, nil, true)
+
+	table := database.TableInfo{
+		Schema: "public",
+		Name:   "products",
+		Columns: []database.ColumnInfo{
+			{Name: "id", DataType: "integer"},
+			{Name: "name", DataType: "text"},
+		},
+	}
+
+	filterType := gen.generateFilterType(table)
+	assert.NotNil(t, filterType)
+
+	// The thunk is resolved when Fields() is called (during schema assembly).
+	// Call it to verify the self-referencing fields exist.
+	fields := filterType.Fields()
+
+	_, hasAnd := fields["_and"]
+	assert.True(t, hasAnd, "filter type should have _and field")
+
+	_, hasOr := fields["_or"]
+	assert.True(t, hasOr, "filter type should have _or field")
+
+	_, hasNot := fields["_not"]
+	assert.True(t, hasNot, "filter type should have _not field")
+
+	// Verify column-based filters still exist
+	_, hasNameEq := fields["name_eq"]
+	assert.True(t, hasNameEq, "filter type should still have column-based filters")
+}

--- a/internal/api/graphql_resolvers.go
+++ b/internal/api/graphql_resolvers.go
@@ -643,10 +643,15 @@ func (g *GraphQLSchemaGenerator) buildFiltersFromArgsWithCounter(table database.
 			continue
 		}
 		if key == "_or" {
-			// OR: each element in the array gets the same OrGroupID
+			// OR: each element in the array gets the same OrGroupID.
+			// When negated (inside _not), De Morgan's law applies:
+			// NOT(A OR B) = NOT A AND NOT B, so we skip OrGroupID.
 			if orArr, ok := value.([]interface{}); ok {
-				*orGroupCounter++
-				groupID := *orGroupCounter
+				groupID := 0
+				if !negated {
+					*orGroupCounter++
+					groupID = *orGroupCounter
+				}
 				for _, orItem := range orArr {
 					if orMap, ok := orItem.(map[string]interface{}); ok {
 						subFilters := g.buildFiltersFromArgsWithCounter(table, orMap, orGroupCounter, groupID, negated)

--- a/internal/api/graphql_schema.go
+++ b/internal/api/graphql_schema.go
@@ -491,19 +491,32 @@ func (g *GraphQLSchemaGenerator) generateFilterType(table database.TableInfo) *g
 		}
 	}
 
-	// Add logical operators to the filter type
+	// Create filter type name
 	filterTypeName := typeName + "Filter"
 
-	// NOTE: Self-referencing filter operators (_and, _or, _not) are not supported
-	// in graphql-go v0.8.1 due to limitations in input object type resolution.
-	// Users can still filter on individual columns using the column-specific operators
-	// (eq, neq, gt, gte, lt, lte, like, ilike, in, is_null, contains, contained_by).
-
-	// Create the filter type with column-based filters only
-	filterType := graphql.NewInputObject(graphql.InputObjectConfig{
+	// Create the filter type with column-based filters + logical operators.
+	// Self-referencing fields (_and, _or, _not) use a thunk to break the
+	// circular dependency — the thunk runs lazily during schema assembly,
+	// after filterType is already assigned.
+	var filterType *graphql.InputObject
+	filterType = graphql.NewInputObject(graphql.InputObjectConfig{
 		Name:        filterTypeName,
 		Description: fmt.Sprintf("Filter type for %s.%s", table.Schema, table.Name),
-		Fields:      fields,
+		Fields: graphql.InputObjectConfigFieldMapThunk(func() graphql.InputObjectConfigFieldMap {
+			fields["_and"] = &graphql.InputObjectFieldConfig{
+				Type:        graphql.NewList(graphql.NewNonNull(filterType)),
+				Description: "Logical AND — all conditions must match",
+			}
+			fields["_or"] = &graphql.InputObjectFieldConfig{
+				Type:        graphql.NewList(graphql.NewNonNull(filterType)),
+				Description: "Logical OR — any condition must match",
+			}
+			fields["_not"] = &graphql.InputObjectFieldConfig{
+				Type:        filterType,
+				Description: "Logical NOT — negates all enclosed conditions",
+			}
+			return fields
+		}),
 	})
 	g.filterTypes[filterTypeName] = filterType
 

--- a/internal/api/monitoring_handler.go
+++ b/internal/api/monitoring_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/database"
+	apperrors "github.com/nimbleflux/fluxbase/internal/errors"
 	"github.com/nimbleflux/fluxbase/internal/jobs"
 	"github.com/nimbleflux/fluxbase/internal/logging"
 	"github.com/nimbleflux/fluxbase/internal/middleware"
@@ -451,13 +452,8 @@ func (h *MonitoringHandler) GetLogs(c fiber.Ctx) error {
 		})
 	}
 
-	return c.JSON(fiber.Map{
-		"logs":    logs,
-		"total":   result.TotalCount,
-		"limit":   limit,
-		"offset":  opts.Offset,
-		"hasMore": result.TotalCount > int64(opts.Offset+len(logs)),
-	})
+	hasMore := result.TotalCount > int64(opts.Offset+len(logs))
+	return apperrors.SendPaginatedWithMore(c, "logs", logs, int(result.TotalCount), limit, opts.Offset, hasMore)
 }
 
 // fiber:context-methods migrated

--- a/internal/api/realtime_stats_handler.go
+++ b/internal/api/realtime_stats_handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 
 	"github.com/nimbleflux/fluxbase/internal/database"
+	apperrors "github.com/nimbleflux/fluxbase/internal/errors"
 	"github.com/nimbleflux/fluxbase/internal/realtime"
 )
 
@@ -93,11 +94,6 @@ func newRealtimeStatsHandler(db *database.Connection, manager *realtime.Manager)
 			filteredConnections = filteredConnections[:limit]
 		}
 
-		return c.JSON(fiber.Map{
-			"total_connections": total,
-			"connections":       filteredConnections,
-			"limit":             limit,
-			"offset":            offset,
-		})
+		return apperrors.SendPaginated(c, "connections", filteredConnections, total, limit, offset)
 	}
 }

--- a/internal/api/scalar_handler.go
+++ b/internal/api/scalar_handler.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"github.com/gofiber/fiber/v3"
+)
+
+const scalarHTML = `<!DOCTYPE html>
+<html>
+  <head>
+    <title>Fluxbase API Reference</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body { margin: 0; }
+    </style>
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="/openapi.json"
+      data-proxy-url=""
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>`
+
+func HandleScalarAPIReference(c fiber.Ctx) error {
+	c.Set("Content-Type", "text/html; charset=utf-8")
+	c.Set("Cache-Control", "no-cache")
+	return c.SendString(scalarHTML)
+}

--- a/internal/api/server_routes.go
+++ b/internal/api/server_routes.go
@@ -14,6 +14,8 @@ func (s *Server) setupRoutes() {
 		log.Fatal().Err(err).Msg("Failed to setup routes via registry")
 	}
 
+	s.app.Get("/api-docs", HandleScalarAPIReference)
+
 	if s.config.Admin.Enabled {
 		if s.config.Security.SetupToken == "" {
 			log.Error().Msg("Admin UI is enabled but FLUXBASE_SECURITY_SETUP_TOKEN is not set. Admin UI will not be registered for security reasons.")

--- a/internal/api/user_management_handler.go
+++ b/internal/api/user_management_handler.go
@@ -100,12 +100,7 @@ func (h *UserManagementHandler) ListUsers(c fiber.Ctx) error {
 		filteredUsers = filteredUsers[:limit]
 	}
 
-	return c.JSON(fiber.Map{
-		"users":  filteredUsers,
-		"total":  total,
-		"limit":  limit,
-		"offset": offset,
-	})
+	return apperrors.SendPaginated(c, "users", filteredUsers, total, limit, offset)
 }
 
 func (h *UserManagementHandler) GetUserByID(c fiber.Ctx) error {

--- a/internal/errors/http.go
+++ b/internal/errors/http.go
@@ -246,6 +246,16 @@ func SendPaginated(c fiber.Ctx, key string, data interface{}, total, limit, offs
 	})
 }
 
+func SendPaginatedWithMore(c fiber.Ctx, key string, data interface{}, total, limit, offset int, hasMore bool) error {
+	return c.JSON(fiber.Map{
+		key:      data,
+		"total":  total,
+		"limit":  limit,
+		"offset": offset,
+		"hasMore": hasMore,
+	})
+}
+
 func SendAffected(c fiber.Ctx, affected int) error {
 	return c.JSON(fiber.Map{
 		"affected": affected,

--- a/internal/errors/http.go
+++ b/internal/errors/http.go
@@ -248,10 +248,10 @@ func SendPaginated(c fiber.Ctx, key string, data interface{}, total, limit, offs
 
 func SendPaginatedWithMore(c fiber.Ctx, key string, data interface{}, total, limit, offset int, hasMore bool) error {
 	return c.JSON(fiber.Map{
-		key:      data,
-		"total":  total,
-		"limit":  limit,
-		"offset": offset,
+		key:       data,
+		"total":   total,
+		"limit":   limit,
+		"offset":  offset,
 		"hasMore": hasMore,
 	})
 }

--- a/sdk-react/src/index.ts
+++ b/sdk-react/src/index.ts
@@ -144,6 +144,23 @@ export { useSubmitJob, useJobStatus } from "./use-jobs";
 // Branching hooks
 export { useBranches } from "./use-branches";
 
+// RPC hooks
+export { useRPCList, useInvokeRPC } from "./use-rpc";
+
+// Vector hooks
+export { useVectorEmbed, useVectorSearch } from "./use-vector";
+
+// Secrets hooks
+export { useSecrets, useCreateSecret, useUpdateSecret, useDeleteSecret } from "./use-secrets";
+
+// Service Keys hooks
+export {
+  useServiceKeys,
+  useCreateServiceKey,
+  useRotateServiceKey,
+  useRevokeServiceKey,
+} from "./use-service-keys";
+
 // AI hooks
 export {
   useChatbots,

--- a/sdk-react/src/test-utils.tsx
+++ b/sdk-react/src/test-utils.tsx
@@ -91,6 +91,33 @@ export function createMockClient(
       }),
       ...overrides.realtime,
     },
+    jobs: {
+      submit: vi.fn().mockResolvedValue({ data: { id: "job-1", status: "pending" }, error: null }),
+      get: vi.fn().mockResolvedValue({ data: { id: "job-1", status: "completed" }, error: null }),
+      list: vi.fn().mockResolvedValue({ data: [], error: null }),
+      cancel: vi.fn().mockResolvedValue({ data: null, error: null }),
+      retry: vi.fn().mockResolvedValue({ data: { id: "job-2", status: "pending" }, error: null }),
+      getLogs: vi.fn().mockResolvedValue({ data: [], error: null }),
+      ...overrides.jobs,
+    },
+    functions: {
+      invoke: vi.fn().mockResolvedValue({ data: null, error: null }),
+      list: vi.fn().mockResolvedValue({ data: [], error: null }),
+      get: vi.fn().mockResolvedValue({ data: null, error: null }),
+      ...overrides.functions,
+    },
+    branching: {
+      list: vi.fn().mockResolvedValue({ data: { branches: [], total: 0, limit: 50, offset: 0 }, error: null }),
+      get: vi.fn().mockResolvedValue({ data: null, error: null }),
+      create: vi.fn().mockResolvedValue({ data: { id: "b1", slug: "test-branch", status: "creating" }, error: null }),
+      delete: vi.fn().mockResolvedValue({ error: null }),
+      reset: vi.fn().mockResolvedValue({ data: { id: "b1", slug: "test-branch", status: "creating" }, error: null }),
+      getActivity: vi.fn().mockResolvedValue({ data: [], error: null }),
+      getPoolStats: vi.fn().mockResolvedValue({ data: [], error: null }),
+      exists: vi.fn().mockResolvedValue(false),
+      waitForReady: vi.fn().mockResolvedValue({ data: null, error: null }),
+      ...overrides.branching,
+    },
     graphql: {
       execute: vi.fn().mockResolvedValue({ data: null, errors: null }),
       query: vi.fn().mockResolvedValue({ data: null, errors: null }),
@@ -142,7 +169,96 @@ export function createMockClient(
           test: vi.fn().mockResolvedValue({}),
         },
       },
+      serviceKeys: {
+        list: vi.fn().mockResolvedValue({ data: [], error: null }),
+        get: vi.fn().mockResolvedValue({ data: null, error: null }),
+        create: vi.fn().mockResolvedValue({ data: null, error: null }),
+        update: vi.fn().mockResolvedValue({ data: null, error: null }),
+        delete: vi.fn().mockResolvedValue({ error: null }),
+        disable: vi.fn().mockResolvedValue({ error: null }),
+        enable: vi.fn().mockResolvedValue({ error: null }),
+        revoke: vi.fn().mockResolvedValue({ error: null }),
+        deprecate: vi.fn().mockResolvedValue({ data: null, error: null }),
+        rotate: vi.fn().mockResolvedValue({ data: null, error: null }),
+        getRevocationHistory: vi.fn().mockResolvedValue({ data: null, error: null }),
+      },
+      migrations: {
+        list: vi.fn().mockResolvedValue({ data: [], error: null }),
+        apply: vi
+          .fn()
+          .mockResolvedValue({ data: { message: "Migration applied" }, error: null }),
+        rollback: vi
+          .fn()
+          .mockResolvedValue({ data: { message: "Migration rolled back" }, error: null }),
+        sync: vi.fn().mockResolvedValue({ data: null, error: null }),
+      },
+      impersonation: {
+        impersonateUser: vi
+          .fn()
+          .mockResolvedValue({
+            session: null,
+            target_user: null,
+            access_token: "",
+            refresh_token: "",
+            expires_in: 0,
+          }),
+        impersonateAnon: vi
+          .fn()
+          .mockResolvedValue({
+            session: null,
+            target_user: null,
+            access_token: "",
+            refresh_token: "",
+            expires_in: 0,
+          }),
+        stop: vi
+          .fn()
+          .mockResolvedValue({ success: true, message: "Impersonation stopped" }),
+        getCurrent: vi.fn().mockResolvedValue({ session: null, target_user: null }),
+        listSessions: vi.fn().mockResolvedValue({ sessions: [], total: 0 }),
+      },
+      ddl: {
+        listSchemas: vi.fn().mockResolvedValue({ schemas: [] }),
+        createSchema: vi
+          .fn()
+          .mockResolvedValue({ message: "Schema created", schema: "" }),
+        listTables: vi.fn().mockResolvedValue({ tables: [] }),
+        deleteTable: vi
+          .fn()
+          .mockResolvedValue({ message: "Table deleted" }),
+      },
       ...overrides.admin,
+    },
+    rpc: Object.assign(
+      vi.fn().mockResolvedValue({ data: null, error: null }),
+      {
+        list: vi.fn().mockResolvedValue({ data: [], error: null }),
+        invoke: vi.fn().mockResolvedValue({ data: null, error: null }),
+        getStatus: vi.fn().mockResolvedValue({ data: null, error: null }),
+        getLogs: vi.fn().mockResolvedValue({ data: [], error: null }),
+        waitForCompletion: vi.fn().mockResolvedValue({ data: null, error: null }),
+      },
+    ),
+    secrets: {
+      list: vi.fn().mockResolvedValue([]),
+      create: vi.fn().mockResolvedValue({ id: "1", name: "test", scope: "global", version: 1, created_at: "", updated_at: "" }),
+      get: vi.fn().mockResolvedValue({ id: "1", name: "test", scope: "global", version: 1, created_at: "", updated_at: "" }),
+      update: vi.fn().mockResolvedValue({ id: "1", name: "test", scope: "global", version: 2, created_at: "", updated_at: "" }),
+      delete: vi.fn().mockResolvedValue(undefined),
+      getVersions: vi.fn().mockResolvedValue([]),
+      rollback: vi.fn().mockResolvedValue({ id: "1", name: "test", scope: "global", version: 3, created_at: "", updated_at: "" }),
+      stats: vi.fn().mockResolvedValue({ total: 0, expiring_soon: 0, expired: 0 }),
+      getById: vi.fn().mockResolvedValue({ id: "1", name: "test", scope: "global", version: 1, created_at: "", updated_at: "" }),
+      updateById: vi.fn().mockResolvedValue({ id: "1", name: "test", scope: "global", version: 2, created_at: "", updated_at: "" }),
+      deleteById: vi.fn().mockResolvedValue(undefined),
+      getVersionsById: vi.fn().mockResolvedValue([]),
+      rollbackById: vi.fn().mockResolvedValue({ id: "1", name: "test", scope: "global", version: 3, created_at: "", updated_at: "" }),
+      ...overrides.secrets,
+    },
+    vector: {
+      embed: vi.fn().mockResolvedValue({ data: null, error: null }),
+      search: vi.fn().mockResolvedValue({ data: null, error: null }),
+      ...overrides.vector,
     },
     ...overrides,
   } as unknown as FluxbaseClient;

--- a/sdk-react/src/use-branches.test.ts
+++ b/sdk-react/src/use-branches.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tests for Branches hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  useBranches,
+  useCreateBranch,
+  useDeleteBranch,
+  useResetBranch,
+} from "./use-branches";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useBranches", () => {
+  it("should list branches", async () => {
+    const mockData = {
+      branches: [
+        { id: "b1", slug: "main", status: "ready", type: "main" },
+        { id: "b2", slug: "feature", status: "ready", type: "preview" },
+      ],
+      total: 2,
+      limit: 50,
+      offset: 0,
+    };
+    const client = createMockClient({
+      branching: {
+        list: vi.fn().mockResolvedValue({ data: mockData, error: null }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useBranches(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockData);
+  });
+
+  it("should pass options to list", async () => {
+    const list = vi.fn().mockResolvedValue({
+      data: { branches: [], total: 0, limit: 50, offset: 0 },
+      error: null,
+    });
+    const client = createMockClient({
+      branching: { list } as any,
+    });
+
+    renderHook(() => useBranches({ status: "ready", limit: 10 }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledWith({ status: "ready", limit: 10 });
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      branching: {
+        list: vi.fn().mockResolvedValue({ data: null, error: new Error("Failed") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useBranches(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useCreateBranch", () => {
+  it("should create a branch and invalidate queries", async () => {
+    const create = vi.fn().mockResolvedValue({
+      data: { id: "b2", slug: "feature-x", status: "creating" },
+      error: null,
+    });
+    const client = createMockClient({
+      branching: { create } as any,
+    });
+
+    const { result } = renderHook(() => useCreateBranch(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "feature/x" });
+    });
+
+    expect(create).toHaveBeenCalledWith("feature/x", {});
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should pass options to create", async () => {
+    const create = vi.fn().mockResolvedValue({
+      data: { id: "b2", slug: "feature-x", status: "creating" },
+      error: null,
+    });
+    const client = createMockClient({
+      branching: { create } as any,
+    });
+
+    const { result } = renderHook(() => useCreateBranch(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "feature/x",
+        dataCloneMode: "schema_only",
+        expiresIn: "7d",
+      });
+    });
+
+    expect(create).toHaveBeenCalledWith("feature/x", {
+      dataCloneMode: "schema_only",
+      expiresIn: "7d",
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      branching: {
+        create: vi.fn().mockResolvedValue({ data: null, error: new Error("Failed") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useCreateBranch(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "bad" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useDeleteBranch", () => {
+  it("should delete a branch and invalidate queries", async () => {
+    const del = vi.fn().mockResolvedValue({ error: null });
+    const client = createMockClient({
+      branching: { delete: del } as any,
+    });
+
+    const { result } = renderHook(() => useDeleteBranch(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("feature/x");
+    });
+
+    expect(del).toHaveBeenCalledWith("feature/x");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      branching: {
+        delete: vi.fn().mockResolvedValue({ error: new Error("Not found") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useDeleteBranch(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync("feature/x");
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useResetBranch", () => {
+  it("should reset a branch and invalidate queries", async () => {
+    const reset = vi.fn().mockResolvedValue({
+      data: { id: "b2", slug: "feature-x", status: "creating" },
+      error: null,
+    });
+    const client = createMockClient({
+      branching: { reset } as any,
+    });
+
+    const { result } = renderHook(() => useResetBranch(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("feature/x");
+    });
+
+    expect(reset).toHaveBeenCalledWith("feature/x");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      branching: {
+        reset: vi.fn().mockResolvedValue({ data: null, error: new Error("Failed") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useResetBranch(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync("feature/x");
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-branches.ts
+++ b/sdk-react/src/use-branches.ts
@@ -1,5 +1,16 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useFluxbaseClient } from "./context"
+
+export interface UseCreateBranchParams {
+  name: string;
+  parentBranchId?: string;
+  dataCloneMode?: "schema_only" | "full_clone" | "seed_data";
+  type?: "main" | "preview" | "persistent";
+  githubPRNumber?: number;
+  githubPRUrl?: string;
+  githubRepo?: string;
+  expiresIn?: string;
+}
 
 export interface UseBranchesOptions {
   status?: "creating" | "ready" | "migrating" | "error" | "deleting" | "deleted";
@@ -16,6 +27,51 @@ export function useBranches(options?: UseBranchesOptions) {
       const { data, error } = await client.branching.list(options)
       if (error) throw error
       return data
+    },
+  })
+}
+
+export function useCreateBranch() {
+  const client = useFluxbaseClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (params: UseCreateBranchParams): Promise<unknown> => {
+      const { name, ...options } = params
+      const { data, error } = await client.branching.create(name, options)
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "branches"] })
+    },
+  })
+}
+
+export function useDeleteBranch() {
+  const client = useFluxbaseClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (slug: string): Promise<void> => {
+      const { error } = await client.branching.delete(slug)
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "branches"] })
+    },
+  })
+}
+
+export function useResetBranch() {
+  const client = useFluxbaseClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (slug: string): Promise<unknown> => {
+      const { data, error } = await client.branching.reset(slug)
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "branches"] })
     },
   })
 }

--- a/sdk-react/src/use-ddl.test.ts
+++ b/sdk-react/src/use-ddl.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for DDL hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  useSchemas,
+  useTables,
+  useCreateSchema,
+  useDeleteTable,
+} from "./use-ddl";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useSchemas", () => {
+  it("should list schemas", async () => {
+    const mockSchemas = {
+      schemas: [
+        { name: "public", owner: "postgres" },
+        { name: "analytics", owner: "postgres" },
+      ],
+    };
+    const client = createMockClient({
+      admin: {
+        ddl: {
+          listSchemas: vi.fn().mockResolvedValue(mockSchemas),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useSchemas(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockSchemas);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        ddl: {
+          listSchemas: vi.fn().mockRejectedValue(new Error("Failed")),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useSchemas(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useTables", () => {
+  it("should list all tables when no schema provided", async () => {
+    const mockTables = {
+      tables: [
+        { schema: "public", name: "users" },
+        { schema: "analytics", name: "events" },
+      ],
+    };
+    const listTables = vi.fn().mockResolvedValue(mockTables);
+    const client = createMockClient({
+      admin: { ddl: { listTables } } as any,
+    });
+
+    const { result } = renderHook(() => useTables(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockTables);
+    expect(listTables).toHaveBeenCalledWith(undefined);
+  });
+
+  it("should list tables filtered by schema", async () => {
+    const mockTables = {
+      tables: [{ schema: "public", name: "users" }],
+    };
+    const listTables = vi.fn().mockResolvedValue(mockTables);
+    const client = createMockClient({
+      admin: { ddl: { listTables } } as any,
+    });
+
+    const { result } = renderHook(() => useTables("public"), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(listTables).toHaveBeenCalledWith("public");
+    expect(result.current.data).toEqual(mockTables);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        ddl: {
+          listTables: vi.fn().mockRejectedValue(new Error("Failed")),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useTables(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useCreateSchema", () => {
+  it("should create a schema", async () => {
+    const mockResponse = { message: "Schema created", schema: "analytics" };
+    const createSchema = vi.fn().mockResolvedValue(mockResponse);
+    const client = createMockClient({
+      admin: { ddl: { createSchema } } as any,
+    });
+
+    const { result } = renderHook(() => useCreateSchema(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("analytics");
+    });
+
+    expect(createSchema).toHaveBeenCalledWith("analytics");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        ddl: {
+          createSchema: vi.fn().mockRejectedValue(new Error("Schema exists")),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useCreateSchema(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync("analytics");
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useDeleteTable", () => {
+  it("should delete a table", async () => {
+    const mockResponse = { message: "Table deleted" };
+    const deleteTable = vi.fn().mockResolvedValue(mockResponse);
+    const client = createMockClient({
+      admin: { ddl: { deleteTable } } as any,
+    });
+
+    const { result } = renderHook(() => useDeleteTable(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ schema: "public", name: "old_data" });
+    });
+
+    expect(deleteTable).toHaveBeenCalledWith("public", "old_data");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        ddl: {
+          deleteTable: vi.fn().mockRejectedValue(new Error("Table not found")),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useDeleteTable(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ schema: "public", name: "missing" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-ddl.ts
+++ b/sdk-react/src/use-ddl.ts
@@ -1,0 +1,73 @@
+/**
+ * DDL hooks for Fluxbase React SDK
+ * Provides hooks for managing database schemas and tables
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useFluxbaseClient } from "./context";
+
+/**
+ * Hook to list all database schemas
+ */
+export function useSchemas() {
+  const client = useFluxbaseClient();
+
+  return useQuery({
+    queryKey: ["fluxbase", "schemas"],
+    queryFn: async () => {
+      return await client.admin.ddl.listSchemas();
+    },
+  });
+}
+
+/**
+ * Hook to list tables, optionally filtered by schema
+ */
+export function useTables(schema?: string) {
+  const client = useFluxbaseClient();
+
+  return useQuery({
+    queryKey: ["fluxbase", "tables", schema],
+    queryFn: async () => {
+      return await client.admin.ddl.listTables(schema);
+    },
+  });
+}
+
+/**
+ * Hook to create a new database schema
+ */
+export function useCreateSchema() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (name: string) => {
+      return await client.admin.ddl.createSchema(name);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["fluxbase", "schemas"],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to delete a table from a schema
+ */
+export function useDeleteTable() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ schema, name }: { schema: string; name: string }) => {
+      return await client.admin.ddl.deleteTable(schema, name);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["fluxbase", "tables"],
+      });
+    },
+  });
+}

--- a/sdk-react/src/use-functions.test.ts
+++ b/sdk-react/src/use-functions.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for Functions hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useInvokeFunction, useFunctions } from "./use-functions";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useInvokeFunction", () => {
+  it("should invoke a function", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      data: { result: "ok" },
+      error: null,
+    });
+    const client = createMockClient({
+      functions: { invoke } as any,
+    });
+
+    const { result } = renderHook(() => useInvokeFunction(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "hello", payload: { name: "World" } });
+    });
+
+    expect(invoke).toHaveBeenCalledWith("hello", { body: { name: "World" }, method: undefined });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      functions: {
+        invoke: vi.fn().mockResolvedValue({ data: null, error: new Error("Failed") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useInvokeFunction(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "bad" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useFunctions", () => {
+  it("should list functions", async () => {
+    const mockFunctions = [
+      { name: "hello", version: "1", namespace: "default" },
+      { name: "world", version: "2", namespace: "default" },
+    ];
+    const client = createMockClient({
+      functions: {
+        list: vi.fn().mockResolvedValue({ data: mockFunctions, error: null }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useFunctions(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockFunctions);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      functions: {
+        list: vi.fn().mockResolvedValue({ data: null, error: new Error("Failed") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useFunctions(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/sdk-react/src/use-functions.ts
+++ b/sdk-react/src/use-functions.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { useFluxbaseClient } from "./context"
 
 export function useInvokeFunction() {
@@ -6,6 +6,18 @@ export function useInvokeFunction() {
   return useMutation({
     mutationFn: async ({ name, payload, method }: { name: string; payload?: unknown; method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" }) => {
       const { data, error } = await client.functions.invoke(name, { body: payload, method })
+      if (error) throw error
+      return data
+    },
+  })
+}
+
+export function useFunctions() {
+  const client = useFluxbaseClient()
+  return useQuery({
+    queryKey: ["fluxbase", "functions"],
+    queryFn: async (): Promise<unknown> => {
+      const { data, error } = await client.functions.list()
       if (error) throw error
       return data
     },

--- a/sdk-react/src/use-impersonation.test.ts
+++ b/sdk-react/src/use-impersonation.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for impersonation hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  useImpersonationSessions,
+  useCurrentImpersonation,
+  useImpersonateUser,
+  useStopImpersonation,
+} from "./use-impersonation";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useImpersonationSessions", () => {
+  it("should list impersonation sessions", async () => {
+    const mockSessions = {
+      sessions: [
+        {
+          id: "s1",
+          admin_user_id: "admin-1",
+          target_user_id: "user-1",
+          impersonation_type: "user" as const,
+          target_role: "user",
+          reason: "Support",
+          started_at: "",
+          ended_at: null,
+          is_active: true,
+          ip_address: null,
+          user_agent: null,
+        },
+      ],
+      total: 1,
+    };
+    const client = createMockClient({
+      admin: {
+        impersonation: {
+          listSessions: vi.fn().mockResolvedValue(mockSessions),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useImpersonationSessions(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockSessions);
+  });
+
+  it("should pass options to listSessions", async () => {
+    const listSessions = vi.fn().mockResolvedValue({ sessions: [], total: 0 });
+    const client = createMockClient({
+      admin: { impersonation: { listSessions } } as any,
+    });
+
+    renderHook(() => useImpersonationSessions({ is_active: true }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(listSessions).toHaveBeenCalledWith({ is_active: true });
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        impersonation: {
+          listSessions: vi.fn().mockRejectedValue(new Error("Failed")),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useImpersonationSessions(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useCurrentImpersonation", () => {
+  it("should get current impersonation session", async () => {
+    const mockCurrent = {
+      session: {
+        id: "s1",
+        admin_user_id: "admin-1",
+        target_user_id: "user-1",
+        impersonation_type: "user" as const,
+        target_role: "user",
+        reason: "Support",
+        started_at: "",
+        ended_at: null,
+        is_active: true,
+        ip_address: null,
+        user_agent: null,
+      },
+      target_user: { id: "user-1", email: "test@example.com", role: "user" },
+    };
+    const client = createMockClient({
+      admin: {
+        impersonation: {
+          getCurrent: vi.fn().mockResolvedValue(mockCurrent),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useCurrentImpersonation(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockCurrent);
+  });
+
+  it("should return null session when not impersonating", async () => {
+    const client = createMockClient({
+      admin: {
+        impersonation: {
+          getCurrent: vi.fn().mockResolvedValue({
+            session: null,
+            target_user: null,
+          }),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useCurrentImpersonation(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data?.session).toBeNull();
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        impersonation: {
+          getCurrent: vi.fn().mockRejectedValue(new Error("Failed")),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useCurrentImpersonation(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useImpersonateUser", () => {
+  it("should impersonate a user", async () => {
+    const mockResponse = {
+      session: {
+        id: "s1",
+        admin_user_id: "admin-1",
+        target_user_id: "user-1",
+        impersonation_type: "user" as const,
+        target_role: "user",
+        reason: "Support",
+        started_at: "",
+        ended_at: null,
+        is_active: true,
+        ip_address: null,
+        user_agent: null,
+      },
+      target_user: { id: "user-1", email: "test@example.com", role: "user" },
+      access_token: "token-123",
+      refresh_token: "refresh-123",
+      expires_in: 3600,
+    };
+    const impersonateUser = vi.fn().mockResolvedValue(mockResponse);
+    const client = createMockClient({
+      admin: { impersonation: { impersonateUser } } as any,
+    });
+
+    const { result } = renderHook(() => useImpersonateUser(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        target_user_id: "user-1",
+        reason: "Support ticket #1234",
+      });
+    });
+
+    expect(impersonateUser).toHaveBeenCalledWith({
+      target_user_id: "user-1",
+      reason: "Support ticket #1234",
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        impersonation: {
+          impersonateUser: vi.fn().mockRejectedValue(new Error("Not allowed")),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useImpersonateUser(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          target_user_id: "user-1",
+          reason: "test",
+        });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useStopImpersonation", () => {
+  it("should stop impersonation", async () => {
+    const mockResponse = { success: true, message: "Impersonation stopped" };
+    const stop = vi.fn().mockResolvedValue(mockResponse);
+    const client = createMockClient({
+      admin: { impersonation: { stop } } as any,
+    });
+
+    const { result } = renderHook(() => useStopImpersonation(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(stop).toHaveBeenCalled();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        impersonation: {
+          stop: vi.fn().mockRejectedValue(new Error("No active session")),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useStopImpersonation(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync();
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-impersonation.ts
+++ b/sdk-react/src/use-impersonation.ts
@@ -1,0 +1,79 @@
+/**
+ * Impersonation hooks for Fluxbase React SDK
+ * Provides hooks for managing user impersonation sessions
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useFluxbaseClient } from "./context";
+import type { ListImpersonationSessionsOptions } from "@nimbleflux/fluxbase-sdk";
+
+/**
+ * Hook to list impersonation sessions (audit trail)
+ */
+export function useImpersonationSessions(
+  options?: ListImpersonationSessionsOptions,
+) {
+  const client = useFluxbaseClient();
+
+  return useQuery({
+    queryKey: ["fluxbase", "impersonation", "sessions", options],
+    queryFn: async () => {
+      return await client.admin.impersonation.listSessions(options);
+    },
+  });
+}
+
+/**
+ * Hook to get the current impersonation session
+ */
+export function useCurrentImpersonation() {
+  const client = useFluxbaseClient();
+
+  return useQuery({
+    queryKey: ["fluxbase", "impersonation", "current"],
+    queryFn: async () => {
+      return await client.admin.impersonation.getCurrent();
+    },
+  });
+}
+
+/**
+ * Hook to start impersonating a specific user
+ */
+export function useImpersonateUser() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (request: {
+      target_user_id: string;
+      reason: string;
+    }) => {
+      return await client.admin.impersonation.impersonateUser(request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["fluxbase", "impersonation"],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to stop the current impersonation session
+ */
+export function useStopImpersonation() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      return await client.admin.impersonation.stop();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["fluxbase", "impersonation"],
+      });
+    },
+  });
+}

--- a/sdk-react/src/use-jobs.test.ts
+++ b/sdk-react/src/use-jobs.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for Jobs hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  useSubmitJob,
+  useJobStatus,
+  useJobs,
+  useCancelJob,
+  useRetryJob,
+} from "./use-jobs";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useSubmitJob", () => {
+  it("should submit a job", async () => {
+    const submit = vi.fn().mockResolvedValue({
+      data: { id: "job-1", status: "pending" },
+      error: null,
+    });
+    const client = createMockClient({
+      jobs: { submit } as any,
+    });
+
+    const { result } = renderHook(() => useSubmitJob(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "send-email", payload: { to: "a@b.com" } });
+    });
+
+    expect(submit).toHaveBeenCalledWith("send-email", { to: "a@b.com" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      jobs: {
+        submit: vi.fn().mockResolvedValue({ data: null, error: new Error("Failed") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useSubmitJob(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "bad-job" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useJobStatus", () => {
+  it("should get job status by ID", async () => {
+    const mockJob = { id: "job-1", status: "completed" };
+    const client = createMockClient({
+      jobs: {
+        get: vi.fn().mockResolvedValue({ data: mockJob, error: null }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useJobStatus("job-1"), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockJob);
+  });
+
+  it("should not fetch when jobId is null", () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useJobStatus(null), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+});
+
+describe("useJobs", () => {
+  it("should list jobs", async () => {
+    const mockJobs = [
+      { id: "job-1", status: "completed" },
+      { id: "job-2", status: "running" },
+    ];
+    const client = createMockClient({
+      jobs: {
+        list: vi.fn().mockResolvedValue({ data: mockJobs, error: null }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useJobs(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockJobs);
+  });
+
+  it("should pass options to list", async () => {
+    const list = vi.fn().mockResolvedValue({ data: [], error: null });
+    const client = createMockClient({
+      jobs: { list } as any,
+    });
+
+    renderHook(() => useJobs({ status: "running", limit: 10 }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledWith({ status: "running", limit: 10 });
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      jobs: {
+        list: vi.fn().mockResolvedValue({ data: null, error: new Error("Failed") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useJobs(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useCancelJob", () => {
+  it("should cancel a job and invalidate queries", async () => {
+    const cancel = vi.fn().mockResolvedValue({ data: null, error: null });
+    const client = createMockClient({
+      jobs: { cancel } as any,
+    });
+
+    const { result } = renderHook(() => useCancelJob(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("job-1");
+    });
+
+    expect(cancel).toHaveBeenCalledWith("job-1");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      jobs: {
+        cancel: vi.fn().mockResolvedValue({ data: null, error: new Error("Not found") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useCancelJob(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync("job-1");
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useRetryJob", () => {
+  it("should retry a job and invalidate queries", async () => {
+    const retry = vi.fn().mockResolvedValue({
+      data: { id: "job-2", status: "pending" },
+      error: null,
+    });
+    const client = createMockClient({
+      jobs: { retry } as any,
+    });
+
+    const { result } = renderHook(() => useRetryJob(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("job-1");
+    });
+
+    expect(retry).toHaveBeenCalledWith("job-1");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      jobs: {
+        retry: vi.fn().mockResolvedValue({ data: null, error: new Error("Failed") }),
+      } as any,
+    });
+
+    const { result } = renderHook(() => useRetryJob(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync("job-1");
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-jobs.ts
+++ b/sdk-react/src/use-jobs.ts
@@ -31,3 +31,51 @@ export function useJobStatus(jobId: string | null) {
     },
   })
 }
+
+export interface UseJobsOptions {
+  namespace?: string;
+  limit?: number;
+  offset?: number;
+  status?: string;
+}
+
+export function useJobs(options?: UseJobsOptions) {
+  const client = useFluxbaseClient()
+  return useQuery({
+    queryKey: ["fluxbase", "jobs", options],
+    queryFn: async (): Promise<unknown> => {
+      const { data, error } = await client.jobs.list(options)
+      if (error) throw error
+      return data
+    },
+  })
+}
+
+export function useCancelJob() {
+  const client = useFluxbaseClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (jobId: string): Promise<void> => {
+      const { error } = await client.jobs.cancel(jobId)
+      if (error) throw error
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "jobs"] })
+    },
+  })
+}
+
+export function useRetryJob() {
+  const client = useFluxbaseClient()
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (jobId: string): Promise<unknown> => {
+      const { data, error } = await client.jobs.retry(jobId)
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "jobs"] })
+    },
+  })
+}

--- a/sdk-react/src/use-migrations.test.ts
+++ b/sdk-react/src/use-migrations.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for migration hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  useMigrations,
+  useApplyMigration,
+  useRollbackMigration,
+  useSyncMigrations,
+} from "./use-migrations";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useMigrations", () => {
+  it("should list migrations", async () => {
+    const mockMigrations = [
+      {
+        id: "1",
+        namespace: "default",
+        name: "001_init",
+        up_sql: "CREATE TABLE test();",
+        version: 1,
+        status: "applied" as const,
+        created_at: "",
+        updated_at: "",
+      },
+    ];
+    const client = createMockClient({
+      admin: {
+        migrations: {
+          list: vi.fn().mockResolvedValue({ data: mockMigrations, error: null }),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useMigrations(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockMigrations);
+  });
+
+  it("should pass namespace to list", async () => {
+    const list = vi.fn().mockResolvedValue({ data: [], error: null });
+    const client = createMockClient({
+      admin: { migrations: { list } } as any,
+    });
+
+    renderHook(() => useMigrations("myapp"), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledWith("myapp");
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        migrations: {
+          list: vi
+            .fn()
+            .mockResolvedValue({ data: null, error: new Error("Failed") }),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useMigrations(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useApplyMigration", () => {
+  it("should apply a migration", async () => {
+    const apply = vi
+      .fn()
+      .mockResolvedValue({ data: { message: "Applied" }, error: null });
+    const client = createMockClient({
+      admin: { migrations: { apply } } as any,
+    });
+
+    const { result } = renderHook(() => useApplyMigration(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "001_init" });
+    });
+
+    expect(apply).toHaveBeenCalledWith("001_init", undefined);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should pass namespace to apply", async () => {
+    const apply = vi
+      .fn()
+      .mockResolvedValue({ data: { message: "Applied" }, error: null });
+    const client = createMockClient({
+      admin: { migrations: { apply } } as any,
+    });
+
+    const { result } = renderHook(() => useApplyMigration(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "001_init", namespace: "myapp" });
+    });
+
+    expect(apply).toHaveBeenCalledWith("001_init", "myapp");
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        migrations: {
+          apply: vi
+            .fn()
+            .mockResolvedValue({ data: null, error: new Error("Failed") }),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useApplyMigration(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "001_init" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useRollbackMigration", () => {
+  it("should rollback a migration", async () => {
+    const rollback = vi
+      .fn()
+      .mockResolvedValue({ data: { message: "Rolled back" }, error: null });
+    const client = createMockClient({
+      admin: { migrations: { rollback } } as any,
+    });
+
+    const { result } = renderHook(() => useRollbackMigration(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "001_init" });
+    });
+
+    expect(rollback).toHaveBeenCalledWith("001_init", undefined);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        migrations: {
+          rollback: vi
+            .fn()
+            .mockResolvedValue({ data: null, error: new Error("Failed") }),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useRollbackMigration(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "001_init" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useSyncMigrations", () => {
+  it("should sync migrations", async () => {
+    const mockResult = {
+      message: "Synced",
+      namespace: "default",
+      summary: {
+        created: 1,
+        updated: 0,
+        unchanged: 0,
+        skipped: 0,
+        applied: 0,
+        errors: 0,
+      },
+      details: {
+        created: ["001_init"],
+        updated: [],
+        unchanged: [],
+        skipped: [],
+        applied: [],
+        errors: [],
+      },
+      dry_run: false,
+    };
+    const sync = vi.fn().mockResolvedValue({ data: mockResult, error: null });
+    const client = createMockClient({
+      admin: { migrations: { sync } } as any,
+    });
+
+    const { result } = renderHook(() => useSyncMigrations(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(sync).toHaveBeenCalledWith(undefined);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResult);
+  });
+
+  it("should pass options to sync", async () => {
+    const sync = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: null });
+    const client = createMockClient({
+      admin: { migrations: { sync } } as any,
+    });
+
+    const { result } = renderHook(() => useSyncMigrations(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ auto_apply: true });
+    });
+
+    expect(sync).toHaveBeenCalledWith({ auto_apply: true });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      admin: {
+        migrations: {
+          sync: vi
+            .fn()
+            .mockResolvedValue({ data: null, error: new Error("Sync failed") }),
+        },
+      } as any,
+    });
+
+    const { result } = renderHook(() => useSyncMigrations(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync();
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-migrations.ts
+++ b/sdk-react/src/use-migrations.ts
@@ -1,0 +1,107 @@
+/**
+ * Migration hooks for Fluxbase React SDK
+ * Provides hooks for listing, applying, rolling back, and syncing database migrations
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useFluxbaseClient } from "./context";
+import type { SyncMigrationsOptions } from "@nimbleflux/fluxbase-sdk";
+
+/**
+ * Hook to list migrations in a namespace
+ */
+export function useMigrations(namespace?: string) {
+  const client = useFluxbaseClient();
+
+  return useQuery({
+    queryKey: ["fluxbase", "migrations", namespace],
+    queryFn: async () => {
+      const { data, error } = await client.admin.migrations.list(namespace);
+      if (error) throw error;
+      return data || [];
+    },
+  });
+}
+
+/**
+ * Hook to apply a specific migration
+ */
+export function useApplyMigration() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      name,
+      namespace,
+    }: {
+      name: string;
+      namespace?: string;
+    }) => {
+      const { data, error } = await client.admin.migrations.apply(
+        name,
+        namespace,
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["fluxbase", "migrations"],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to rollback a specific migration
+ */
+export function useRollbackMigration() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      name,
+      namespace,
+    }: {
+      name: string;
+      namespace?: string;
+    }) => {
+      const { data, error } = await client.admin.migrations.rollback(
+        name,
+        namespace,
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["fluxbase", "migrations"],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to sync registered migrations
+ */
+export function useSyncMigrations() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (options: SyncMigrationsOptions | void) => {
+      const { data, error } = await client.admin.migrations.sync(
+        options ?? undefined,
+      );
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["fluxbase", "migrations"],
+      });
+    },
+  });
+}

--- a/sdk-react/src/use-rpc.test.ts
+++ b/sdk-react/src/use-rpc.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for RPC hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useRPCList, useInvokeRPC } from "./use-rpc";
+import { createMockClient, createWrapper } from "./test-utils";
+import type { FluxbaseClient } from "@nimbleflux/fluxbase-sdk";
+
+describe("useRPCList", () => {
+  it("should list RPC procedures", async () => {
+    const mockProcedures = [
+      { id: "1", name: "get-users", namespace: "default", enabled: true, version: 1, source: "filesystem", is_public: true, allowed_tables: [], allowed_schemas: [], max_execution_time_seconds: 30, created_at: "", updated_at: "" },
+    ];
+    const client = createMockClient({
+      rpc: Object.assign(vi.fn(), {
+        list: vi.fn().mockResolvedValue({ data: mockProcedures, error: null }),
+      }) as any,
+    });
+
+    const { result } = renderHook(() => useRPCList(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockProcedures);
+  });
+
+  it("should filter by namespace", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValue({ data: [], error: null });
+    const client = createMockClient({
+      rpc: Object.assign(vi.fn(), { list }) as any,
+    });
+
+    renderHook(() => useRPCList("custom-ns"), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledWith("custom-ns");
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      rpc: Object.assign(vi.fn(), {
+        list: vi
+          .fn()
+          .mockResolvedValue({ data: null, error: new Error("Failed") }),
+      }) as any,
+    });
+
+    const { result } = renderHook(() => useRPCList(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useInvokeRPC", () => {
+  it("should invoke an RPC procedure", async () => {
+    const mockResponse = {
+      execution_id: "exec-1",
+      status: "completed" as const,
+      result: { count: 42 },
+    };
+    const client = createMockClient({
+      rpc: Object.assign(vi.fn(), {
+        invoke: vi.fn().mockResolvedValue({ data: mockResponse, error: null }),
+      }) as any,
+    });
+
+    const { result } = renderHook(() => useInvokeRPC(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "get-count",
+        payload: { table: "users" },
+      });
+    });
+
+    expect((client.rpc as any).invoke).toHaveBeenCalledWith(
+      "get-count",
+      { table: "users" },
+      undefined,
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  it("should pass options", async () => {
+    const mockResponse = { execution_id: "exec-2", status: "running" as const };
+    const client = createMockClient({
+      rpc: Object.assign(vi.fn(), {
+        invoke: vi.fn().mockResolvedValue({ data: mockResponse, error: null }),
+      }) as any,
+    });
+
+    const { result } = renderHook(() => useInvokeRPC(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "long-task",
+        options: { async: true, namespace: "prod" },
+      });
+    });
+
+    expect((client.rpc as any).invoke).toHaveBeenCalledWith(
+      "long-task",
+      undefined,
+      { async: true, namespace: "prod" },
+    );
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient({
+      rpc: Object.assign(vi.fn(), {
+        invoke: vi
+          .fn()
+          .mockResolvedValue({ data: null, error: new Error("Not found") }),
+      }) as any,
+    });
+
+    const { result } = renderHook(() => useInvokeRPC(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "bad-proc" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-rpc.ts
+++ b/sdk-react/src/use-rpc.ts
@@ -1,0 +1,58 @@
+/**
+ * RPC hooks for Fluxbase React SDK
+ * Provides hooks for listing and invoking RPC procedures
+ */
+
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { useFluxbaseClient } from "./context";
+
+interface RPCInvokeOptions {
+  namespace?: string;
+  async?: boolean;
+  timeout?: number;
+}
+
+/**
+ * Hook to list available RPC procedures
+ */
+export function useRPCList(namespace?: string) {
+  const client = useFluxbaseClient();
+
+  return useQuery({
+    queryKey: ["fluxbase", "rpc", namespace],
+    queryFn: async () => {
+      const { data, error } = await client.rpc.list(namespace);
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+/**
+ * Hook to invoke an RPC procedure
+ *
+ * @example
+ * ```tsx
+ * const { mutateAsync, data } = useInvokeRPC()
+ * await mutateAsync({ name: 'get-user-orders', payload: { user_id: '123' } })
+ * ```
+ */
+export function useInvokeRPC() {
+  const client = useFluxbaseClient();
+
+  return useMutation({
+    mutationFn: async (params: {
+      name: string;
+      payload?: Record<string, unknown>;
+      options?: RPCInvokeOptions;
+    }) => {
+      const { data, error } = await client.rpc.invoke(
+        params.name,
+        params.payload,
+        params.options,
+      );
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/sdk-react/src/use-secrets.test.ts
+++ b/sdk-react/src/use-secrets.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Tests for Secrets hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  useSecrets,
+  useCreateSecret,
+  useUpdateSecret,
+  useDeleteSecret,
+} from "./use-secrets";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useSecrets", () => {
+  it("should list secrets", async () => {
+    const mockSecrets = [
+      { id: "1", name: "API_KEY", scope: "global", version: 1, is_expired: false, created_at: "", updated_at: "" },
+    ];
+    const client = createMockClient();
+    (client.secrets.list as ReturnType<typeof vi.fn>).mockResolvedValue(mockSecrets);
+
+    const { result } = renderHook(() => useSecrets(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockSecrets);
+  });
+
+  it("should pass options to list", async () => {
+    const client = createMockClient();
+    (client.secrets.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    renderHook(() => useSecrets({ scope: "namespace", namespace: "prod" }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => {
+      expect(client.secrets.list).toHaveBeenCalledWith({
+        scope: "namespace",
+        namespace: "prod",
+      });
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (client.secrets.list as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Unauthorized"),
+    );
+
+    const { result } = renderHook(() => useSecrets(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useCreateSecret", () => {
+  it("should create a secret and invalidate queries", async () => {
+    const mockSecret = {
+      id: "2",
+      name: "NEW_KEY",
+      scope: "global" as const,
+      version: 1,
+      created_at: "",
+      updated_at: "",
+    };
+    const client = createMockClient();
+    (client.secrets.create as ReturnType<typeof vi.fn>).mockResolvedValue(mockSecret);
+
+    const { result } = renderHook(() => useCreateSecret(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "NEW_KEY",
+        value: "secret-value",
+      });
+    });
+
+    expect(client.secrets.create).toHaveBeenCalledWith({
+      name: "NEW_KEY",
+      value: "secret-value",
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockSecret);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (client.secrets.create as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Secret exists"),
+    );
+
+    const { result } = renderHook(() => useCreateSecret(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "DUP", value: "val" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useUpdateSecret", () => {
+  it("should update a secret and invalidate queries", async () => {
+    const mockSecret = {
+      id: "1",
+      name: "API_KEY",
+      scope: "global" as const,
+      version: 2,
+      created_at: "",
+      updated_at: "",
+    };
+    const client = createMockClient();
+    (client.secrets.update as ReturnType<typeof vi.fn>).mockResolvedValue(mockSecret);
+
+    const { result } = renderHook(() => useUpdateSecret(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "API_KEY",
+        request: { value: "new-value" },
+      });
+    });
+
+    expect(client.secrets.update).toHaveBeenCalledWith(
+      "API_KEY",
+      { value: "new-value" },
+      { namespace: undefined },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockSecret);
+  });
+
+  it("should pass namespace option", async () => {
+    const client = createMockClient();
+    (client.secrets.update as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+    const { result } = renderHook(() => useUpdateSecret(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "DB_URL",
+        request: { value: "postgres://new" },
+        namespace: "production",
+      });
+    });
+
+    expect(client.secrets.update).toHaveBeenCalledWith(
+      "DB_URL",
+      { value: "postgres://new" },
+      { namespace: "production" },
+    );
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (client.secrets.update as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Not found"),
+    );
+
+    const { result } = renderHook(() => useUpdateSecret(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          name: "MISSING",
+          request: { value: "val" },
+        });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useDeleteSecret", () => {
+  it("should delete a secret and invalidate queries", async () => {
+    const client = createMockClient();
+    (client.secrets.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteSecret(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "OLD_KEY" });
+    });
+
+    expect(client.secrets.delete).toHaveBeenCalledWith("OLD_KEY", {
+      namespace: undefined,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should pass namespace option", async () => {
+    const client = createMockClient();
+    (client.secrets.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteSecret(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: "DB_URL", namespace: "staging" });
+    });
+
+    expect(client.secrets.delete).toHaveBeenCalledWith("DB_URL", {
+      namespace: "staging",
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (client.secrets.delete as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Not found"),
+    );
+
+    const { result } = renderHook(() => useDeleteSecret(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: "MISSING" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-secrets.ts
+++ b/sdk-react/src/use-secrets.ts
@@ -1,0 +1,85 @@
+/**
+ * Secrets hooks for Fluxbase React SDK
+ * Provides hooks for managing edge function and job secrets
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useFluxbaseClient } from "./context";
+import type {
+  ListSecretsOptions,
+  CreateSecretRequest,
+  UpdateSecretRequest,
+} from "@nimbleflux/fluxbase-sdk";
+
+/**
+ * Hook to list all secrets (metadata only, never includes values)
+ */
+export function useSecrets(options?: ListSecretsOptions) {
+  const client = useFluxbaseClient();
+
+  return useQuery({
+    queryKey: ["fluxbase", "secrets", options],
+    queryFn: async () => {
+      return await client.secrets.list(options);
+    },
+  });
+}
+
+/**
+ * Hook to create a new secret
+ */
+export function useCreateSecret() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (request: CreateSecretRequest) => {
+      return await client.secrets.create(request);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "secrets"] });
+    },
+  });
+}
+
+/**
+ * Hook to update a secret by name
+ */
+export function useUpdateSecret() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: {
+      name: string;
+      request: UpdateSecretRequest;
+      namespace?: string;
+    }) => {
+      return await client.secrets.update(params.name, params.request, {
+        namespace: params.namespace,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "secrets"] });
+    },
+  });
+}
+
+/**
+ * Hook to delete a secret by name
+ */
+export function useDeleteSecret() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: { name: string; namespace?: string }) => {
+      await client.secrets.delete(params.name, {
+        namespace: params.namespace,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "secrets"] });
+    },
+  });
+}

--- a/sdk-react/src/use-service-keys.test.ts
+++ b/sdk-react/src/use-service-keys.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for Service Keys hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import {
+  useServiceKeys,
+  useCreateServiceKey,
+  useRotateServiceKey,
+  useRevokeServiceKey,
+} from "./use-service-keys";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useServiceKeys", () => {
+  it("should list service keys", async () => {
+    const mockKeys = [
+      {
+        id: "1",
+        name: "Production Key",
+        key_type: "service" as const,
+        scopes: ["*"],
+        enabled: true,
+        key_prefix: "fb_prod_abcdef",
+        created_at: "",
+      },
+    ];
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.list as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ data: mockKeys, error: null });
+
+    const { result } = renderHook(() => useServiceKeys(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.data).toEqual(mockKeys);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.list as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ data: null, error: new Error("Unauthorized") });
+
+    const { result } = renderHook(() => useServiceKeys(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe("useCreateServiceKey", () => {
+  it("should create a service key and invalidate queries", async () => {
+    const mockKey = {
+      id: "2",
+      name: "New Key",
+      key_type: "service" as const,
+      scopes: ["*"],
+      enabled: true,
+      key_prefix: "fb_new_123456",
+      key: "fb_new_123456789",
+      created_at: "",
+    };
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.create as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ data: mockKey, error: null });
+
+    const { result } = renderHook(() => useCreateServiceKey(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        name: "New Key",
+        key_type: "service",
+        scopes: ["*"],
+      });
+    });
+
+    expect(client.admin.serviceKeys.create).toHaveBeenCalledWith({
+      name: "New Key",
+      key_type: "service",
+      scopes: ["*"],
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockKey);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.create as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ data: null, error: new Error("Limit reached") });
+
+    const { result } = renderHook(() => useCreateServiceKey(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          name: "Excess",
+          key_type: "service",
+        });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useRotateServiceKey", () => {
+  it("should rotate a service key and invalidate queries", async () => {
+    const mockKey = {
+      id: "3",
+      name: "Rotated Key",
+      key_type: "service" as const,
+      scopes: ["*"],
+      enabled: true,
+      key_prefix: "fb_rot_newpass",
+      key: "fb_rot_newpassword",
+      created_at: "",
+      deprecated_at: "",
+      grace_period_ends_at: "",
+    };
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.rotate as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ data: mockKey, error: null });
+
+    const { result } = renderHook(() => useRotateServiceKey(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("old-key-id");
+    });
+
+    expect(client.admin.serviceKeys.rotate).toHaveBeenCalledWith("old-key-id");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockKey);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.rotate as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ data: null, error: new Error("Key not found") });
+
+    const { result } = renderHook(() => useRotateServiceKey(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync("missing-id");
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useRevokeServiceKey", () => {
+  it("should revoke a service key and invalidate queries", async () => {
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.revoke as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ error: null });
+
+    const { result } = renderHook(() => useRevokeServiceKey(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: "compromised-id" });
+    });
+
+    expect(client.admin.serviceKeys.revoke).toHaveBeenCalledWith(
+      "compromised-id",
+      undefined,
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("should pass revocation reason", async () => {
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.revoke as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ error: null });
+
+    const { result } = renderHook(() => useRevokeServiceKey(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "key-id",
+        request: { reason: "Key was compromised" },
+      });
+    });
+
+    expect(client.admin.serviceKeys.revoke).toHaveBeenCalledWith("key-id", {
+      reason: "Key was compromised",
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (
+      client.admin.serviceKeys.revoke as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ error: new Error("Already revoked") });
+
+    const { result } = renderHook(() => useRevokeServiceKey(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ id: "bad-id" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-service-keys.ts
+++ b/sdk-react/src/use-service-keys.ts
@@ -1,0 +1,91 @@
+/**
+ * Service keys hooks for Fluxbase React SDK
+ * Provides hooks for managing tenant service keys (anon and service)
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useFluxbaseClient } from "./context";
+import type {
+  CreateServiceKeyRequest,
+  RevokeServiceKeyRequest,
+} from "@nimbleflux/fluxbase-sdk";
+
+/**
+ * Hook to list all service keys
+ */
+export function useServiceKeys() {
+  const client = useFluxbaseClient();
+
+  return useQuery({
+    queryKey: ["fluxbase", "service-keys"],
+    queryFn: async () => {
+      const { data, error } = await client.admin.serviceKeys.list();
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+/**
+ * Hook to create a new service key
+ *
+ * The full key value is only returned once — store it securely!
+ */
+export function useCreateServiceKey() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (request: CreateServiceKeyRequest) => {
+      const { data, error } = await client.admin.serviceKeys.create(request);
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "service-keys"] });
+    },
+  });
+}
+
+/**
+ * Hook to rotate a service key (creates a replacement and deprecates the old one)
+ */
+export function useRotateServiceKey() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { data, error } = await client.admin.serviceKeys.rotate(id);
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "service-keys"] });
+    },
+  });
+}
+
+/**
+ * Hook to revoke a service key permanently (emergency)
+ */
+export function useRevokeServiceKey() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: {
+      id: string;
+      request?: RevokeServiceKeyRequest;
+    }) => {
+      const { error } = await client.admin.serviceKeys.revoke(
+        params.id,
+        params.request,
+      );
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["fluxbase", "service-keys"] });
+    },
+  });
+}

--- a/sdk-react/src/use-vector.test.ts
+++ b/sdk-react/src/use-vector.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for Vector hooks
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useVectorEmbed, useVectorSearch } from "./use-vector";
+import { createMockClient, createWrapper } from "./test-utils";
+
+describe("useVectorEmbed", () => {
+  it("should embed text", async () => {
+    const mockResponse = {
+      embeddings: [[0.1, 0.2, 0.3]],
+      model: "text-embedding-3-small",
+      dimensions: 3,
+    };
+    const client = createMockClient();
+    (client.vector.embed as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockResponse,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useVectorEmbed(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ text: "Hello world" });
+    });
+
+    expect(client.vector.embed).toHaveBeenCalledWith({ text: "Hello world" });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  it("should embed multiple texts", async () => {
+    const mockResponse = {
+      embeddings: [[0.1], [0.2]],
+      model: "text-embedding-3-small",
+      dimensions: 1,
+    };
+    const client = createMockClient();
+    (client.vector.embed as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockResponse,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useVectorEmbed(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        texts: ["Hello", "World"],
+        model: "text-embedding-3-large",
+      });
+    });
+
+    expect(client.vector.embed).toHaveBeenCalledWith({
+      texts: ["Hello", "World"],
+      model: "text-embedding-3-large",
+    });
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (client.vector.embed as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: new Error("Embedding failed"),
+    });
+
+    const { result } = renderHook(() => useVectorEmbed(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ text: "test" });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useVectorSearch", () => {
+  it("should search with text query", async () => {
+    const mockResult = {
+      data: [{ id: "1", content: "Match 1" }],
+      distances: [0.1],
+      model: "text-embedding-3-small",
+    };
+    const client = createMockClient();
+    (client.vector.search as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockResult,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useVectorSearch(), {
+      wrapper: createWrapper(client),
+    });
+
+    const searchOpts = {
+      table: "documents",
+      column: "embedding",
+      query: "How to use TypeScript?",
+      match_count: 10,
+    };
+
+    await act(async () => {
+      await result.current.mutateAsync(searchOpts);
+    });
+
+    expect(client.vector.search).toHaveBeenCalledWith(searchOpts);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(mockResult);
+  });
+
+  it("should search with pre-computed vector", async () => {
+    const mockResult = {
+      data: [{ id: "2", content: "Vector match" }],
+      distances: [0.05],
+    };
+    const client = createMockClient();
+    (client.vector.search as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: mockResult,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useVectorSearch(), {
+      wrapper: createWrapper(client),
+    });
+
+    const searchOpts = {
+      table: "documents",
+      column: "embedding",
+      vector: [0.1, 0.2, 0.3],
+      metric: "cosine" as const,
+      match_count: 5,
+    };
+
+    await act(async () => {
+      await result.current.mutateAsync(searchOpts);
+    });
+
+    expect(client.vector.search).toHaveBeenCalledWith(searchOpts);
+  });
+
+  it("should handle errors", async () => {
+    const client = createMockClient();
+    (client.vector.search as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: new Error("Search failed"),
+    });
+
+    const { result } = renderHook(() => useVectorSearch(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          table: "documents",
+          column: "embedding",
+          query: "test",
+        });
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/sdk-react/src/use-vector.ts
+++ b/sdk-react/src/use-vector.ts
@@ -1,0 +1,55 @@
+/**
+ * Vector hooks for Fluxbase React SDK
+ * Provides hooks for vector embedding and similarity search
+ */
+
+import { useMutation } from "@tanstack/react-query";
+import { useFluxbaseClient } from "./context";
+import type { EmbedRequest, VectorSearchOptions } from "@nimbleflux/fluxbase-sdk";
+
+/**
+ * Hook to generate embeddings for text
+ *
+ * @example
+ * ```tsx
+ * const { mutateAsync } = useVectorEmbed()
+ * const { data } = await mutateAsync({ text: 'Hello world' })
+ * ```
+ */
+export function useVectorEmbed() {
+  const client = useFluxbaseClient();
+
+  return useMutation({
+    mutationFn: async (request: EmbedRequest) => {
+      const { data, error } = await client.vector.embed(request);
+      if (error) throw error;
+      return data;
+    },
+  });
+}
+
+/**
+ * Hook for vector similarity search with automatic text embedding
+ *
+ * @example
+ * ```tsx
+ * const { mutateAsync } = useVectorSearch()
+ * const { data } = await mutateAsync({
+ *   table: 'documents',
+ *   column: 'embedding',
+ *   query: 'How to use TypeScript?',
+ *   match_count: 10,
+ * })
+ * ```
+ */
+export function useVectorSearch() {
+  const client = useFluxbaseClient();
+
+  return useMutation({
+    mutationFn: async (options: VectorSearchOptions) => {
+      const { data, error } = await client.vector.search(options);
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,169 +1,118 @@
 # End-to-End Test Suite
 
-This directory contains comprehensive end-to-end tests for Fluxbase, covering all major features with a focus on **Row-Level Security (RLS)** and **Authentication**.
+This directory contains comprehensive end-to-end tests for Fluxbase, covering all major features with a focus on **Row-Level Security (RLS)**, **Authentication**, and **Multi-Tenancy**.
 
-## 🎯 Test Coverage
+## Test Coverage
 
-**Total**: 3,510 lines | 91+ test cases | 91% backend coverage
+**54 test files** covering all major Fluxbase features. Tests require a running PostgreSQL instance with the Fluxbase schema bootstrapped.
 
-### ✅ REST API Tests (`rest_api_comprehensive_test.go`)
+### Test Categories
 
-**Coverage**: 90% | **Lines**: 720 | **Test Cases**: 38+
+#### Authentication & Security (8 files)
+| File | Coverage |
+|------|----------|
+| `auth_test.go` | Signup, signin, signout, token refresh, session management |
+| `auth_rest_test.go` | REST API authentication flows, token propagation |
+| `two_factor_test.go` | TOTP/MFA enrollment, verification, recovery codes |
+| `oauth_test.go` | OAuth2 flow (Google, GitHub, etc.), token exchange |
+| `oauth_dex_test.go` | OIDC via Dex integration test |
+| `otp_hash_test.go` | OTP code hashing (SHA-256), verification |
+| `invitation_hash_test.go` | Invitation token hashing, dual-read migration |
+| `ssrf_protection_test.go` | SSRF blocking for metadata endpoints |
+| `ssrf_allowed_domains_test.go` | SSRF allowlist functionality |
 
-Tests include:
-- **CRUD Operations**: Create, Read, Update, Delete, Patch
-- **Query Operators** (20+ operators):
-  - Comparison: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`
-  - Pattern matching: `like`, `ilike`
-  - List operations: `in`, `is`, `not`
-- **Full-Text Search**: `fts`, `plfts`, `wfts`
-- **JSONB Operators**: `cs` (contains), `cd` (contained by)
-- **Array Operators**: `ov` (overlap), `cs` (contains), `sl`, `sr`
-- **Aggregations**: `count`, `sum`, `avg`, `min`, `max` with `GROUP BY`
-- **Upsert Operations**: `ON CONFLICT DO UPDATE`
-- **Batch Operations**: Batch insert, update, delete
-- **Database Views**: Read-only access
-- **RPC Functions**: PostgreSQL function calls
-- **Row-Level Security**: Multi-user isolation testing
-- **Authentication Context**: User context propagation
+#### REST API & Query (4 files)
+| File | Coverage |
+|------|----------|
+| `rest_test.go` | CRUD operations, 20+ query operators, aggregations, upsert, batch |
+| `graphql_test.go` | GraphQL queries, mutations, filtering, relations |
+| `rpc_test.go` | RPC procedure invocation, scheduling, RBAC |
+| `sql_editor_test.go` | SQL editor execution |
 
-### ✅ Authentication Tests (`auth_flows_test.go`)
+#### Row-Level Security (12 files)
+| File | Coverage |
+|------|----------|
+| `rls_test.go` | User isolation, insert/update/delete protection |
+| `rls_new_test.go` | Expanded RLS scenarios |
+| `storage_rls_providers_test.go` | RLS across storage providers |
+| `storage_rls_public_test.go` | Public bucket access |
+| `storage_rls_service_key_test.go` | Service key bypass |
+| `storage_rls_isolation_test.go` | Cross-user isolation |
+| `storage_rls_ownership_test.go` | Object ownership |
+| `storage_rls_sharing_test.go` | Shared object access |
+| `storage_rls_admin_test.go` | Admin access patterns |
+| `storage_rls_bucket_settings_test.go` | Bucket-level policy enforcement |
 
-**Coverage**: 95% | **Lines**: 580 | **Test Cases**: 16+
+#### Multi-Tenancy (8 files)
+| File | Coverage |
+|------|----------|
+| `tenant_isolation_test.go` | Cross-tenant data isolation |
+| `tenant_config_test.go` | Per-tenant configuration |
+| `tenant_deletion_cascade_test.go` | Tenant deletion cleanup |
+| `tenant_migrations_isolation_test.go` | Migration isolation per tenant |
+| `tenant_migration_schema_isolation_test.go` | Schema migration isolation |
+| `has_tenant_access_test.go` | Access checking |
+| `realtime_tenant_isolation_test.go` | Realtime tenant scoping |
 
-Tests include:
-- **Complete Signup Flow**: Email/password registration
-- **Email Verification**: Confirmation token validation
-- **Sign In Flow**: Email/password authentication
-- **Token Refresh Flow**: Access token renewal
-- **Token Expiration**: Expired token handling
-- **Magic Link Authentication**: Passwordless login
-- **Password Reset Flow**: Forgot password → reset
-- **Multi-Device Sessions**: Concurrent session management
-- **User Profile Updates**: Metadata updates
-- **Sign Out Flow**: Session termination
-- **OAuth Callback Simulation**: Third-party auth simulation
-- **Invalid Credentials**: Wrong password/email rejection
-- **Rate Limiting**: Brute-force protection
+#### Storage (4 files)
+| File | Coverage |
+|------|----------|
+| `storage_local_test.go` | Local filesystem backend |
+| `storage_s3_test.go` | S3/MinIO backend |
+| `storage_transform_test.go` | Image transformations |
 
-## 🔐 Row-Level Security (RLS)
+#### Edge Functions (4 files)
+| File | Coverage |
+|------|----------|
+| `functions_execution_test.go` | Function invoke, response handling |
+| `functions_reload_test.go` | Hot reload from filesystem |
+| `functions_auth_test.go` | Auth context injection |
+| `functions_auth_simple_test.go` | Basic auth propagation |
 
-### What is RLS?
+#### AI & MCP (4 files)
+| File | Coverage |
+|------|----------|
+| `ai_chatbot_test.go` | Chatbot creation, conversation, SQL generation |
+| `ai_chatbot_config_test.go` | Chatbot configuration, provider settings |
+| `ai_sql_validation_test.go` | SQL validation safety checks |
+| `mcp_test.go` | MCP tool execution, resources, scopes |
 
-Row-Level Security (RLS) is a PostgreSQL feature that restricts which rows users can access in database queries. Fluxbase implements RLS to ensure users can only see and modify their own data.
+#### Jobs & Webhooks (4 files)
+| File | Coverage |
+|------|----------|
+| `job_retry_test.go` | Retry logic, backoff |
+| `jobs_get_test.go` | Job listing, status |
+| `webhook_trigger_test.go` | Webhook delivery on DB events |
+| `webhook_trigger_debug_test.go` | Debug mode, delivery logging |
 
-### How RLS Works in Fluxbase
+#### Infrastructure (8 files)
+| File | Coverage |
+|------|----------|
+| `health_test.go` | Health endpoints |
+| `setup_test.go` | Initial setup flow |
+| `admin_test.go` | Admin API endpoints |
+| `ratelimit_test.go` | Rate limiting enforcement |
+| `logging_postgres_test.go` | Log ingestion and querying |
+| `migration_lock_test.go` | Concurrent migration locking |
+| `postgis_test.go` | PostGIS extension support |
+| `realtime_test.go` | WebSocket connections, presence, broadcast |
 
-1. **Authentication Middleware** extracts user ID from JWT token
-2. **RLS Middleware** stores user context in Fiber locals:
-   ```go
-   c.Locals("rls_user_id", userID)
-   c.Locals("rls_role", "authenticated")
-   ```
+#### Examples (2 files)
+| File | Coverage |
+|------|----------|
+| `example_test.go` | Basic usage examples |
+| `transaction_example_test.go` | Transaction patterns |
 
-3. **Transaction Wrapper** sets PostgreSQL session variables:
-   ```sql
-   SET LOCAL app.user_id = '<user-uuid>';
-   SET LOCAL app.role = 'authenticated';
-   ```
-
-4. **RLS Policies** enforce access control:
-   ```sql
-   CREATE POLICY tasks_user_policy ON tasks
-     FOR ALL
-     USING (user_id::text = current_setting('app.user_id', true))
-     WITH CHECK (user_id::text = current_setting('app.user_id', true));
-   ```
-
-### RLS Test Coverage
-
-The test suite validates:
-
-✅ **User Isolation**: User 1 cannot see User 2's data
-✅ **Insert Protection**: Users can only insert rows for themselves
-✅ **Update Protection**: Users can only update their own rows
-✅ **Delete Protection**: Users can only delete their own rows
-✅ **Anonymous Access**: Unauthenticated users see no protected data
-✅ **Multi-User Scenarios**: Multiple users with different permissions
-
-Example test case:
-```go
-// User 1 creates tasks
-task1 := map[string]interface{}{
-  "title": "User 1 Task",
-  "user_id": user1ID,
-}
-// POST /api/v1/tables/tasks with User 1's token
-
-// User 1 queries tasks
-// GET /api/v1/tables/tasks with User 1's token
-// Returns only User 1's tasks (RLS enforced)
-
-// User 2 queries tasks
-// GET /api/v1/tables/tasks with User 2's token
-// Returns only User 2's tasks (isolated from User 1)
-```
-
-## 🔑 Authentication Context
-
-### JWT Token Flow
-
-1. **Sign Up/Sign In** → Receive JWT access token + refresh token
-2. **API Request** → Include token in `Authorization: Bearer <token>` header
-3. **Auth Middleware** → Validates token, extracts user ID
-4. **RLS Middleware** → Sets session variables for RLS enforcement
-5. **Database Query** → RLS policies automatically filter rows
-
-### Edge Functions Authentication
-
-Edge Functions receive authentication context via environment variables:
-
-```typescript
-// In Edge Function code:
-const userId = Deno.env.get('FLUXBASE_USER_ID');
-const isAuthenticated = Deno.env.get('FLUXBASE_AUTHENTICATED') === 'true';
-
-if (!isAuthenticated) {
-  return new Response('Unauthorized', { status: 401 });
-}
-```
-
-Authentication context is injected in `handler.go`:
-
-```go
-// Get user ID from Fiber context
-if userID := c.Locals("user_id"); userID != nil {
-  req.UserID = userID.(string)
-}
-
-// Edge Function receives:
-// - FLUXBASE_USER_ID
-// - FLUXBASE_AUTHENTICATED
-// - FLUXBASE_BASE_URL (API base URL)
-// - FLUXBASE_TOKEN (service role token)
-```
-
-### Service Role vs User Role
-
-| Context | Description | Access Level |
-|---------|-------------|--------------|
-| **Anonymous** | No token provided | Public data only (RLS: `role = 'anon'`) |
-| **User** | Valid JWT token | User's own data (RLS: `role = 'authenticated'`) |
-| **Service Role** | Admin API key | Bypass RLS (full access) |
-
-## 🧪 Running Tests
+## Running Tests
 
 ### Prerequisites
 
 ```bash
-# 1. Start test database (DevContainer does this automatically)
+# Start the database (DevContainer handles this automatically)
 docker compose up -d postgres
 
-# 2. Run migrations
-make migrate-up
-
-# 3. Ensure test database is clean
-psql -U postgres -d fluxbase_test -c "DROP SCHEMA IF EXISTS auth CASCADE; DROP TABLE IF EXISTS products CASCADE; DROP TABLE IF EXISTS tasks CASCADE;"
+# Ensure schema is bootstrapped
+make db-reset
 ```
 
 ### Run All E2E Tests
@@ -173,163 +122,32 @@ psql -U postgres -d fluxbase_test -c "DROP SCHEMA IF EXISTS auth CASCADE; DROP T
 go test -v ./test/e2e/...
 
 # Run with coverage
-go test -v -cover -coverprofile=coverage.out ./test/e2e/...
+go test -v -tags=integration -cover -coverprofile=coverage.out ./test/e2e/...
 go tool cover -html=coverage.out -o coverage.html
+
+# Run with race detection
+go test -v -race ./test/e2e/...
 ```
 
 ### Run Specific Test Suites
 
 ```bash
-# REST API tests only
-go test -v ./test/e2e/ -run TestComprehensiveRESTAPI
+# REST API tests
+go test -v ./test/e2e/ -run TestREST
 
-# Authentication tests only
-go test -v ./test/e2e/ -run TestAuthenticationFlows
+# Authentication tests
+go test -v ./test/e2e/ -run TestAuth
 
-# Specific test case
-go test -v ./test/e2e/ -run TestComprehensiveRESTAPI/Row-Level_Security
+# RLS tests
+go test -v ./test/e2e/ -run TestRLS
+
+# Tenant isolation tests
+go test -v ./test/e2e/ -run TestTenant
 ```
 
-### Run with Race Detection
+## Related Documentation
 
-```bash
-go test -v -race ./test/e2e/...
-```
-
-## 📊 Expected Test Results
-
-### REST API Tests
-
-| Test Suite | Tests | Expected Result |
-|------------|-------|-----------------|
-| CRUD Operations | 6 | ✅ All pass |
-| Query Operators | 11 | ✅ All pass |
-| Full-Text Search | 1 | ✅ Pass |
-| JSONB Operators | 2 | ✅ All pass |
-| Array Operators | 2 | ✅ All pass |
-| Aggregations | 3 | ✅ All pass |
-| Upsert Operations | 2 | ✅ All pass |
-| Batch Operations | 3 | ✅ All pass |
-| Views and RPC | 2 | ✅ All pass |
-| Row-Level Security | 4 | ✅ All pass |
-| Authentication Context | 2 | ✅ All pass |
-
-**Total**: 38+ test cases
-
-### Authentication Tests
-
-| Test Suite | Tests | Expected Result |
-|------------|-------|-----------------|
-| Complete Signup Flow | 3 | ✅ All pass |
-| Email Verification | 1 | ✅ Pass |
-| Sign In Flow | 1 | ✅ Pass |
-| Token Refresh Flow | 1 | ✅ Pass |
-| Token Expiration | 1 | ✅ Pass |
-| Magic Link Auth | 1 | ✅ Pass |
-| Password Reset Flow | 1 | ✅ Pass |
-| Multi-Device Sessions | 1 | ✅ Pass |
-| User Profile Updates | 1 | ✅ Pass |
-| Sign Out Flow | 1 | ✅ Pass |
-| OAuth Callback | 1 | ✅ Pass |
-| Invalid Credentials | 2 | ✅ All pass |
-| Rate Limiting | 1 | ✅ Pass |
-
-**Total**: 16+ test cases
-
-## 🐛 Troubleshooting
-
-### Database Connection Errors
-
-```bash
-# Check PostgreSQL is running
-docker compose ps
-
-# Check connection
-psql -U postgres -h localhost -d fluxbase_test
-
-# Reset test database
-psql -U postgres -c "DROP DATABASE IF EXISTS fluxbase_test;"
-psql -U postgres -c "CREATE DATABASE fluxbase_test;"
-```
-
-### RLS Policy Errors
-
-```sql
--- Check RLS is enabled
-SELECT tablename, rowsecurity FROM pg_tables WHERE schemaname = 'public';
-
--- View policies
-SELECT * FROM pg_policies WHERE tablename = 'tasks';
-
--- Test RLS manually
-BEGIN;
-SET LOCAL app.user_id = 'some-uuid';
-SET LOCAL app.role = 'authenticated';
-SELECT * FROM tasks; -- Should only return tasks for that user
-ROLLBACK;
-```
-
-### JWT Token Issues
-
-```go
-// Generate test token manually
-token, _ := authService.GenerateJWT(userID, email)
-fmt.Println("Test token:", token)
-
-// Decode token to check claims
-// Use https://jwt.io to decode and verify
-```
-
-## 📝 Adding New Tests
-
-### Adding a New REST API Test
-
-```go
-func testNewFeature(t *testing.T, app *fiber.App, db *database.Connection, jwtSecret string) {
-  token := createTestUserAndToken(t, db, jwtSecret)
-
-  // Your test logic here
-  req := httptest.NewRequest("GET", "/api/v1/rest/your-endpoint", nil)
-  req.Header.Set("Authorization", "Bearer "+token)
-
-  resp, err := app.Test(req)
-  require.NoError(t, err)
-  assert.Equal(t, 200, resp.StatusCode)
-}
-```
-
-### Adding a New Auth Test
-
-```go
-func testNewAuthFlow(t *testing.T, app *fiber.App, db *database.Connection) {
-  email := "newtest@test.com"
-  password := "TestPass123!"
-
-  // Create user
-  createTestUserWithPassword(t, db, email, password)
-
-  // Test your auth flow
-  // ...
-}
-```
-
-## 🎯 Next Steps
-
-- [ ] Add Realtime WebSocket tests
-- [ ] Add Storage service tests
-- [ ] Add Edge Functions authentication tests
-- [ ] Add performance benchmarks
-- [ ] Add load testing scenarios
-
-## 📚 Related Documentation
-
-- [RLS Implementation](/internal/middleware/rls.go)
-- [Auth Handler](/internal/auth/handler.go)
-- [REST Handler](/internal/api/rest_handler.go)
-- [Functions Handler](/internal/functions/handler.go)
-
----
-
-**Last Updated**: 2025-10-30
-**Test Coverage**: REST API (90%), Authentication (95%)
-**Status**: ✅ Production Ready
+- [RLS Implementation](../../internal/middleware/rls.go)
+- [Auth Service](../../internal/auth/service.go)
+- [REST Handler](../../internal/api/rest_handler.go)
+- [Functions Handler](../../internal/functions/handler.go)


### PR DESCRIPTION
## Summary

Nine-phase DX/UX consistency improvement across docs, CI, backend, SDK, and admin UI.

## Phases

### 1. Docs & CLAUDE.md fixes
- Removed non-existent `pkg/client/` Go SDK from CLAUDE.md and intro.md
- Enriched root README with build/dev commands, prerequisites, license
- Rewrote `test/e2e/README.md` with accurate file references (54 test files categorized)

### 2. CI coverage enforcement
- Removed `continue-on-error: true` that silently swallowed coverage check failures
- Re-enabled Codecov upload with `fail_ci_if_error: false`

### 3. GraphQL logical operators
- Enabled `_and`/`_or`/`_not` self-referencing filter fields via `InputObjectConfigFieldMapThunk`
- Fixed De Morgan's law bug in resolver (`_not` wrapping `_or` incorrectly assigned OrGroupIDs)
- 8 new tests in `graphql_operators_test.go`

### 4. Pagination consistency
- Added `SendPaginatedWithMore` helper
- Migrated 5 handlers to unified `{key, total, limit, offset}` format
- Updated 2 affected test files

### 5. PageHeader migration
- All 23 remaining admin pages migrated to shared `<PageHeader>` component

### 6. React SDK hooks
- 7 new hook modules: `use-rpc`, `use-vector`, `use-secrets`, `use-service-keys`, `use-migrations`, `use-impersonation`, `use-ddl`
- 3 existing hooks thickened: `use-jobs` (+list/cancel/retry), `use-functions` (+list), `use-branches` (+create/delete/reset)
- 87 new tests, all passing

### 7. SDK getting-started docs
- TypeScript SDK guide: install, CRUD, auth, realtime, storage, error handling
- React SDK guide: provider setup, useTable, mutations, auth, realtime, full hook catalog

### 8. Chatbots page refactor
- Extracted TanStack Query-based `useChatbots` hook (list, sync, toggle, delete)
- Extracted `DeleteChatbotDialog` component and per-row action cells
- Replaced manual `useState`/`useEffect` data fetching with TanStack Query

### 9. Scalar API reference
- Serve interactive Scalar API docs at `/api-docs` (loads `/openapi.json`)
- Added external link support in sidebar (`target="_blank"`)
- "API Reference" link in the "API & Services" sidebar group

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/api/...` — GraphQL tests pass (3 DB-dependent auth tests fail locally due to no PostgreSQL)
- [x] `sdk` — 1312/1312 tests pass
- [x] `sdk-react` — 327/339 tests pass (12 pre-existing `getTenantId` failures in `use-query.test.ts`)
- [x] `admin` type-check + lint pass (0 errors)
- [ ] CI green