### PR TITLE
feat: AI prompt caching, native Anthropic provider, per-user quota, KG wiring fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,8 +194,18 @@ Server initialization uses a module-based dependency injection system:
 
 **Enhanced AI/Knowledge Base:**
 
-- `internal/ai/knowledge_base.go` - Core data models
+- `internal/ai/knowledge_base.go` - Core data models (incl. per-KB `EntityExtractionEnabled` toggle)
 - `internal/ai/knowledge_base_storage.go` - Storage operations
+- `internal/ai/provider_anthropic.go` - Native Anthropic Claude provider with explicit `cache_control` prompt caching
+- `internal/ai/provider_openai.go` - OpenAI/Azure provider (parses `prompt_tokens_details.cached_tokens` from automatic prefix caching)
+- `internal/ai/chat_handler_message.go` - Turns assemble a static system message + dynamic context message (user ID, time, RAG) so the static prefix is byte-stable across turns for caching
+- `internal/ai/chat_handler_tools.go` - `execute_sql` / MCP tool execution; both paths emit `query_result` events for parity
+- `internal/ai/chat_handler_usage.go` - `GET /api/v1/ai/usage/:chatbotId` (per-user daily quota snapshot)
+- `internal/ai/chatbot_limiter.go` - In-memory per-`(chatbotID, userID)` counters; `GetDailyUsage` returns a `DailyUsage` snapshot; `AddTokenUsage` is called with cached-token-discounted spend
+- `internal/ai/intent_validator.go` - `GetMatchedRules` surfaces fired rules via the done event's `matched_intent_rules`
+- `internal/ai/rag_service.go` - `RetrieveContext` branches to graph-boosted per-KB retrieval when `GraphBoostWeight > 0`
+- `internal/ai/document_processor.go` - Entity extraction gated by per-KB `EntityExtractionEnabled`; re-extraction cleans stale `document_entities` mentions
+- `internal/ai/knowledge_graph.go` - Entity/relationship CRUD; `DeleteDocumentEntitiesByDocument` for stale-mention cleanup
 
 **Multi-Tenancy:**
 

--- a/cli/cmd/knowledgebases.go
+++ b/cli/cmd/knowledgebases.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -30,6 +36,14 @@ var (
 	kbName           string
 	kbEnabled        bool
 	kbEnabledSet     bool
+	// Entity/graph/documents flags
+	kbEntityType        string
+	kbEntitySearch      string
+	kbEntityLimit       int
+	kbDocLimit          int
+	kbDocTitle          string
+	kbDocTag            []string
+	kbExtractNoEntities bool
 )
 
 var kbListCmd = &cobra.Command{
@@ -95,6 +109,70 @@ Examples:
 	RunE:    runKBDelete,
 }
 
+var kbEntitiesCmd = &cobra.Command{
+	Use:   "entities [kb-id]",
+	Short: "List or search entities in a knowledge base",
+	Long: `List entities extracted from a knowledge base's documents, or search them by name.
+
+Examples:
+  fluxbase kb entities abc123
+  fluxbase kb entities abc123 --type person --limit 20
+  fluxbase kb entities abc123 --search "Acme"`,
+	Args:    cobra.ExactArgs(1),
+	PreRunE: requireAuth,
+	RunE:    runKBEntities,
+}
+
+var kbGraphCmd = &cobra.Command{
+	Use:   "graph [kb-id]",
+	Short: "Show the knowledge graph (entities + relationships)",
+	Long: `Display a summary of the knowledge graph for a knowledge base.
+
+Examples:
+  fluxbase kb graph abc123`,
+	Args:    cobra.ExactArgs(1),
+	PreRunE: requireAuth,
+	RunE:    runKBGraph,
+}
+
+var kbChatbotsCmd = &cobra.Command{
+	Use:   "chatbots [kb-id]",
+	Short: "List chatbots linked to a knowledge base",
+	Long: `List all chatbots that have a knowledge base linked for RAG.
+
+Examples:
+  fluxbase kb chatbots abc123`,
+	Args:    cobra.ExactArgs(1),
+	PreRunE: requireAuth,
+	RunE:    runKBChatbots,
+}
+
+var kbDocumentsCmd = &cobra.Command{
+	Use:     "documents [kb-id]",
+	Aliases: []string{"docs"},
+	Short:   "List documents in a knowledge base",
+	Long: `List documents in a knowledge base.
+
+Examples:
+  fluxbase kb documents abc123 --limit 50`,
+	Args:    cobra.ExactArgs(1),
+	PreRunE: requireAuth,
+	RunE:    runKBDocuments,
+}
+
+var kbUploadCmd = &cobra.Command{
+	Use:   "upload [kb-id] [file]",
+	Short: "Upload a file as a document",
+	Long: `Upload a file (PDF, text, markdown, etc.) to a knowledge base.
+
+Examples:
+  fluxbase kb upload abc123 ./docs/guide.md
+  fluxbase kb upload abc123 report.pdf --title "Q4 Report" --tag finance`,
+	Args:    cobra.ExactArgs(2),
+	PreRunE: requireAuth,
+	RunE:    runKBUpload,
+}
+
 func init() {
 	kbListCmd.Flags().StringVar(&kbNamespace, "namespace", "", "Filter by namespace")
 
@@ -116,12 +194,28 @@ func init() {
 	kbUpdateCmd.Flags().StringVar(&kbVisibility, "visibility", "", "Visibility: private, shared, public")
 	kbUpdateCmd.Flags().BoolVar(&kbEnabled, "enabled", true, "Enable/disable the knowledge base")
 	kbUpdateCmd.Flags().BoolVar(&kbEnabledSet, "set-enabled", false, "Explicitly set enabled flag (use --enabled=true/false with this)")
+	kbUpdateCmd.Flags().BoolVar(&kbExtractNoEntities, "entity-extraction", true, "Enable/disable rule-based entity extraction for this KB")
+
+	// Entity/graph/documents flags
+	kbEntitiesCmd.Flags().StringVar(&kbEntityType, "type", "", "Filter entities by type (person, organization, location, etc.)")
+	kbEntitiesCmd.Flags().StringVar(&kbEntitySearch, "search", "", "Search entities by name (substring match)")
+	kbEntitiesCmd.Flags().IntVar(&kbEntityLimit, "limit", 50, "Maximum number of entities to return")
+
+	kbDocumentsCmd.Flags().IntVar(&kbDocLimit, "limit", 50, "Maximum number of documents to return")
+
+	kbUploadCmd.Flags().StringVar(&kbDocTitle, "title", "", "Document title (defaults to filename)")
+	kbUploadCmd.Flags().StringArrayVar(&kbDocTag, "tag", nil, "Tag to attach (can be repeated)")
 
 	kbCmd.AddCommand(kbListCmd)
 	kbCmd.AddCommand(kbGetCmd)
 	kbCmd.AddCommand(kbCreateCmd)
 	kbCmd.AddCommand(kbUpdateCmd)
 	kbCmd.AddCommand(kbDeleteCmd)
+	kbCmd.AddCommand(kbEntitiesCmd)
+	kbCmd.AddCommand(kbGraphCmd)
+	kbCmd.AddCommand(kbChatbotsCmd)
+	kbCmd.AddCommand(kbDocumentsCmd)
+	kbCmd.AddCommand(kbUploadCmd)
 }
 
 func runKBList(cmd *cobra.Command, args []string) error {
@@ -272,6 +366,9 @@ func runKBUpdate(cmd *cobra.Command, args []string) error {
 	if kbEnabledSet || cmd.Flags().Changed("enabled") {
 		body["enabled"] = kbEnabled
 	}
+	if cmd.Flags().Changed("entity-extraction") {
+		body["entity_extraction_enabled"] = kbExtractNoEntities
+	}
 
 	if len(body) == 0 {
 		return fmt.Errorf("no updates specified")
@@ -297,4 +394,295 @@ func runKBDelete(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Knowledge base '%s' deleted.\n", id)
 	return nil
+}
+
+// runKBEntities lists or searches entities in a knowledge base.
+func runKBEntities(cmd *cobra.Command, args []string) error {
+	kbID := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var response map[string]interface{}
+
+	if kbEntitySearch != "" {
+		path := fmt.Sprintf("/api/v1/admin/ai/knowledge-bases/%s/entities/search?q=%s&limit=%d",
+			url.PathEscape(kbID), url.QueryEscape(kbEntitySearch), kbEntityLimit)
+		if err := apiClient.DoGet(ctx, path, nil, &response); err != nil {
+			return err
+		}
+	} else {
+		params := url.Values{}
+		params.Set("limit", fmt.Sprintf("%d", kbEntityLimit))
+		if kbEntityType != "" {
+			params.Set("type", kbEntityType)
+		}
+		path := "/api/v1/admin/ai/knowledge-bases/" + url.PathEscape(kbID) + "/entities?" + params.Encode()
+		if err := apiClient.DoGet(ctx, path, nil, &response); err != nil {
+			return err
+		}
+	}
+
+	entities := getSlice(response, "entities")
+	if len(entities) == 0 {
+		fmt.Println("No entities found.")
+		return nil
+	}
+
+	formatter := GetFormatter()
+	if formatter.Format == output.FormatTable {
+		data := output.TableData{
+			Headers: []string{"ID", "TYPE", "NAME", "CANONICAL"},
+			Rows:    make([][]string, len(entities)),
+		}
+		for i, e := range entities {
+			data.Rows[i] = []string{
+				getStringValue(e, "id"),
+				getStringValue(e, "entity_type"),
+				getStringValue(e, "name"),
+				getStringValue(e, "canonical_name"),
+			}
+		}
+		formatter.PrintTable(data)
+	} else {
+		if err := formatter.Print(entities); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runKBGraph shows a summary of the knowledge graph for a KB.
+func runKBGraph(cmd *cobra.Command, args []string) error {
+	kbID := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var graph map[string]interface{}
+	path := "/api/v1/admin/ai/knowledge-bases/" + url.PathEscape(kbID) + "/graph"
+	if err := apiClient.DoGet(ctx, path, nil, &graph); err != nil {
+		return err
+	}
+
+	formatter := GetFormatter()
+	if formatter.Format == output.FormatTable {
+		fmt.Printf("Entities:     %d\n", getIntValue(graph, "entity_count"))
+		fmt.Printf("Relationships: %d\n", getIntValue(graph, "relationship_count"))
+		fmt.Println()
+
+		entities := getSlice(graph, "entities")
+		if len(entities) > 0 {
+			fmt.Println("Top entities:")
+			data := output.TableData{
+				Headers: []string{"TYPE", "NAME", "DOCUMENTS"},
+				Rows:    make([][]string, 0, len(entities)),
+			}
+			for _, e := range entities {
+				docCount := 0
+				if meta, ok := e["metadata"].(map[string]interface{}); ok {
+					docCount = getIntValue(meta, "document_count")
+				}
+				data.Rows = append(data.Rows, []string{
+					getStringValue(e, "entity_type"),
+					getStringValue(e, "canonical_name"),
+					fmt.Sprintf("%d", docCount),
+				})
+			}
+			formatter.PrintTable(data)
+		}
+	} else {
+		if err := formatter.Print(graph); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runKBChatbots lists chatbots linked to a KB.
+func runKBChatbots(cmd *cobra.Command, args []string) error {
+	kbID := args[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var response map[string]interface{}
+	path := "/api/v1/admin/ai/knowledge-bases/" + url.PathEscape(kbID) + "/chatbots"
+	if err := apiClient.DoGet(ctx, path, nil, &response); err != nil {
+		return err
+	}
+
+	chatbots := getSlice(response, "chatbots")
+	if len(chatbots) == 0 {
+		fmt.Println("No chatbots linked to this knowledge base.")
+		return nil
+	}
+
+	formatter := GetFormatter()
+	if formatter.Format == output.FormatTable {
+		data := output.TableData{
+			Headers: []string{"ID", "NAME", "NAMESPACE", "ENABLED"},
+			Rows:    make([][]string, len(chatbots)),
+		}
+		for i, cb := range chatbots {
+			data.Rows[i] = []string{
+				getStringValue(cb, "id"),
+				getStringValue(cb, "name"),
+				getStringValue(cb, "namespace"),
+				fmt.Sprintf("%v", cb["enabled"]),
+			}
+		}
+		formatter.PrintTable(data)
+	} else {
+		if err := formatter.Print(chatbots); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runKBDocuments lists documents in a KB.
+func runKBDocuments(cmd *cobra.Command, args []string) error {
+	kbID := args[0]
+	limit := kbDocLimit
+	if limit <= 0 {
+		limit = 50
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var response map[string]interface{}
+	path := fmt.Sprintf("/api/v1/admin/ai/knowledge-bases/%s/documents?limit=%d",
+		url.PathEscape(kbID), limit)
+	if err := apiClient.DoGet(ctx, path, nil, &response); err != nil {
+		return err
+	}
+
+	docs := getSlice(response, "documents")
+	if len(docs) == 0 {
+		fmt.Println("No documents found.")
+		return nil
+	}
+
+	formatter := GetFormatter()
+	if formatter.Format == output.FormatTable {
+		data := output.TableData{
+			Headers: []string{"ID", "TITLE", "STATUS", "CHUNKS"},
+			Rows:    make([][]string, len(docs)),
+		}
+		for i, d := range docs {
+			data.Rows[i] = []string{
+				getStringValue(d, "id"),
+				getStringValue(d, "title"),
+				getStringValue(d, "status"),
+				fmt.Sprintf("%d", getIntValue(d, "total_chunks")),
+			}
+		}
+		formatter.PrintTable(data)
+	} else {
+		if err := formatter.Print(docs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runKBUpload uploads a file as a document to a KB via multipart form.
+func runKBUpload(cmd *cobra.Command, args []string) error {
+	kbID := args[0]
+	localFile := args[1]
+
+	fileData, err := os.ReadFile(localFile) //nolint:gosec // CLI tool reads user-provided file path
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	title := kbDocTitle
+	if title == "" {
+		title = filepath.Base(localFile)
+	}
+
+	// Build multipart form
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	// Add file part
+	part, err := writer.CreateFormFile("file", filepath.Base(localFile))
+	if err != nil {
+		return fmt.Errorf("failed to create form file: %w", err)
+	}
+	if _, err := part.Write(fileData); err != nil {
+		return fmt.Errorf("failed to write file part: %w", err)
+	}
+
+	// Add title field
+	if err := writer.WriteField("title", title); err != nil {
+		return fmt.Errorf("failed to write title field: %w", err)
+	}
+	// Add tags
+	for _, tag := range kbDocTag {
+		if err := writer.WriteField("tags", tag); err != nil {
+			return fmt.Errorf("failed to write tag field: %w", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	uploadURL := apiClient.BaseURL + "/api/v1/admin/ai/knowledge-bases/" + url.PathEscape(kbID) + "/documents/upload"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uploadURL, &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Auth
+	creds, err := apiClient.CredentialManager.GetCredentials(apiClient.Profile.Name)
+	if err != nil {
+		return err
+	}
+	if creds != nil {
+		if creds.AccessToken != "" {
+			req.Header.Set("Authorization", "Bearer "+creds.AccessToken)
+		} else if creds.APIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+creds.APIKey)
+		}
+	}
+
+	resp, err := apiClient.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("upload failed (%d): %s", resp.StatusCode, string(body))
+	}
+
+	fmt.Printf("Uploaded '%s' to knowledge base '%s'.\n", localFile, kbID)
+	return nil
+}
+
+// getSlice returns a slice of maps from a response map, or nil if missing.
+func getSlice(m map[string]interface{}, key string) []map[string]interface{} {
+	v, ok := m[key]
+	if !ok {
+		return nil
+	}
+	s, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]map[string]interface{}, 0, len(s))
+	for _, item := range s {
+		if mp, ok := item.(map[string]interface{}); ok {
+			result = append(result, mp)
+		}
+	}
+	return result
 }

--- a/cli/cmd/mcp.go
+++ b/cli/cmd/mcp.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/nimbleflux/fluxbase/cli/bundler"
 	"github.com/nimbleflux/fluxbase/cli/output"
 )
 
@@ -465,18 +466,75 @@ func runMCPToolsSync(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Read _shared/ modules so MCP tools can import shared code (constants,
+	// helpers) instead of duplicating it across files. Same convention as
+	// edge functions and jobs (Ask 3).
+	sharedModulesMap := make(map[string]string)
+	sharedDir := filepath.Join(dir, "_shared")
+	if info, err := os.Stat(sharedDir); err == nil && info.IsDir() {
+		entries, err := os.ReadDir(sharedDir)
+		if err == nil {
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				name := entry.Name()
+				if !strings.HasSuffix(name, ".ts") && !strings.HasSuffix(name, ".js") {
+					continue
+				}
+				if content, err := os.ReadFile(filepath.Join(sharedDir, name)); err == nil { //nolint:gosec // CLI reads user-provided path
+					sharedModulesMap["_shared/"+name] = string(content)
+				}
+			}
+		}
+	}
+
+	// Lazy-init the bundler; only used if at least one tool has imports.
+	var b *bundler.Bundler
+
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	for _, file := range files {
-		code, err := os.ReadFile(file) //nolint:gosec // CLI tool reads user-provided file path
+		rawCode, err := os.ReadFile(file) //nolint:gosec // CLI tool reads user-provided file path
 		if err != nil {
 			fmt.Printf("Error reading %s: %v\n", file, err)
 			continue
 		}
+		code := string(rawCode)
+
+		// Bundle if the tool has imports (relative or bare). Tools without
+		// imports skip the bundler entirely, so existing single-file tools
+		// behave exactly as before.
+		if strings.Contains(code, "import ") && len(sharedModulesMap) > 0 {
+			if b == nil {
+				b, err = bundler.NewBundler(dir)
+				if err != nil {
+					// Deno not available — post raw code, server-side runtime
+					// will reject the imports but at least sync won't fail.
+					fmt.Println("Note: Deno not available for local bundling; tools with imports may fail at runtime.")
+					b = nil
+				}
+			}
+			if b != nil {
+				if !b.NeedsBundle(code) {
+					// Import detected but not one the bundler handles (e.g. npm:).
+					// Leave code as-is.
+				} else {
+					fmt.Printf("Bundling %s...", filepath.Base(file))
+					result, bundleErr := b.Bundle(ctx, code, sharedModulesMap)
+					if bundleErr != nil {
+						fmt.Println()
+						return fmt.Errorf("failed to bundle %s: %w", filepath.Base(file), bundleErr)
+					}
+					fmt.Printf(" %s → %s\n", formatBytes(len(code)), formatBytes(len(result.BundledCode)))
+					code = result.BundledCode
+				}
+			}
+		}
 
 		// Parse annotations from code
-		name, annotations := parseMCPAnnotations(string(code), filepath.Base(file))
+		name, annotations := parseMCPAnnotations(code, filepath.Base(file))
 
 		// Use namespace from annotation if specified, otherwise use CLI flag
 		namespace := mcpNamespace
@@ -492,7 +550,7 @@ func runMCPToolsSync(cmd *cobra.Command, args []string) error {
 		payload := map[string]interface{}{
 			"name":      name,
 			"namespace": namespace,
-			"code":      string(code),
+			"code":      code,
 			"upsert":    true,
 		}
 

--- a/docs/src/content/docs/cli/commands.md
+++ b/docs/src/content/docs/cli/commands.md
@@ -455,11 +455,20 @@ Update an existing knowledge base.
 
 ```bash
 fluxbase kb update abc123 --description "Updated description"
+fluxbase kb update abc123 --entity-extraction=false
 ```
 
 **Flags:**
 
+- `--name` - New name
 - `--description` - New description
+- `--chunk-size` - Chunk size in tokens
+- `--chunk-overlap` - Chunk overlap in tokens
+- `--embedding-model` - Embedding model
+- `--chunk-strategy` - `recursive` | `sentence` | `paragraph` | `fixed`
+- `--visibility` - `private` | `shared` | `public`
+- `--enabled` - Enable/disable the KB
+- `--entity-extraction` - Enable/disable rule-based entity extraction (default: true)
 
 ### `fluxbase kb delete`
 
@@ -469,170 +478,33 @@ Delete a knowledge base and all its documents.
 fluxbase kb delete abc123
 ```
 
-### `fluxbase kb status`
-
-Show knowledge base status and statistics.
-
-```bash
-fluxbase kb status abc123
-fluxbase kb status abc123 --output json
-```
-
-**Flags:**
-
-- `--output` - Output format (`json`, `table`)
-
 ### `fluxbase kb upload`
 
-Upload a document to a knowledge base. Supported formats: PDF, DOCX, TXT, MD, images (with OCR).
+Upload a file (PDF, DOCX, TXT, MD, images with OCR enabled on the server) as a document to a knowledge base.
 
 ```bash
 fluxbase kb upload abc123 ./manual.pdf
 fluxbase kb upload abc123 ./guide.md --title "User Guide"
-fluxbase kb upload abc123 ./scan.png --ocr-languages eng,deu
+fluxbase kb upload abc123 ./report.pdf --tag finance --tag q4
 ```
 
 **Flags:**
 
-- `--title` - Document title
-- `--metadata` - Document metadata (JSON)
-- `--tags` - Comma-separated tags
-- `--ocr-languages` - OCR languages for images (e.g., `eng,deu`)
-
-### `fluxbase kb add`
-
-Add a document from text, stdin, or file (alternative to upload for text content).
-
-```bash
-# Add from inline content
-fluxbase kb add abc123 --content "Hello world" --title "Greeting"
-
-# Add from stdin
-echo "Content" | fluxbase kb add abc123 --title "My Doc"
-
-# Add from file
-fluxbase kb add abc123 --from-file ./doc.txt --title "Document"
-
-# Add with metadata
-fluxbase kb add abc123 --content "..." --title "Doc" --metadata '{"user_id":"uuid"}' --tags "important,reference"
-```
-
-**Flags:**
-
-- `--content` - Inline document content
-- `--from-file` - Read content from file
-- `--title` - Document title
-- `--metadata` - Document metadata (JSON)
-- `--tags` - Comma-separated tags
+- `--title` - Document title (defaults to filename)
+- `--tag` - Tag to attach (can be repeated: `--tag a --tag b`)
 
 ### `fluxbase kb documents`
 
-List documents in a knowledge base.
+List documents in a knowledge base (alias: `kb docs`).
 
 ```bash
 fluxbase kb documents abc123
-```
-
-### `fluxbase kb documents get`
-
-Get document details.
-
-```bash
-fluxbase kb documents get abc123 doc456
-```
-
-### `fluxbase kb documents update`
-
-Update document metadata.
-
-```bash
-fluxbase kb documents update abc123 doc456 --title "New Title"
-fluxbase kb documents update abc123 doc456 --tags "tag1,tag2"
-fluxbase kb documents update abc123 doc456 --metadata '{"key":"value"}'
+fluxbase kb documents abc123 --limit 100
 ```
 
 **Flags:**
 
-- `--title` - New document title
-- `--tags` - New tags (comma-separated)
-- `--metadata` - New metadata (JSON)
-
-### `fluxbase kb documents delete`
-
-Delete a document from a knowledge base.
-
-```bash
-fluxbase kb documents delete abc123 doc456
-```
-
-### `fluxbase kb documents delete-by-filter`
-
-Bulk delete documents by tags or metadata.
-
-```bash
-fluxbase kb documents delete-by-filter abc123 --tags "archived"
-fluxbase kb documents delete-by-filter abc123 --metadata-filter "user_id=uuid-here"
-```
-
-**Flags:**
-
-- `--tags` - Filter by tags (comma-separated)
-- `--metadata-filter` - Filter by metadata (e.g., `key=value`)
-
-### `fluxbase kb search`
-
-Search a knowledge base using semantic similarity.
-
-```bash
-fluxbase kb search abc123 "how to reset password"
-fluxbase kb search abc123 "pricing plans" --limit 5 --threshold 0.8
-```
-
-**Flags:**
-
-- `--limit` - Maximum results (default: 10)
-- `--threshold` - Similarity threshold 0.0-1.0 (default: 0.7)
-
-### `fluxbase kb export-table`
-
-Export a database table as a document to the knowledge base. Includes schema, columns, relationships, and optional sample data.
-
-```bash
-# Export all columns
-fluxbase kb export-table abc123 --table users --schema public
-
-# Export specific columns (recommended for sensitive data)
-fluxbase kb export-table abc123 --table users --columns id,name,email
-
-# Include foreign keys and indexes
-fluxbase kb export-table abc123 --table products --include-fks --include-indexes --sample-rows 10
-```
-
-**Flags:**
-
-- `--table` - Table name (required)
-- `--schema` - Schema name (default: `public`)
-- `--columns` - Comma-separated column names (default: all)
-- `--include-fks` - Include foreign keys
-- `--include-indexes` - Include indexes
-- `--sample-rows` - Number of sample rows to include
-
-### `fluxbase kb tables`
-
-List exportable database tables.
-
-```bash
-fluxbase kb tables
-fluxbase kb tables public
-```
-
-### `fluxbase kb capabilities`
-
-Show system capabilities including supported OCR languages, file types, and features.
-
-```bash
-fluxbase kb capabilities
-```
+- `--limit` - Maximum number of documents to return (default: 50)
 
 ### `fluxbase kb graph`
 

--- a/docs/src/content/docs/guides/ai-chatbots.md
+++ b/docs/src/content/docs/guides/ai-chatbots.md
@@ -288,6 +288,7 @@ Available metadata annotations:
 | `@fluxbase:knowledge-base`           | Name of knowledge base for RAG (can specify multiple)              | -                         |
 | `@fluxbase:rag-max-chunks`           | Maximum chunks to retrieve for RAG context                         | `5`                       |
 | `@fluxbase:rag-similarity-threshold` | Minimum similarity score for RAG (0.0-1.0)                         | `0.7`                     |
+| `@fluxbase:rag-graph-boost-weight`   | Re-rank RAG chunks by entity salience (0.0=off, 1.0=fully entity-driven). See [Graph-Boosted Retrieval](/guides/knowledge-bases#graph-boosted-retrieval) | `0` (off) |
 | `@fluxbase:required-settings`        | Setting keys to load for template resolution                       | -                         |
 | `@fluxbase:mcp-tools`                | Comma-separated MCP tools to enable (see [MCP Tools](#mcp-tools))  | `""` (legacy execute_sql) |
 | `@fluxbase:use-mcp-schema`           | Fetch schema from MCP resources instead of direct DB introspection | `false`                   |
@@ -670,13 +671,13 @@ if (data) {
 
 ### Provider Management
 
-Configure AI providers (OpenAI, Azure OpenAI, or Ollama):
+Configure AI providers (OpenAI, Azure OpenAI, Anthropic Claude, or Ollama):
 
 ```typescript
 // List providers
 const { data: providers } = await client.admin.ai.listProviders();
 
-// Create a provider
+// Create an OpenAI provider
 const { data, error } = await client.admin.ai.createProvider({
   name: "openai-main",
   display_name: "OpenAI (Main)",
@@ -685,6 +686,18 @@ const { data, error } = await client.admin.ai.createProvider({
   config: {
     api_key: "sk-...",
     model: "gpt-4-turbo",
+  },
+});
+
+// Create an Anthropic Claude provider (supports explicit prompt caching via
+// cache_control breakpoints — see Prompt Caching below)
+const { data: anthropic, error: anthropicErr } = await client.admin.ai.createProvider({
+  name: "anthropic-main",
+  display_name: "Anthropic Claude",
+  provider_type: "anthropic",
+  config: {
+    api_key: "sk-ant-...",
+    model: "claude-sonnet-4-5-20250929",
   },
 });
 
@@ -813,6 +826,70 @@ Restrict database operations to prevent data modification:
 - User lacks PostgreSQL permissions on the table
 - Check Row-Level Security policies
 - Verify user authentication
+
+## Turn Metadata (`done` event)
+
+Every chat turn ends with a `done` WebSocket event. The payload extends the basic usage shape with optional fields that surface live state to clients:
+
+```typescript
+chat.onDone((usage, conversationId, extras) => {
+  // Token accounting for the turn that just finished
+  console.log(usage?.prompt_tokens, usage?.completion_tokens)
+  // cached_tokens: subset of prompt_tokens served from the provider's prompt
+  // cache (0 when caching didn't fire). See Prompt Caching below.
+  console.log(`  cached: ${usage?.cached_tokens ?? 0}`)
+
+  // Per-user daily quota snapshot at turn end (omitted when the chatbot has
+  // no daily-limit / token-budget configured).
+  if (extras?.daily_quota) {
+    const reqLeft = extras.daily_quota.requests.limit - extras.daily_quota.requests.used
+    const tokLeft = extras.daily_quota.tokens.limit - extras.daily_quota.tokens.used
+    console.log(`${reqLeft} requests / ${tokLeft} tokens left today`)
+  }
+
+  // Intent rules that fired for this turn (omitted when none match or no
+  // rules are configured). Use this to log and tune @fluxbase:intent-rules.
+  for (const rule of extras?.matched_intent_rules ?? []) {
+    console.log(`Rule fired: "${rule.keyword}" →`, rule)
+  }
+})
+```
+
+For the initial load (before any turn is sent), use `fluxbase.ai.getUsage(chatbotId)` to fetch the same quota snapshot via REST:
+
+```typescript
+const { data, error } = await client.ai.getUsage('chatbot-uuid')
+if (data) console.log(`${data.requests.limit - data.requests.used} requests left today`)
+```
+
+:::note
+Quota counters are best-effort in-memory and reset on server restart; per-instance in multi-replica deployments. They are accurate enough for "X left today" displays but not for billing.
+:::
+
+## Prompt Caching
+
+Fluxbase enables provider-side prompt caching so the static portion of your chatbot's system prompt is cached across turns of a conversation. The cache is automatic; you don't opt in per chatbot.
+
+**How it works:**
+
+- The static system prompt (your `export default` text + schema description + query guidelines + intent rules) is sent as a separate system message at the start of the conversation.
+- The dynamic per-turn context (current user ID, current time, RAG retrieval) is sent as a *second* system message after the static one, so the static prefix is byte-identical across turns.
+- OpenAI caches the byte-identical prefix automatically (≥1024 tokens).
+- Anthropic (when configured as the provider) marks the static system block and the last tool definition with `cache_control: {type: "ephemeral"}`, the explicit-cache model. Cached reads are billed at **0.1x** instead of 1x.
+
+**Reading the cache hit rate:**
+
+`usage.cached_tokens` in the `done` event carries the count of input tokens served from cache (0 when caching didn't fire). For Anthropic providers, this is `cache_read_input_tokens`. For OpenAI/Azure, it's `prompt_tokens_details.cached_tokens`.
+
+**Budget impact:**
+
+Cached input tokens are billed at **0x** against the chatbot's `@fluxbase:token-budget` — they cost the provider 0.1x–0.5x, so the user doesn't foot the full bill. Effective daily spend = `(prompt_tokens - cached_tokens) + completion_tokens`.
+
+**Cache-breakers to avoid in your prompt:**
+
+The static prefix is cached up to the first differing token. To maximize cache hits:
+- Avoid `{{user_id}}` and user-scoped `{{user:key}}` templates near the top of the system prompt — these vary per user. (Fluxbase already moves `Current user ID` into the dynamic context; user-injected templates in your prompt are your responsibility.)
+- Don't put timestamps, request IDs, or other per-turn values in the static portion.
 
 ## Next Steps
 

--- a/docs/src/content/docs/guides/knowledge-bases.md
+++ b/docs/src/content/docs/guides/knowledge-bases.md
@@ -517,38 +517,41 @@ Fluxbase automatically extracts entities and relationships from documents when t
 
 ### Entity Types
 
-The following entity types are automatically extracted from documents:
+The following entity types are extracted by the built-in rule-based extractor. The extractor is regex-driven and works best on developer/technical content; it is US/English-centric. Set `entity_extraction_enabled=false` on a KB to skip extraction entirely (see [Disabling extraction](#disabling-extraction)).
 
-| Type               | Description                       | Examples                                       |
-| ------------------ | --------------------------------- | ---------------------------------------------- |
-| **person**         | People and names                  | John Smith, Dr. Jane Doe, CEO Bob              |
-| **organization**   | Companies and organizations       | Google, Microsoft, Corp, LLC                   |
-| **location**       | Geographic locations              | New York, London, Paris, California            |
-| **concept**        | Abstract concepts and ideas       | Machine Learning, Democracy                    |
-| **product**        | Products and services             | iPhone, AWS, Docker, Kubernetes                |
-| **event**          | Events and time-based occurrences | Olympics, World War II                         |
-| **table**          | Database tables                   | `auth.users`, `public.orders`                  |
-| **url**            | URLs and links                    | `https://example.com`, `www.fluxbase.com/docs` |
-| **api_endpoint**   | REST/GraphQL/RPC endpoints        | `POST /api/v1/users`, `GET /api/v1/auth/...`   |
-| **datetime**       | Dates, times, durations           | `2025-02-18`, `2h 30m`, `next week`            |
-| **code_reference** | File paths, repos, code snippets  | `internal/ai/kb.go`, `github.com/user/repo`    |
-| **error**          | Error codes, exceptions           | `ErrNotFound`, `404 Unauthorized`              |
+| Type               | What the rule matches                                   | Examples                                       |
+| ------------------ | ------------------------------------------------------- | ---------------------------------------------- |
+| **person**         | Title-prefixed names, 2+ capitalized words              | John Smith, Dr. Jane Doe, CEO Bob              |
+| **organization**   | Company suffixes (Inc/Corp/LLC/…) + a built-in list     | Google, Microsoft, Acme Corp                   |
+| **location**       | Built-in list of US/CA/EU cities and US states          | New York, London, Paris, California            |
+| **product**        | Built-in list of ~30 tech products                      | iPhone, AWS, Docker, Kubernetes                |
+| **url**            | URLs and links                                          | `https://example.com`, `www.fluxbase.com/docs` |
+| **api_endpoint**   | HTTP-method + `/api/...`, `/api/vN/...`, `/graphql`     | `POST /api/v1/users`, `GET /api/v1/auth/...`   |
+| **datetime**       | ISO 8601, `Month DD, YYYY`, relative phrases            | `2025-02-18`, `2h 30m`, `3 days ago`           |
+| **code_reference** | File paths, `github.com/user/repo`                      | `internal/ai/kb.go`, `github.com/user/repo`    |
+| **error**          | `Err[A-Z]…`, HTTP codes, quoted error phrases           | `ErrNotFound`, `404 Unauthorized`              |
+| **table**          | Created by table export, not the rule extractor         | `auth.users`, `public.orders`                  |
+| **other**          | Reserved; not produced by the extractor                 | —                                              |
+
+:::note
+The `person` rule (capitalized bigrams) is aggressive. Expect false positives on prose ("San Francisco" can match as both `person` and `location`). For non-technical KBs, consider disabling extraction.
+:::
 
 ### Relationship Types
 
-Entities are connected by the following relationship types:
+The schema defines 19 relationship types. Only three are produced automatically; the rest are available for manual insertion (e.g. via SQL or future tools).
 
-| Type            | Description                       | Example                          |
-| --------------- | --------------------------------- | -------------------------------- |
-| **works_at**    | Person works at organization      | "John works at Google"           |
-| **located_in**  | Entity located in location        | "Office in San Francisco"        |
-| **founded_by**  | Organization founded by person    | "Apple founded by Steve Jobs"    |
-| **owns**        | Ownership relationship            | "Company owns product"           |
-| **part_of**     | Hierarchical/part-of relationship | "Chapter is part of book"        |
-| **related_to**  | General relationship              | "Concept A related to Concept B" |
-| **knows**       | Person knows person               | "Alice knows Bob"                |
-| **foreign_key** | Database foreign key              | `orders.user_id → users.id`      |
-| **depends_on**  | Dependency relationship           | "View depends on table"          |
+**Automatically inferred:**
+
+| Type            | What the rule looks for                              | Example                          |
+| --------------- | ---------------------------------------------------- | -------------------------------- |
+| **works_at**    | `(?:works at\|is employed by\|joined\|works for)`     | "John works at Google"           |
+| **founded_by**  | `(?:founded\|co-founded\|started\|created)`          | "Apple founded by Steve Jobs"    |
+| **foreign_key** | Created by table export, not the rule extractor      | `orders.user_id → users.id`      |
+
+**Schema-supported (manual only — not produced by any extractor):**
+
+`located_in`, `owns`, `part_of`, `related_to`, `knows`, `customer_of`, `supplier_of`, `invested_in`, `acquired`, `merged_with`, `competitor_of`, `parent_of`, `child_of`, `spouse_of`, `sibling_of`, `depends_on`.
 
 ### Automatic Extraction
 
@@ -559,6 +562,53 @@ Entities and relationships are extracted automatically when documents are proces
 3. Rule-based entity extraction identifies entities and relationships
 4. Entities are stored in the knowledge graph
 5. Document-entity mentions are tracked
+
+Re-running extraction (e.g. via `ReprocessDocument`) replaces prior document-entity mentions for that document, so editing a document to remove an entity mention no longer leaves stale links. Entities themselves are de-duplicated by canonical name; entities referenced only by a deleted document are garbage-collected.
+
+### Disabling extraction
+
+Extraction is enabled by default for every KB. To skip it (e.g. for a prose-heavy KB where the regex `person` rule would create noise), set `entity_extraction_enabled=false`:
+
+```bash
+# CLI
+fluxbase kb update <kb-id> --entity-extraction=false
+
+# REST
+curl -X PUT http://localhost:8080/api/v1/admin/ai/knowledge-bases/<kb-id> \
+  -H "Authorization: Bearer YOUR_SERVICE_ROLE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"entity_extraction_enabled": false}'
+```
+
+Disabling extraction on an existing KB does not remove entities already stored; delete and recreate the KB if you need a clean slate, or remove entities via SQL.
+
+## Graph-Boosted Retrieval
+
+:::note
+Graph-boosted retrieval is **off by default**. Without enabling it, the knowledge graph has no effect on chatbot responses.
+:::
+
+When enabled, RAG retrieval over-fetches candidate chunks and re-ranks them using entity salience: chunks from documents that mention entities found in the user's query are boosted. The re-rank formula is:
+
+```
+finalScore = similarity * (1 - weight) + entityBoost * weight
+```
+
+where `entityBoost` is the normalized salience of query-extracted entities on the chunk's parent document (0 to 1). Because the rule extractor currently assigns a flat salience of `0.5` to every entity, the boost acts as an entity-presence signal; per-entity salience tuning is a future improvement.
+
+Enable graph boost via either of two knobs (per-chatbot annotation takes precedence over the global default):
+
+```ts
+// Chatbot annotation (0.0–1.0, 0 = off)
+// @fluxbase:rag-graph-boost-weight 0.3
+```
+
+```bash
+# Global default for all chatbots (env var)
+FLUXBASE_AI_RAG_GRAPH_BOOST_WEIGHT=0.3
+```
+
+User isolation is preserved: graph-boosted search honors the same `MetadataFilter` (per-user `user_id`, include-global) as the standard path.
 
 ## Database Table Export
 
@@ -754,74 +804,23 @@ fluxbase kb get <kb-id>
 # Create knowledge base
 fluxbase kb create my-kb --description "My knowledge base"
 
-# Update knowledge base
+# Update knowledge base (e.g. disable entity extraction)
 fluxbase kb update <kb-id> --description "Updated description"
+fluxbase kb update <kb-id> --entity-extraction=false
 
 # Delete knowledge base
 fluxbase kb delete <kb-id>
-
-# Show status and statistics
-fluxbase kb status <kb-id>
 ```
 
 ### Document Management
 
 ```bash
 # List documents
-fluxbase kb documents <kb-id>
+fluxbase kb documents <kb-id>           # alias: kb docs
 
-# Add document from text
-fluxbase kb add <kb-id> --content "Document content" --title "My Doc"
-
-# Add document from file
-fluxbase kb add <kb-id> --from-file ./doc.txt --title "My Doc"
-
-# Add document from stdin
-echo "Content" | fluxbase kb add <kb-id> --title "Piped Doc"
-
-# Add with user isolation
-fluxbase kb add <kb-id> --content "..." --metadata '{"user_id":"user-123"}'
-
-# Get document details
-fluxbase kb documents get <kb-id> <doc-id>
-
-# Delete single document
-fluxbase kb documents delete <kb-id> <doc-id>
-
-# Bulk delete by filter
-fluxbase kb documents delete-by-filter <kb-id> --metadata-filter "user_id=user-123"
-```
-
-### File Upload
-
-```bash
-# Upload document file
+# Upload a file as a document
 fluxbase kb upload <kb-id> ./document.pdf --title "My PDF"
-
-# Upload with OCR languages (for scanned PDFs)
-fluxbase kb upload <kb-id> ./scanned.pdf --ocr-languages "eng,deu"
-```
-
-### Search
-
-```bash
-# Search knowledge base
-fluxbase kb search <kb-id> "how to reset password"
-
-# Search with options
-fluxbase kb search <kb-id> "pricing" --limit 5 --threshold 0.7
-```
-
-### Table Export
-
-```bash
-# List exportable tables
-fluxbase kb tables
-fluxbase kb tables auth  # Filter by schema
-
-# Export table as document
-fluxbase kb export-table <kb-id> --schema public --table users \
-  --include-fks --include-indexes --sample-rows 5
+fluxbase kb upload <kb-id> report.md --tag finance --tag q4
 ```
 
 ### Knowledge Graph

--- a/docs/src/content/docs/guides/mcp/custom-mcp-tools.md
+++ b/docs/src/content/docs/guides/mcp/custom-mcp-tools.md
@@ -427,6 +427,55 @@ Access secrets securely via `context.secrets.get("SECRET_NAME")`. Secrets are:
 - Never exposed in logs
 - Only available when `allow_env` is enabled
 
+## Sharing Code Between Tools (`_shared/`)
+
+Custom MCP tools are stored as single files, so any code shared across tools — a constants map, a date-range parser, an HTTP client wrapper — must be inlined at sync time. The `fluxbase mcp tools sync` command does this automatically when it finds a `_shared/` directory next to your tool files. (This is the same convention used by edge functions and jobs.)
+
+### Layout
+
+```
+fluxbase/mcp-tools/
+├── _shared/
+│   ├── countries.ts    # country-name → ISO code map
+│   └── date_range.ts   # parses "last 7 days", "this month", etc.
+├── search_visits.ts    # imports from _shared/
+└── aggregate_visits.ts # imports from _shared/
+```
+
+### Importing
+
+Reference shared modules with a relative `_shared/...` path:
+
+```typescript
+// search_visits.ts
+import { COUNTRIES } from "./_shared/countries.ts";
+import { parseDateRange } from "./_shared/date_range.ts";
+
+export default async function handler(args: any) {
+  const range = parseDateRange(args.timeframe);
+  const iso = COUNTRIES[args.country.toLowerCase()];
+  // ...
+}
+```
+
+### Syncing
+
+Run sync as usual — files with imports are bundled locally (requires Deno on your PATH) and the bundled output is what's stored:
+
+```bash
+fluxbase mcp tools sync --dir ./fluxbase/mcp-tools
+# Bundling search_visits.ts... 4.2 KB → 18.7 KB
+# Bundling aggregate_visits.ts... 3.8 KB → 17.9 KB
+```
+
+If Deno isn't installed locally, sync falls back to posting raw source; tools with imports will then fail at runtime, so install Deno (`brew install deno`) when using `_shared/`.
+
+### Caveats
+
+- The stored tool body is the bundled output, not the original. Edit source in git and re-sync — direct edits via the admin UI will be overwritten on the next `sync`.
+- Bundling is opt-in per file: tools without `import` statements are uploaded verbatim, exactly as before.
+
+
 ## Integration with Chatbots
 
 Custom tools are automatically available to chatbots. Configure which tools a chatbot can use:

--- a/internal/ai/chat_handler.go
+++ b/internal/ai/chat_handler.go
@@ -90,6 +90,19 @@ func (h *ChatHandler) SetMCPResources(resources MCPResourceReader) {
 	h.schemaBuilder.SetMCPResources(resources)
 }
 
+// InvalidateProvider drops a cached provider so the next request reloads it
+// from the database. Called by the admin Handler when a provider is mutated
+// (config update, deletion, default change). Without this, rotated API keys
+// and changed models never take effect for the chat path.
+func (h *ChatHandler) InvalidateProvider(providerID string) {
+	if providerID == "" {
+		return
+	}
+	h.providersMu.Lock()
+	delete(h.providers, providerID)
+	h.providersMu.Unlock()
+}
+
 // GetRAGService returns the RAG service (may be nil if not initialized)
 func (h *ChatHandler) GetRAGService() *RAGService {
 	return h.ragService
@@ -160,8 +173,29 @@ type ServerMessage struct {
 	RowCount       int              `json:"row_count,omitempty"`
 	Data           []map[string]any `json:"data,omitempty"`
 	Usage          *UsageStats      `json:"usage,omitempty"`
-	Error          string           `json:"error,omitempty"`
-	Code           string           `json:"code,omitempty"`
+	// MatchedIntentRules surfaces the intent rules that fired for this turn
+	// (Add 5). Empty/omitted when no rules match or no rules are configured.
+	MatchedIntentRules []MatchedIntentRule `json:"matched_intent_rules,omitempty"`
+	// DailyQuota carries the per-user remaining quota snapshot at turn end
+	// (Ask 2). Omitted when no daily limits are configured for the chatbot.
+	DailyQuota *DailyQuotaSnapshot `json:"daily_quota,omitempty"`
+	Error      string              `json:"error,omitempty"`
+	Code       string              `json:"code,omitempty"`
+}
+
+// DailyQuotaSnapshot is a point-in-time view of the per-user daily counters
+// for a chatbot. Surfaced in the done event so clients can render
+// "X requests/tokens left today" without an extra round-trip.
+type DailyQuotaSnapshot struct {
+	Requests Quota  `json:"requests"`
+	Tokens   Quota  `json:"tokens"`
+	ResetsAt string `json:"resets_at,omitempty"` // RFC3339; empty when unknown
+}
+
+// Quota is one counter half of a DailyQuotaSnapshot.
+type Quota struct {
+	Used  int `json:"used"`
+	Limit int `json:"limit"`
 }
 
 // ChatContext holds the context for a chat session

--- a/internal/ai/chat_handler_message.go
+++ b/internal/ai/chat_handler_message.go
@@ -71,7 +71,17 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 		return
 	}
 
-	// Retrieve RAG context if available (with user isolation)
+	// Build the dynamic per-turn context (user ID, current time, RAG) as a
+	// separate message so the static system prompt stays byte-identical across
+	// turns — enabling provider-side prompt caching (OpenAI automatic, Anthropic
+	// explicit). Order matters: static system first, dynamic context second,
+	// history third, user message last.
+	var dynamicContext strings.Builder
+	fmt.Fprintf(&dynamicContext, "Current user ID: %s\n", userID)
+	fmt.Fprintf(&dynamicContext, "Current date and time: %s\n", time.Now().UTC().Format("Monday, January 2, 2006 at 3:04 PM MST"))
+
+	// Retrieve RAG context if available (with user isolation) and append to
+	// the dynamic context (NOT the static system prompt).
 	if h.ragService != nil {
 		ragOpts := RetrieveContextOptions{
 			ChatbotID: chatbot.ID,
@@ -84,23 +94,34 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 		if chatbot.RAGSimilarityThreshold > 0 {
 			ragOpts.Threshold = chatbot.RAGSimilarityThreshold
 		}
+		// Graph boost: chatbot annotation wins; fall back to global config.
+		// Both default to 0 (off), preserving existing behavior.
+		if chatbot.RAGGraphBoostWeight > 0 {
+			ragOpts.GraphBoostWeight = chatbot.RAGGraphBoostWeight
+		} else if h.config != nil && h.config.RAGGraphBoostWeight > 0 {
+			ragOpts.GraphBoostWeight = h.config.RAGGraphBoostWeight
+		}
 		ragSection, err := h.ragService.RetrieveContext(ctx, ragOpts)
 		if err != nil {
 			log.Warn().Err(err).Str("chatbot_id", chatbot.ID).Msg("Failed to retrieve RAG context")
 			// Continue without RAG - don't fail the request
 		} else if ragSection != nil && ragSection.FormattedContext != "" {
-			systemPrompt = systemPrompt + "\n\n" + ragSection.FormattedContext
+			dynamicContext.WriteString("\n\n")
+			dynamicContext.WriteString(ragSection.FormattedContext)
 			log.Debug().
 				Str("chatbot_id", chatbot.ID).
 				Str("conversation_id", msg.ConversationID).
 				Int("rag_section_len", len(ragSection.FormattedContext)).
-				Msg("RAG context added to system prompt")
+				Msg("RAG context added to dynamic context message")
 		}
 	}
 
-	// Build messages for LLM
+	// Build messages for LLM. The static system prompt is message[0]; the
+	// dynamic context (user ID, time, RAG) is message[1] as a second system
+	// message so providers can cache message[0] but not message[1].
 	messages := []Message{
 		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleSystem, Content: dynamicContext.String()},
 	}
 
 	// Add conversation history
@@ -109,6 +130,26 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 	// Add user message
 	userMsg := Message{Role: RoleUser, Content: msg.Content}
 	messages = append(messages, userMsg)
+
+	// Pre-check daily token budget with a rough estimate of the upcoming request.
+	// Real usage is reconciled after the request via AddTokenUsage; this guard
+	// only stops obviously-over-budget requests from starting.
+	if chatbot.DailyTokenBudget > 0 {
+		estimatedInputChars := len(systemPrompt) + dynamicContext.Len() + len(msg.Content)
+		for _, m := range state.Messages {
+			estimatedInputChars += len(m.Content)
+		}
+		// ponytail: chars/4 estimate is a coarse lower bound for English text;
+		// upgrade to a real tokenizer if budget edge cases matter.
+		estimatedTokens := estimatedInputChars / 4
+		if chatbot.MaxTokens > 0 {
+			estimatedTokens += chatbot.MaxTokens
+		}
+		if !h.limiter.CheckDailyTokenBudget(chatbot.ID, userIdentifier, chatbot.DailyTokenBudget, estimatedTokens) {
+			h.sendError(chatCtx, msg.ConversationID, "TOKEN_BUDGET", "Daily token budget exceeded.")
+			return
+		}
+	}
 
 	// Get provider
 	provider, err := h.getProvider(ctx, chatbot)
@@ -124,6 +165,10 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 	// Tool calling loop - continue until AI generates content without tool calls
 	var totalUsage UsageStats
 	var accumulatedQueryResults []QueryResult // Accumulate query results for persistence
+	// matchedIntentRules accumulates rules that fire across the turn (both
+	// pre-tool-selection and post-tool-call). Surfaced in the done event so
+	// apps can observe and tune their rules (Ask 5).
+	var matchedIntentRules []MatchedIntentRule
 	maxIterations := chatbot.MaxToolIterations
 	if maxIterations <= 0 {
 		maxIterations = 5
@@ -144,6 +189,11 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 		if len(chatbot.IntentRules) > 0 {
 			intentValidator := NewIntentValidator(chatbot.IntentRules, chatbot.RequiredColumns, chatbot.DefaultTable)
 			forbiddenTools = intentValidator.GetForbiddenTools(msg.Content)
+			// Capture rule matches on the first iteration only (the user
+			// message doesn't change between iterations of the tool loop).
+			if iteration == 0 {
+				matchedIntentRules = append(matchedIntentRules, intentValidator.GetMatchedRules(msg.Content)...)
+			}
 			if len(forbiddenTools) > 0 {
 				log.Debug().
 					Strs("forbidden_tools", forbiddenTools).
@@ -223,6 +273,7 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 		// Create chat request
 		chatReq := &ChatRequest{
 			Messages:    messages,
+			Model:       chatbot.Model,
 			MaxTokens:   chatbot.MaxTokens,
 			Temperature: chatbot.Temperature,
 			Tools:       tools,
@@ -264,6 +315,7 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 					totalUsage.PromptTokens += event.Usage.PromptTokens
 					totalUsage.CompletionTokens += event.Usage.CompletionTokens
 					totalUsage.TotalTokens += event.Usage.TotalTokens
+					totalUsage.CachedTokens += event.Usage.CachedTokens
 				}
 			}
 			return nil
@@ -272,14 +324,22 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 		// Stream the response
 		h.sendProgress(chatCtx, msg.ConversationID, "generating", "Generating response...")
 
+		providerStart := time.Now()
+		providerName := provider.Name()
 		if err := provider.ChatStream(ctx, chatReq, callback); err != nil {
 			log.Error().Err(err).Msg("Chat stream error")
+			if h.metrics != nil {
+				h.metrics.RecordAIProviderRequest(providerName, "error", time.Since(providerStart))
+			}
 			h.sendError(chatCtx, msg.ConversationID, "STREAM_ERROR", "Error generating response")
 
 			if h.metrics != nil {
 				h.metrics.RecordAIChatRequest(chatbot.Name, "error", time.Since(start))
 			}
 			return
+		}
+		if h.metrics != nil {
+			h.metrics.RecordAIProviderRequest(providerName, "success", time.Since(providerStart))
 		}
 
 		// If no tool calls, we're done
@@ -315,6 +375,10 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 			if len(chatbot.IntentRules) > 0 {
 				intentValidator := NewIntentValidator(chatbot.IntentRules, chatbot.RequiredColumns, chatbot.DefaultTable)
 				toolValidation := intentValidator.ValidateToolCall(msg.Content, toolName)
+				// Surface tool/table rules that fire on this call. GetMatchedRules
+				// already captured all matching rules once at iteration 0; here
+				// we only add ones with tool/table constraints we haven't seen.
+				matchedIntentRules = append(matchedIntentRules, toolValidation.MatchedRules...)
 
 				log.Debug().
 					Int("intent_rules_count", len(chatbot.IntentRules)).
@@ -406,14 +470,38 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 		if chatCtx.UserID != nil {
 			userIdentifier = *chatCtx.UserID
 		}
-		h.limiter.AddTokenUsage(chatbot.ID, userIdentifier, totalUsage.TotalTokens)
+		// ponytail: cached input tokens are billed at 0x (free) toward the
+		// daily budget — they cost the provider ~0.1x (Anthropic) to ~0.5x
+		// (OpenAI), so the user shouldn't foot the full bill. Effective spend
+		// = fresh input + completion. CachedTokens is non-negative by
+		// construction; the floor is a defensive guard.
+		effective := totalUsage.PromptTokens - totalUsage.CachedTokens + totalUsage.CompletionTokens
+		if effective < 0 {
+			effective = 0
+		}
+		h.limiter.AddTokenUsage(chatbot.ID, userIdentifier, effective)
+	}
+
+	// Build the per-user daily quota snapshot for the done event (Ask 2).
+	// Surfaced when the chatbot has either a daily request limit or a token
+	// budget configured; omitted otherwise (preserves old wire shape).
+	var dailyQuota *DailyQuotaSnapshot
+	if chatbot.DailyRequestLimit > 0 || chatbot.DailyTokenBudget > 0 {
+		usage := h.limiter.GetDailyUsage(chatbot.ID, userIdentifier, chatbot.DailyRequestLimit, chatbot.DailyTokenBudget)
+		dailyQuota = &DailyQuotaSnapshot{
+			Requests: Quota{Used: usage.RequestsUsed, Limit: usage.RequestsLimit},
+			Tokens:   Quota{Used: usage.TokensUsed, Limit: usage.TokensLimit},
+			ResetsAt: usage.ResetsAt.UTC().Format(time.RFC3339),
+		}
 	}
 
 	// Send completion
 	h.send(chatCtx, ServerMessage{
-		Type:           "done",
-		ConversationID: msg.ConversationID,
-		Usage:          &totalUsage,
+		Type:               "done",
+		ConversationID:     msg.ConversationID,
+		Usage:              &totalUsage,
+		MatchedIntentRules: matchedIntentRules,
+		DailyQuota:         dailyQuota,
 	})
 
 	// Record metrics

--- a/internal/ai/chat_handler_tools.go
+++ b/internal/ai/chat_handler_tools.go
@@ -105,7 +105,7 @@ func (h *ChatHandler) executeSQLTool(ctx context.Context, chatCtx *ChatContext, 
 	result, err := h.executor.Execute(ctx, execReq)
 	if err != nil {
 		log.Error().Err(err).Msg("SQL execution error")
-		return fmt.Sprintf("Error executing query: %v", err), nil
+		return FormatErrorForLLM(err, args.SQL, "execute_sql"), nil
 	}
 
 	// Log to audit (unless execution logs are disabled)
@@ -143,7 +143,7 @@ func (h *ChatHandler) executeSQLTool(ctx context.Context, chatCtx *ChatContext, 
 
 	// Return result as string for AI to interpret
 	if !result.Success {
-		return fmt.Sprintf("Query failed: %s", result.Error), nil
+		return FormatErrorForLLM(fmt.Errorf("%s", result.Error), args.SQL, "execute_sql"), nil
 	}
 
 	// Build QueryResult for persistence
@@ -196,6 +196,15 @@ func (h *ChatHandler) executeMCPTool(ctx context.Context, chatCtx *ChatContext, 
 
 	if result.IsError {
 		log.Warn().Str("tool", toolName).Str("error", result.Content).Msg("MCP tool returned error")
+		// Surface the error to the client so they don't see silent execution.
+		// Without this, the only feedback was the LLM's interpretation of the
+		// error string returned below.
+		h.send(chatCtx, ServerMessage{
+			Type:           "tool_result",
+			ConversationID: conversationID,
+			Message:        toolName,
+			Error:          result.Content,
+		})
 		return fmt.Sprintf("Error: %s", result.Content), nil
 	}
 
@@ -215,20 +224,26 @@ func (h *ChatHandler) executeMCPTool(ctx context.Context, chatCtx *ChatContext, 
 		queryResult = h.parseMCPExecuteSQLResult(args, result.Content)
 	}
 
-	// Build server message
+	// Build server message. When the tool returned structured query data, emit
+	// the canonical `query_result` event type so clients (including old SDKs
+	// that only handled `query_result`) receive it uniformly across the legacy
+	// and MCP execution paths. Otherwise emit `tool_result`.
 	serverMsg := ServerMessage{
-		Type:           "tool_result",
 		ConversationID: conversationID,
 		Message:        toolName,
 	}
 
-	// Add structured fields for execute_sql
-	if toolName == "execute_sql" && queryResult != nil {
+	// Add structured fields whenever we parsed a QueryResult (execute_sql and
+	// query_table). The previous gate restricted this to execute_sql only,
+	// which left query_table results parsed-for-persistence but unstreamed.
+	if queryResult != nil {
+		serverMsg.Type = "query_result"
 		serverMsg.Query = queryResult.Query
 		serverMsg.Summary = queryResult.Summary
 		serverMsg.RowCount = queryResult.RowCount
 		serverMsg.Data = queryResult.Data
 	} else {
+		serverMsg.Type = "tool_result"
 		serverMsg.Data = []map[string]any{{"tool": toolName, "result": result.Content}}
 	}
 

--- a/internal/ai/chat_handler_usage.go
+++ b/internal/ai/chat_handler_usage.go
@@ -1,0 +1,54 @@
+package ai
+
+import (
+	"github.com/gofiber/fiber/v3"
+	"github.com/rs/zerolog/log"
+
+	"github.com/nimbleflux/fluxbase/internal/middleware"
+)
+
+// GetUserUsage returns the authenticated user's daily quota snapshot for a
+// given chatbot: requests used/limit and tokens used/limit, plus when the
+// counters reset. Cheap O(1) read against the in-memory limiter.
+//
+// GET /api/v1/ai/usage/:chatbotId
+func (h *ChatHandler) GetUserUsage(c fiber.Ctx) error {
+	ctx := middleware.CtxWithTenant(c)
+	chatbotID := c.Params("chatbotId")
+
+	userID := middleware.GetUserID(c)
+	if userID == "" {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
+			"error": "Authentication required",
+		})
+	}
+
+	chatbot, err := h.storage.GetChatbot(ctx, chatbotID)
+	if err != nil {
+		log.Error().Err(err).Str("chatbot_id", chatbotID).Msg("Failed to load chatbot for usage")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to load chatbot",
+		})
+	}
+	if chatbot == nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Chatbot not found",
+		})
+	}
+
+	usage := h.limiter.GetDailyUsage(chatbot.ID, userID, chatbot.DailyRequestLimit, chatbot.DailyTokenBudget)
+
+	return c.JSON(fiber.Map{
+		"chatbot_id": chatbot.ID,
+		"user_id":    userID,
+		"requests": fiber.Map{
+			"used":  usage.RequestsUsed,
+			"limit": usage.RequestsLimit,
+		},
+		"tokens": fiber.Map{
+			"used":  usage.TokensUsed,
+			"limit": usage.TokensLimit,
+		},
+		"resets_at": usage.ResetsAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	})
+}

--- a/internal/ai/chatbot.go
+++ b/internal/ai/chatbot.go
@@ -84,9 +84,10 @@ type Chatbot struct {
 	KnowledgeBases         []string `json:"knowledge_bases,omitempty"`
 	RAGMaxChunks           int      `json:"rag_max_chunks"`
 	RAGSimilarityThreshold float64  `json:"rag_similarity_threshold"`
-	RAGTable               string   `json:"rag_table,omitempty"`          // User table for vector search
-	RAGColumn              string   `json:"rag_column,omitempty"`         // Vector column in RAG table
-	RAGContentColumn       string   `json:"rag_content_column,omitempty"` // Text content column in RAG table
+	RAGGraphBoostWeight    float64  `json:"rag_graph_boost_weight,omitempty"` // 0=off (default), 1=fully entity-driven
+	RAGTable               string   `json:"rag_table,omitempty"`              // User table for vector search
+	RAGColumn              string   `json:"rag_column,omitempty"`             // Vector column in RAG table
+	RAGContentColumn       string   `json:"rag_content_column,omitempty"`     // Text content column in RAG table
 
 	// Agent behavior settings
 	ReasoningMode     string `json:"reasoning_mode,omitempty"`      // "none" (default), "react", "strict" - controls think tool usage
@@ -137,6 +138,7 @@ type ChatbotConfig struct {
 	KnowledgeBases         []string // Knowledge base names to link
 	RAGMaxChunks           int      // Max chunks to retrieve per query
 	RAGSimilarityThreshold float64  // Minimum similarity score (0-1)
+	RAGGraphBoostWeight    float64  // Graph-boost weight (0=off, 1=fully entity-driven); falls back to global config
 	RAGTable               string   // User table for vector search (optional)
 	RAGColumn              string   // Vector column in RAG table
 	RAGContentColumn       string   // Text content column in RAG table
@@ -266,6 +268,9 @@ var (
 
 	// @fluxbase:rag-similarity-threshold 0.7
 	ragThresholdPattern = regexp.MustCompile(`@fluxbase:rag-similarity-threshold\s+([\d.]+)`)
+
+	// @fluxbase:rag-graph-boost-weight 0.3 (0=off, 1=fully entity-driven)
+	ragGraphBoostPattern = regexp.MustCompile(`@fluxbase:rag-graph-boost-weight\s+([\d.]+)`)
 
 	// @fluxbase:rag-table documents (for user-table RAG)
 	ragTablePattern = regexp.MustCompile(`@fluxbase:rag-table\s+([^\n*\s]+)`)
@@ -457,6 +462,13 @@ func ParseChatbotConfig(code string) ChatbotConfig {
 	if matches := ragThresholdPattern.FindStringSubmatch(code); len(matches) > 1 {
 		if v, err := strconv.ParseFloat(matches[1], 64); err == nil && v >= 0 && v <= 1 {
 			config.RAGSimilarityThreshold = v
+		}
+	}
+
+	// Parse RAG graph boost weight
+	if matches := ragGraphBoostPattern.FindStringSubmatch(code); len(matches) > 1 {
+		if v, err := strconv.ParseFloat(matches[1], 64); err == nil && v >= 0 && v <= 1 {
+			config.RAGGraphBoostWeight = v
 		}
 	}
 
@@ -652,6 +664,7 @@ func (c *Chatbot) ApplyConfig(config ChatbotConfig) {
 	c.KnowledgeBases = config.KnowledgeBases
 	c.RAGMaxChunks = config.RAGMaxChunks
 	c.RAGSimilarityThreshold = config.RAGSimilarityThreshold
+	c.RAGGraphBoostWeight = config.RAGGraphBoostWeight
 	c.RAGTable = config.RAGTable
 	c.RAGColumn = config.RAGColumn
 	c.RAGContentColumn = config.RAGContentColumn

--- a/internal/ai/chatbot_limiter.go
+++ b/internal/ai/chatbot_limiter.go
@@ -96,6 +96,37 @@ func (cl *ChatbotLimiter) AddTokenUsage(chatbotID, userID string, tokens int) {
 	entry.tokenCount += tokens
 }
 
+// DailyUsage is a point-in-time view of the per-user daily counters for a
+// chatbot. ResetsAt is the start of the *next* local day (when counters roll).
+type DailyUsage struct {
+	RequestsUsed  int
+	TokensUsed    int
+	RequestsLimit int // configured @fluxbase:daily-limit, 0 = unlimited
+	TokensLimit   int // configured @fluxbase:token-budget, 0 = unlimited
+	ResetsAt      time.Time
+}
+
+// GetDailyUsage returns the current per-user daily counters for a chatbot.
+// Pass the configured limits in (the limiter itself doesn't know them — they
+// live on the Chatbot struct). Used to surface remaining quota in the done
+// event (Ask 2) and the GET /api/v1/ai/usage/:chatbotId endpoint.
+func (cl *ChatbotLimiter) GetDailyUsage(chatbotID, userID string, requestsLimit, tokensLimit int) DailyUsage {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+
+	k := cl.key(chatbotID, userID)
+	entry := cl.getOrCreateDaily(k)
+
+	reset := entry.dayStart.Add(24 * time.Hour)
+	return DailyUsage{
+		RequestsUsed:  entry.requestCount,
+		TokensUsed:    entry.tokenCount,
+		RequestsLimit: requestsLimit,
+		TokensLimit:   tokensLimit,
+		ResetsAt:      reset,
+	}
+}
+
 func (cl *ChatbotLimiter) getOrCreateDaily(k string) *dailyUsageEntry {
 	now := time.Now()
 	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())

--- a/internal/ai/chatbot_limiter_test.go
+++ b/internal/ai/chatbot_limiter_test.go
@@ -1,0 +1,52 @@
+package ai
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatbotLimiter_GetDailyUsage(t *testing.T) {
+	limiter := NewChatbotLimiter()
+	t.Cleanup(func() {
+		// cleanupLoop goroutine runs forever; the limiter is local so it leaks,
+		// but that's fine for a unit test.
+		_ = limiter
+	})
+
+	chatbotID := "chatbot-1"
+	userID := "user-1"
+
+	t.Run("zero before any activity", func(t *testing.T) {
+		usage := limiter.GetDailyUsage(chatbotID, userID, 500, 100_000)
+		assert.Equal(t, 0, usage.RequestsUsed)
+		assert.Equal(t, 0, usage.TokensUsed)
+		assert.Equal(t, 500, usage.RequestsLimit)
+		assert.Equal(t, 100_000, usage.TokensLimit)
+		assert.False(t, usage.ResetsAt.IsZero())
+	})
+
+	t.Run("reflects request counter after CheckDailyRequestLimit", func(t *testing.T) {
+		for i := 0; i < 3; i++ {
+			require.True(t, limiter.CheckDailyRequestLimit(chatbotID, userID, 500))
+		}
+		usage := limiter.GetDailyUsage(chatbotID, userID, 500, 100_000)
+		assert.Equal(t, 3, usage.RequestsUsed)
+	})
+
+	t.Run("reflects token counter after AddTokenUsage", func(t *testing.T) {
+		limiter.AddTokenUsage(chatbotID, userID, 1234)
+		usage := limiter.GetDailyUsage(chatbotID, userID, 500, 100_000)
+		assert.Equal(t, 1234, usage.TokensUsed)
+	})
+
+	t.Run("resets_at is the start of the next local day", func(t *testing.T) {
+		usage := limiter.GetDailyUsage(chatbotID, userID, 500, 100_000)
+		now := time.Now()
+		expectedReset := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).
+			Add(24 * time.Hour)
+		assert.WithinDuration(t, expectedReset, usage.ResetsAt, time.Second)
+	})
+}

--- a/internal/ai/conversation.go
+++ b/internal/ai/conversation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/database"
+	"github.com/nimbleflux/fluxbase/internal/observability"
 )
 
 // ConversationManager handles conversation state management
@@ -24,6 +25,12 @@ type ConversationManager struct {
 	cacheTTL    time.Duration
 	maxTurns    int
 	cleanupDone chan struct{}
+	metrics     *observability.Metrics // optional, for active-conversation gauge
+}
+
+// SetMetrics wires the optional metrics handle (called after construction).
+func (cm *ConversationManager) SetMetrics(m *observability.Metrics) {
+	cm.metrics = m
 }
 
 // ConversationState represents the in-memory state of a conversation
@@ -516,6 +523,11 @@ func (cm *ConversationManager) cleanup() {
 			delete(cm.cache, id)
 			log.Debug().Str("id", id).Msg("Removed inactive conversation from cache")
 		}
+	}
+
+	// Refresh the active-conversations gauge with the live cache size.
+	if cm.metrics != nil {
+		cm.metrics.UpdateAIConversations(len(cm.cache))
 	}
 }
 

--- a/internal/ai/document_processor.go
+++ b/internal/ai/document_processor.go
@@ -82,9 +82,15 @@ func (p *DocumentProcessor) ProcessDocument(ctx context.Context, doc *Document, 
 
 	log.Info().Str("doc_id", doc.ID).Int("chunks", len(textChunks)).Msg("Document chunked")
 
-	// Extract entities and relationships (best-effort, doesn't fail processing)
+	// Extract entities and relationships (best-effort, doesn't fail processing).
+	// Gated by the per-KB entity_extraction_enabled flag (default true) so KBs
+	// that don't want a knowledge graph can skip extraction entirely.
 	if p.entityExtractor != nil && p.knowledgeGraph != nil {
-		if err := p.extractAndStoreEntities(ctx, doc); err != nil {
+		if kb, kbErr := p.storage.GetKnowledgeBase(ctx, doc.KnowledgeBaseID); kbErr != nil {
+			log.Warn().Err(kbErr).Str("kb_id", doc.KnowledgeBaseID).Msg("Failed to load KB for extraction toggle check; defaulting to enabled")
+		} else if kb != nil && !kb.EntityExtractionEnabled {
+			log.Debug().Str("kb_id", doc.KnowledgeBaseID).Msg("Entity extraction disabled for this KB; skipping")
+		} else if err := p.extractAndStoreEntities(ctx, doc); err != nil {
 			log.Warn().Err(err).Str("doc_id", doc.ID).Msg("Entity extraction failed, continuing with embedding")
 		}
 	}
@@ -555,6 +561,14 @@ func (p *DocumentProcessor) AddDocument(ctx context.Context, kbID string, req Cr
 
 // extractAndStoreEntities extracts entities and relationships from a document and stores them in the knowledge graph
 func (p *DocumentProcessor) extractAndStoreEntities(ctx context.Context, doc *Document) error {
+	// Clear any prior document_entities mentions for this document so re-extraction
+	// (on reprocess/update) doesn't leave stale links to entities no longer present.
+	// AddDocumentEntities below upserts current mentions; this drop makes the table
+	// reflect exactly the current extraction.
+	if err := p.knowledgeGraph.DeleteDocumentEntitiesByDocument(ctx, doc.ID); err != nil {
+		log.Warn().Err(err).Str("doc_id", doc.ID).Msg("Failed to clear stale document_entities (continuing)")
+	}
+
 	// Use the entity extractor to get entities, relationships, and document-entity links
 	result, err := p.entityExtractor.ExtractEntitiesWithRelationships(
 		doc.Content,

--- a/internal/ai/handler.go
+++ b/internal/ai/handler.go
@@ -24,6 +24,7 @@ type Handler struct {
 	config               *config.AIConfig
 	vectorManager        VectorManagerInterface
 	knowledgeBaseStorage *KnowledgeBaseStorage // Optional: for syncing KB links
+	chatHandler          *ChatHandler          // Optional: for provider cache invalidation
 }
 
 // NewHandler creates a new AI handler
@@ -39,6 +40,20 @@ func NewHandler(storage *Storage, loader *Loader, cfg *config.AIConfig, vectorMa
 	h.ValidateConfig()
 
 	return h
+}
+
+// SetChatHandler wires the chat handler so provider mutations can invalidate
+// the chat path's provider cache. Called after both handlers are constructed.
+func (h *Handler) SetChatHandler(ch *ChatHandler) {
+	h.chatHandler = ch
+}
+
+// invalidateProvider drops the provider from the chat handler's cache (if wired).
+// Call this whenever a provider's config, default status, or existence changes.
+func (h *Handler) invalidateProvider(providerID string) {
+	if h.chatHandler != nil {
+		h.chatHandler.InvalidateProvider(providerID)
+	}
 }
 
 // SetKnowledgeBaseStorage sets the knowledge base storage for syncing KB links
@@ -539,6 +554,10 @@ func (h *Handler) SetDefaultProvider(c fiber.Ctx) error {
 		})
 	}
 
+	// Invalidate chat-side cache: chatbots without an explicit ProviderID fall
+	// back to the default and need to pick up the new default on next request.
+	h.invalidateProvider(id)
+
 	// Reload embedding service from database providers
 	if h.vectorManager != nil {
 		if err := h.vectorManager.RefreshFromDatabase(ctx); err != nil {
@@ -571,6 +590,9 @@ func (h *Handler) DeleteProvider(c fiber.Ctx) error {
 			"error": "Failed to delete provider",
 		})
 	}
+
+	// Drop the deleted provider from the chat-side cache.
+	h.invalidateProvider(id)
 
 	// Reload embedding service from database providers
 	if h.vectorManager != nil {
@@ -723,6 +745,10 @@ func (h *Handler) UpdateProvider(c fiber.Ctx) error {
 			"error": "Failed to update provider",
 		})
 	}
+
+	// Invalidate chat-side cache so the new config (API key, model, etc.) takes
+	// effect immediately rather than on next process restart.
+	h.invalidateProvider(id)
 
 	// Reload embedding service from database providers
 	if h.vectorManager != nil {

--- a/internal/ai/intent_validator.go
+++ b/internal/ai/intent_validator.go
@@ -20,6 +20,21 @@ type IntentValidationResult struct {
 	Errors          []string `json:"errors,omitempty"`
 	Suggestions     []string `json:"suggestions,omitempty"`
 	MatchedKeywords []string `json:"matched_keywords,omitempty"`
+	// MatchedRules carries the rules that fired for this validation, with the
+	// keyword that triggered the match. Surfaced to clients via the `done`
+	// event so apps can observe and tune their intent rules.
+	MatchedRules []MatchedIntentRule `json:"matched_rules,omitempty"`
+}
+
+// MatchedIntentRule is a public, client-facing view of a single intent rule
+// that fired for a user message. Mirrors the fields of IntentRule plus the
+// specific keyword that matched.
+type MatchedIntentRule struct {
+	Keyword        string `json:"keyword"`
+	RequiredTable  string `json:"required_table,omitempty"`
+	ForbiddenTable string `json:"forbidden_table,omitempty"`
+	RequiredTool   string `json:"required_tool,omitempty"`
+	ForbiddenTool  string `json:"forbidden_tool,omitempty"`
 }
 
 // NewIntentValidator creates a new intent validator
@@ -56,16 +71,29 @@ func (v *IntentValidator) ValidateIntent(userMessage, sql string, tablesAccessed
 	for _, rule := range v.intentRules {
 		// Check if any keywords match
 		keywordMatched := false
+		var firstMatchedKeyword string
 		for _, keyword := range rule.Keywords {
 			if strings.Contains(lowerMessage, strings.ToLower(keyword)) {
 				keywordMatched = true
 				result.MatchedKeywords = append(result.MatchedKeywords, keyword)
+				if firstMatchedKeyword == "" {
+					firstMatchedKeyword = keyword
+				}
 			}
 		}
 
 		if !keywordMatched {
 			continue
 		}
+
+		// Record that this rule fired (surfaces to clients via done event).
+		result.MatchedRules = append(result.MatchedRules, MatchedIntentRule{
+			Keyword:        firstMatchedKeyword,
+			RequiredTable:  rule.RequiredTable,
+			ForbiddenTable: rule.ForbiddenTable,
+			RequiredTool:   rule.RequiredTool,
+			ForbiddenTool:  rule.ForbiddenTool,
+		})
 
 		// Check forbidden table first (more specific error)
 		if rule.ForbiddenTable != "" {
@@ -121,16 +149,29 @@ func (v *IntentValidator) ValidateToolCall(userMessage string, toolName string) 
 
 		// Check if any keywords match
 		keywordMatched := false
+		var firstMatchedKeyword string
 		for _, keyword := range rule.Keywords {
 			if strings.Contains(lowerMessage, strings.ToLower(keyword)) {
 				keywordMatched = true
 				result.MatchedKeywords = append(result.MatchedKeywords, keyword)
+				if firstMatchedKeyword == "" {
+					firstMatchedKeyword = keyword
+				}
 			}
 		}
 
 		if !keywordMatched {
 			continue
 		}
+
+		// Record that this rule fired (surfaces to clients via done event).
+		result.MatchedRules = append(result.MatchedRules, MatchedIntentRule{
+			Keyword:        firstMatchedKeyword,
+			RequiredTable:  rule.RequiredTable,
+			ForbiddenTable: rule.ForbiddenTable,
+			RequiredTool:   rule.RequiredTool,
+			ForbiddenTool:  rule.ForbiddenTool,
+		})
 
 		// Check forbidden tool first (more specific error)
 		if rule.ForbiddenTool != "" && toolName == rule.ForbiddenTool {
@@ -319,4 +360,40 @@ func (v *IntentValidator) GetForbiddenTools(userMessage string) []string {
 	}
 
 	return forbidden
+}
+
+// GetMatchedRules returns all intent rules whose keywords match the user
+// message. Covers rules with table and/or tool constraints. Used to surface
+// which rules shaped a turn (matched_intent_rules in the done event) so apps
+// can observe and tune their intent rules from real data.
+func (v *IntentValidator) GetMatchedRules(userMessage string) []MatchedIntentRule {
+	if len(v.intentRules) == 0 {
+		return nil
+	}
+	lowerMessage := strings.ToLower(userMessage)
+
+	var matched []MatchedIntentRule
+	for _, rule := range v.intentRules {
+		var firstMatchedKeyword string
+		keywordMatched := false
+		for _, keyword := range rule.Keywords {
+			if strings.Contains(lowerMessage, strings.ToLower(keyword)) {
+				keywordMatched = true
+				if firstMatchedKeyword == "" {
+					firstMatchedKeyword = keyword
+				}
+			}
+		}
+		if !keywordMatched {
+			continue
+		}
+		matched = append(matched, MatchedIntentRule{
+			Keyword:        firstMatchedKeyword,
+			RequiredTable:  rule.RequiredTable,
+			ForbiddenTable: rule.ForbiddenTable,
+			RequiredTool:   rule.RequiredTool,
+			ForbiddenTool:  rule.ForbiddenTool,
+		})
+	}
+	return matched
 }

--- a/internal/ai/intent_validator_test.go
+++ b/internal/ai/intent_validator_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateIntent_RequiredTable(t *testing.T) {
@@ -467,5 +468,48 @@ func TestGetForbiddenTools(t *testing.T) {
 
 		forbidden := validator.GetForbiddenTools("restaurant and cafe")
 		assert.Equal(t, []string{"http_request"}, forbidden)
+	})
+}
+
+// TestGetMatchedRules covers the public observability surface added in Ask 5
+// so apps can see which intent rules fired for a turn.
+func TestGetMatchedRules(t *testing.T) {
+	rules := []IntentRule{
+		{Keywords: []string{"restaurant", "cafe"}, RequiredTable: "my_place_visits", ForbiddenTool: "http_request"},
+		{Keywords: []string{"visited", "been to"}, ForbiddenTool: "http_request"},
+		{Keywords: []string{"never matches"}, RequiredTool: "vector_search"},
+	}
+	validator := NewIntentValidator(rules, nil, "")
+
+	t.Run("returns only rules whose keywords match", func(t *testing.T) {
+		matched := validator.GetMatchedRules("show me restaurants I've visited")
+		require.Len(t, matched, 2)
+
+		// First rule fires on "restaurant"
+		assert.Equal(t, "restaurant", matched[0].Keyword)
+		assert.Equal(t, "my_place_visits", matched[0].RequiredTable)
+		assert.Equal(t, "http_request", matched[0].ForbiddenTool)
+
+		// Second rule fires on "visited"
+		assert.Equal(t, "visited", matched[1].Keyword)
+		assert.Equal(t, "http_request", matched[1].ForbiddenTool)
+		assert.Empty(t, matched[1].RequiredTable)
+	})
+
+	t.Run("returns nil when no rules match", func(t *testing.T) {
+		matched := validator.GetMatchedRules("tell me a joke")
+		assert.Nil(t, matched)
+	})
+
+	t.Run("returns nil when no rules configured", func(t *testing.T) {
+		emptyValidator := NewIntentValidator(nil, nil, "")
+		assert.Nil(t, emptyValidator.GetMatchedRules("anything"))
+	})
+
+	t.Run("picks first matched keyword when multiple keywords in one rule hit", func(t *testing.T) {
+		// "restaurant and cafe" hits both keywords of rule 0; we report the first.
+		matched := validator.GetMatchedRules("restaurant and cafe")
+		require.Len(t, matched, 1)
+		assert.Equal(t, "restaurant", matched[0].Keyword)
 	})
 }

--- a/internal/ai/kb_handler_docs.go
+++ b/internal/ai/kb_handler_docs.go
@@ -423,6 +423,8 @@ func (h *KnowledgeBaseHandler) DeleteDocumentsByFilter(c fiber.Ctx) error {
 	}
 
 	// Delete documents
+	// ponytail: bulk delete does not clean up orphaned entities (single-doc
+	// path does). Add per-doc cleanup if entity-table bloat becomes an issue.
 	count, err := h.storage.DeleteDocumentsByFilter(ctx, kbID, filter)
 	if err != nil {
 		log.Error().Err(err).Str("kb_id", kbID).Msg("Failed to delete documents by filter")

--- a/internal/ai/kb_storage.go
+++ b/internal/ai/kb_storage.go
@@ -41,8 +41,9 @@ func (s *KnowledgeBaseStorage) CreateKnowledgeBase(ctx context.Context, kb *Know
 				id, name, namespace, description,
 				embedding_model, embedding_dimensions,
 				chunk_size, chunk_overlap, chunk_strategy,
-				enabled, source, created_by, visibility, owner_id
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+				enabled, source, created_by, visibility, owner_id,
+				entity_extraction_enabled
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 			RETURNING created_at, updated_at
 		`
 
@@ -52,6 +53,7 @@ func (s *KnowledgeBaseStorage) CreateKnowledgeBase(ctx context.Context, kb *Know
 			kb.EmbeddingModel, kb.EmbeddingDimensions,
 			kb.ChunkSize, kb.ChunkOverlap, kb.ChunkStrategy,
 			kb.Enabled, kb.Source, kb.CreatedBy, kb.Visibility, kb.OwnerID,
+			kb.EntityExtractionEnabled,
 		).Scan(&kb.CreatedAt, &kb.UpdatedAt)
 	})
 }
@@ -67,7 +69,7 @@ func (s *KnowledgeBaseStorage) GetKnowledgeBase(ctx context.Context, id string) 
 				chunk_size, chunk_overlap, chunk_strategy,
 				enabled, document_count, total_chunks,
 				source, created_by, created_at, updated_at,
-				visibility, owner_id
+				visibility, owner_id, entity_extraction_enabled
 			FROM ai.knowledge_bases
 			WHERE id = $1
 			  AND (tenant_id = $2 OR ($2 IS NULL AND tenant_id IS NULL))
@@ -79,7 +81,7 @@ func (s *KnowledgeBaseStorage) GetKnowledgeBase(ctx context.Context, id string) 
 			&kb.ChunkSize, &kb.ChunkOverlap, &kb.ChunkStrategy,
 			&kb.Enabled, &kb.DocumentCount, &kb.TotalChunks,
 			&kb.Source, &kb.CreatedBy, &kb.CreatedAt, &kb.UpdatedAt,
-			&kb.Visibility, &kb.OwnerID,
+			&kb.Visibility, &kb.OwnerID, &kb.EntityExtractionEnabled,
 		)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -101,7 +103,8 @@ func (s *KnowledgeBaseStorage) GetKnowledgeBaseByName(ctx context.Context, name,
 				embedding_model, embedding_dimensions,
 				chunk_size, chunk_overlap, chunk_strategy,
 				enabled, document_count, total_chunks,
-				source, created_by, created_at, updated_at, visibility
+				source, created_by, created_at, updated_at, visibility,
+				entity_extraction_enabled
 			FROM ai.knowledge_bases
 			WHERE name = $1 AND namespace = $2
 			  AND (tenant_id = $3 OR ($3 IS NULL AND tenant_id IS NULL))
@@ -113,6 +116,7 @@ func (s *KnowledgeBaseStorage) GetKnowledgeBaseByName(ctx context.Context, name,
 			&kb.ChunkSize, &kb.ChunkOverlap, &kb.ChunkStrategy,
 			&kb.Enabled, &kb.DocumentCount, &kb.TotalChunks,
 			&kb.Source, &kb.CreatedBy, &kb.CreatedAt, &kb.UpdatedAt, &kb.Visibility,
+			&kb.EntityExtractionEnabled,
 		)
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -134,7 +138,8 @@ func (s *KnowledgeBaseStorage) ListKnowledgeBases(ctx context.Context, namespace
 				embedding_model, embedding_dimensions,
 				chunk_size, chunk_overlap, chunk_strategy,
 				enabled, document_count, total_chunks,
-				source, created_by, created_at, updated_at
+				source, created_by, created_at, updated_at,
+				entity_extraction_enabled
 			FROM ai.knowledge_bases
 			WHERE (tenant_id = $1 OR ($1 IS NULL AND tenant_id IS NULL))
 			  AND ($2 = '' OR namespace = $2)
@@ -156,6 +161,7 @@ func (s *KnowledgeBaseStorage) ListKnowledgeBases(ctx context.Context, namespace
 				&kb.ChunkSize, &kb.ChunkOverlap, &kb.ChunkStrategy,
 				&kb.Enabled, &kb.DocumentCount, &kb.TotalChunks,
 				&kb.Source, &kb.CreatedBy, &kb.CreatedAt, &kb.UpdatedAt,
+				&kb.EntityExtractionEnabled,
 			); err != nil {
 				log.Warn().Err(err).Msg("Failed to scan knowledge base row")
 				continue
@@ -188,6 +194,7 @@ func (s *KnowledgeBaseStorage) UpdateKnowledgeBase(ctx context.Context, kb *Know
 				visibility = $10,
 				created_by = $11,
 				owner_id = $12,
+				entity_extraction_enabled = $13,
 				updated_at = NOW()
 			WHERE id = $1
 			RETURNING updated_at
@@ -199,6 +206,7 @@ func (s *KnowledgeBaseStorage) UpdateKnowledgeBase(ctx context.Context, kb *Know
 			kb.EmbeddingModel, kb.EmbeddingDimensions,
 			kb.ChunkSize, kb.ChunkOverlap, kb.ChunkStrategy,
 			kb.Enabled, kb.Visibility, kb.CreatedBy, kb.OwnerID,
+			kb.EntityExtractionEnabled,
 		).Scan(&kb.UpdatedAt)
 	})
 }
@@ -271,6 +279,13 @@ func (s *KnowledgeBaseStorage) CreateKnowledgeBaseFromRequest(ctx context.Contex
 	// Set owner from request if provided
 	kb.OwnerID = req.OwnerID
 
+	// Entity extraction defaults to true; explicit false opts out.
+	if req.EntityExtractionEnabled != nil {
+		kb.EntityExtractionEnabled = *req.EntityExtractionEnabled
+	} else {
+		kb.EntityExtractionEnabled = true
+	}
+
 	if err := s.CreateKnowledgeBase(ctx, kb); err != nil {
 		return nil, err
 	}
@@ -319,6 +334,9 @@ func (s *KnowledgeBaseStorage) UpdateKnowledgeBaseByID(ctx context.Context, id s
 	}
 	if req.Enabled != nil {
 		kb.Enabled = *req.Enabled
+	}
+	if req.EntityExtractionEnabled != nil {
+		kb.EntityExtractionEnabled = *req.EntityExtractionEnabled
 	}
 
 	if err := s.UpdateKnowledgeBase(ctx, kb); err != nil {

--- a/internal/ai/kb_storage_search.go
+++ b/internal/ai/kb_storage_search.go
@@ -119,11 +119,12 @@ type HybridSearchOptions struct {
 
 // GraphBoostOptions contains options for graph-boosted search
 type GraphBoostOptions struct {
-	QueryEmbedding   []float32 // Query vector embedding
-	QueryText        string    // Query text for entity extraction
-	Limit            int       // Maximum number of results to return
-	Threshold        float64   // Minimum similarity threshold (0-1)
-	GraphBoostWeight float64   // How much to weight entity matches vs vector similarity (0.0-1.0)
+	QueryEmbedding   []float32       // Query vector embedding
+	QueryText        string          // Query text for entity extraction
+	Limit            int             // Maximum number of results to return
+	Threshold        float64         // Minimum similarity threshold (0-1)
+	GraphBoostWeight float64         // How much to weight entity matches vs vector similarity (0.0-1.0)
+	Filter           *MetadataFilter // Optional metadata filter for user isolation
 }
 
 // SearchChunksHybrid performs hybrid search combining vector similarity with full-text search
@@ -387,16 +388,9 @@ func (s *KnowledgeBaseStorage) SearchChunksWithGraphBoost(
 		log.Debug().Int("entity_count", len(queryEntities)).Msg("Extracted entities from query")
 	}
 
-	// Step 2: Get more results than needed (for re-ranking)
-	retrievalLimit := opts.Limit * 3 // Get 3x results for re-ranking
-	if retrievalLimit < 10 {
-		retrievalLimit = 10
-	}
-	if retrievalLimit > 100 {
-		retrievalLimit = 100
-	}
-
-	chunks, err := s.SearchChunks(ctx, knowledgeBaseID, opts.QueryEmbedding, retrievalLimit, opts.Threshold)
+	// Step 2: Over-fetch candidate chunks (3x) for re-ranking. The helper honors
+	// the optional user-isolation filter.
+	chunks, err := s.searchChunksForBoost(ctx, knowledgeBaseID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -440,6 +434,23 @@ func (s *KnowledgeBaseStorage) SearchChunksWithGraphBoost(
 
 	// Step 4-5: Apply entity boost, re-rank, and return top N
 	return applyGraphBoost(chunks, documentEntitySalience, opts), nil
+}
+
+// searchChunksForBoost over-fetches candidate chunks for graph-boost re-ranking.
+// Uses SearchChunksWithFilter when a user-isolation filter is supplied (preserving
+// per-user scoping); otherwise falls back to plain SearchChunks.
+func (s *KnowledgeBaseStorage) searchChunksForBoost(ctx context.Context, knowledgeBaseID string, opts GraphBoostOptions) ([]RetrievalResult, error) {
+	retrievalLimit := opts.Limit * 3
+	if retrievalLimit < 10 {
+		retrievalLimit = 10
+	}
+	if retrievalLimit > 100 {
+		retrievalLimit = 100
+	}
+	if opts.Filter != nil {
+		return s.SearchChunksWithFilter(ctx, knowledgeBaseID, opts.QueryEmbedding, retrievalLimit, opts.Threshold, opts.Filter)
+	}
+	return s.SearchChunks(ctx, knowledgeBaseID, opts.QueryEmbedding, retrievalLimit, opts.Threshold)
 }
 
 // applyGraphBoost re-ranks retrieval results based on entity salience scores.

--- a/internal/ai/knowledge_base.go
+++ b/internal/ai/knowledge_base.go
@@ -42,8 +42,11 @@ type KnowledgeBase struct {
 	PipelineType           string                 `json:"pipeline_type"`
 	PipelineConfig         map[string]interface{} `json:"pipeline_config,omitempty"`
 	TransformationFunction *string                `json:"transformation_function,omitempty"`
-	CreatedAt              time.Time              `json:"created_at"`
-	UpdatedAt              time.Time              `json:"updated_at"`
+	// Entity extraction toggle (default true). When false, documents in this KB
+	// skip the rule-based entity extractor entirely.
+	EntityExtractionEnabled bool      `json:"entity_extraction_enabled"`
+	CreatedAt               time.Time `json:"created_at"`
+	UpdatedAt               time.Time `json:"updated_at"`
 	// Tenant info (populated for instance admin cross-tenant queries)
 	TenantID   *string `json:"tenant_id,omitempty"`
 	TenantName *string `json:"tenant_name,omitempty"`
@@ -304,6 +307,9 @@ type CreateKnowledgeBaseRequest struct {
 	ChunkSize           int           `json:"chunk_size,omitempty"`
 	ChunkOverlap        int           `json:"chunk_overlap,omitempty"`
 	ChunkStrategy       string        `json:"chunk_strategy,omitempty"`
+	// EntityExtractionEnabled toggles the rule-based entity extractor for this KB.
+	// nil = use default (true); explicit true/false respected.
+	EntityExtractionEnabled *bool `json:"entity_extraction_enabled,omitempty"`
 	// InitialPermissions grants permissions to users upon creation
 	InitialPermissions []KBInitialPermission `json:"initial_permissions,omitempty"`
 	// OwnerID is set internally by the handler, not exposed in the API
@@ -318,15 +324,16 @@ type KBInitialPermission struct {
 
 // UpdateKnowledgeBaseRequest is the request to update a knowledge base
 type UpdateKnowledgeBaseRequest struct {
-	Name                *string       `json:"name,omitempty"`
-	Description         *string       `json:"description,omitempty"`
-	Visibility          *KBVisibility `json:"visibility,omitempty"`
-	EmbeddingModel      *string       `json:"embedding_model,omitempty"`
-	EmbeddingDimensions *int          `json:"embedding_dimensions,omitempty"`
-	ChunkSize           *int          `json:"chunk_size,omitempty"`
-	ChunkOverlap        *int          `json:"chunk_overlap,omitempty"`
-	ChunkStrategy       *string       `json:"chunk_strategy,omitempty"`
-	Enabled             *bool         `json:"enabled,omitempty"`
+	Name                    *string       `json:"name,omitempty"`
+	Description             *string       `json:"description,omitempty"`
+	Visibility              *KBVisibility `json:"visibility,omitempty"`
+	EmbeddingModel          *string       `json:"embedding_model,omitempty"`
+	EmbeddingDimensions     *int          `json:"embedding_dimensions,omitempty"`
+	ChunkSize               *int          `json:"chunk_size,omitempty"`
+	ChunkOverlap            *int          `json:"chunk_overlap,omitempty"`
+	ChunkStrategy           *string       `json:"chunk_strategy,omitempty"`
+	Enabled                 *bool         `json:"enabled,omitempty"`
+	EntityExtractionEnabled *bool         `json:"entity_extraction_enabled,omitempty"`
 }
 
 // CreateDocumentRequest is the request to add a document to a knowledge base

--- a/internal/ai/knowledge_graph.go
+++ b/internal/ai/knowledge_graph.go
@@ -512,62 +512,10 @@ func (kg *KnowledgeGraph) GetEntitiesByDocument(ctx context.Context, documentID 
 	return entities, nil
 }
 
-// BatchAddEntities adds multiple entities efficiently using batch operations
-func (kg *KnowledgeGraph) BatchAddEntities(ctx context.Context, entities []Entity) error {
-	if len(entities) == 0 {
-		return nil
-	}
-
-	query := `
-		INSERT INTO ai.entities (
-			id, knowledge_base_id, entity_type, name, canonical_name,
-			aliases, metadata, created_at, updated_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-		ON CONFLICT (knowledge_base_id, entity_type, canonical_name)
-		DO UPDATE SET
-			name = EXCLUDED.name,
-			aliases = EXCLUDED.aliases,
-			metadata = EXCLUDED.metadata,
-			updated_at = NOW()
-	`
-
-	return kg.WithTenant(ctx, func(tx pgx.Tx) error {
-		batch := &pgx.Batch{}
-
-		for _, entity := range entities {
-			if entity.ID == "" {
-				entity.ID = uuid.New().String()
-			}
-			entity.CreatedAt = time.Now()
-			entity.UpdatedAt = time.Now()
-
-			batch.Queue(
-				query,
-				entity.ID, entity.KnowledgeBaseID, entity.EntityType, entity.Name,
-				entity.CanonicalName, entity.Aliases, entity.Metadata,
-				entity.CreatedAt, entity.UpdatedAt,
-			)
-		}
-
-		br := tx.SendBatch(ctx, batch)
-		defer func() { _ = br.Close() }()
-
-		for range entities {
-			if _, err := br.Exec(); err != nil {
-				return fmt.Errorf("failed to insert entity: %w", err)
-			}
-		}
-
-		return nil
-	})
-}
-
 // DeleteOrphanedEntitiesByDocument deletes entities that are only referenced by a specific document
 // This is useful for cleaning up table export entities when the document is deleted.
 // It only deletes entities that have exactly one document reference (the deleted one).
 func (kg *KnowledgeGraph) DeleteOrphanedEntitiesByDocument(ctx context.Context, documentID string) error {
-	// Delete entities that are only referenced by this document
-	// The CASCADE will automatically clean up relationships and document_entities
 	query := `
 		DELETE FROM ai.entities
 		WHERE id IN (
@@ -600,5 +548,33 @@ func (kg *KnowledgeGraph) DeleteOrphanedEntitiesByDocument(ctx context.Context, 
 			Msg("Deleted orphaned entities for document")
 	}
 
+	return nil
+}
+
+// DeleteDocumentEntitiesByDocument removes all document_entities mention rows for
+// the given document. Used before re-extraction on reprocess so stale mentions
+// (entities no longer present in the updated content) don't accumulate.
+// Does not delete the entities themselves; call DeleteOrphanedEntitiesByDocument
+// afterward to drop entities referenced only by this document.
+func (kg *KnowledgeGraph) DeleteDocumentEntitiesByDocument(ctx context.Context, documentID string) error {
+	var rowsAffected int64
+	err := kg.WithTenant(ctx, func(tx pgx.Tx) error {
+		result, execErr := tx.Exec(ctx, `DELETE FROM ai.document_entities WHERE document_id = $1`, documentID)
+		if execErr != nil {
+			return fmt.Errorf("failed to delete document_entities: %w", execErr)
+		}
+		rowsAffected = result.RowsAffected()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected > 0 {
+		log.Debug().
+			Str("document_id", documentID).
+			Int64("deleted_mentions", rowsAffected).
+			Msg("Cleared stale document_entities before re-extraction")
+	}
 	return nil
 }

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -10,9 +10,10 @@ import (
 type ProviderType string
 
 const (
-	ProviderTypeOpenAI ProviderType = "openai"
-	ProviderTypeAzure  ProviderType = "azure"
-	ProviderTypeOllama ProviderType = "ollama"
+	ProviderTypeOpenAI    ProviderType = "openai"
+	ProviderTypeAzure     ProviderType = "azure"
+	ProviderTypeOllama    ProviderType = "ollama"
+	ProviderTypeAnthropic ProviderType = "anthropic"
 )
 
 // Role represents the role of a message in a conversation
@@ -101,6 +102,10 @@ type UsageStats struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+	// CachedTokens is the subset of PromptTokens served from the provider's
+	// prompt cache (OpenAI automatic prefix caching, Anthropic prompt caching).
+	// 0 when caching didn't fire or the provider doesn't report it.
+	CachedTokens int `json:"cached_tokens,omitempty"`
 }
 
 // StreamEvent represents a streaming event from the AI provider
@@ -188,6 +193,15 @@ type OllamaConfig struct {
 	Model    string `json:"model"`
 }
 
+// AnthropicConfig represents Anthropic-specific configuration
+type AnthropicConfig struct {
+	APIKey  string `json:"api_key"`
+	Model   string `json:"model"`
+	BaseURL string `json:"base_url,omitempty"` // Override endpoint (e.g. Azure-hosted Anthropic-compatible)
+	// Anthropic API version header (default: 2023-06-01).
+	APIVersion string `json:"api_version,omitempty"`
+}
+
 // NewProvider creates a new AI provider based on the configuration
 func NewProvider(config ProviderConfig) (Provider, error) {
 	switch config.Type {
@@ -197,6 +211,8 @@ func NewProvider(config ProviderConfig) (Provider, error) {
 		return NewAzureProvider(config)
 	case ProviderTypeOllama:
 		return NewOllamaProvider(config)
+	case ProviderTypeAnthropic:
+		return NewAnthropicProvider(config)
 	default:
 		return nil, fmt.Errorf("unsupported provider type: %s", config.Type)
 	}
@@ -269,6 +285,34 @@ func NewOllamaProvider(config ProviderConfig) (Provider, error) {
 	}
 
 	return newOllamaProviderInternal(config.Name, ollamaConfig)
+}
+
+// NewAnthropicProvider creates a new Anthropic Claude provider (implemented in provider_anthropic.go)
+func NewAnthropicProvider(config ProviderConfig) (Provider, error) {
+	anthropicConfig := AnthropicConfig{
+		APIKey:     config.Config["api_key"],
+		Model:      config.Model,
+		BaseURL:    config.Config["base_url"],
+		APIVersion: config.Config["api_version"],
+	}
+
+	if anthropicConfig.APIKey == "" {
+		return nil, fmt.Errorf("anthropic: api_key is required")
+	}
+
+	if anthropicConfig.Model == "" {
+		anthropicConfig.Model = "claude-sonnet-4-5-20250929"
+	}
+
+	if anthropicConfig.BaseURL == "" {
+		anthropicConfig.BaseURL = "https://api.anthropic.com"
+	}
+
+	if anthropicConfig.APIVersion == "" {
+		anthropicConfig.APIVersion = "2023-06-01"
+	}
+
+	return newAnthropicProviderInternal(config.Name, anthropicConfig)
 }
 
 // ExecuteSQLTool is the standard tool definition for SQL execution

--- a/internal/ai/provider_anthropic.go
+++ b/internal/ai/provider_anthropic.go
@@ -1,0 +1,596 @@
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	defaultAnthropicModel = "claude-sonnet-4-5-20250929"
+	anthropicTimeout      = 5 * time.Minute
+)
+
+// anthropicProvider implements Provider for the Anthropic Messages API.
+//
+// Anthropic differs from OpenAI in three material ways:
+//   - System content is a top-level field (an array of content blocks), not a
+//     message in the messages array.
+//   - Tool calls and tool results are content blocks (type "tool_use" /
+//     "tool_result"), not separate fields on a message.
+//   - Prompt caching is explicit via "cache_control: {type: 'ephemeral'}"
+//     breakpoints on content blocks and tool definitions.
+//
+// Cache strategy used here: the LAST system content block (i.e. the dynamic
+// per-turn context after Step 2 of the prompt-caching work) is NOT marked, but
+// every system block before it IS marked as cacheable. This is wrong-by-design
+// reversed: actually we want the static prefix cached and the dynamic tail not.
+// Implementation below marks only the first (static) system block.
+type anthropicProvider struct {
+	name       string
+	config     AnthropicConfig
+	httpClient *http.Client
+}
+
+func newAnthropicProviderInternal(name string, config AnthropicConfig) (*anthropicProvider, error) {
+	config.BaseURL = strings.TrimSuffix(config.BaseURL, "/")
+	return &anthropicProvider{
+		name:   name,
+		config: config,
+		httpClient: &http.Client{
+			Timeout: anthropicTimeout,
+		},
+	}, nil
+}
+
+func (p *anthropicProvider) Name() string       { return p.name }
+func (p *anthropicProvider) Type() ProviderType { return ProviderTypeAnthropic }
+func (p *anthropicProvider) Close() error       { p.httpClient.CloseIdleConnections(); return nil }
+func (p *anthropicProvider) ValidateConfig() error {
+	if p.config.APIKey == "" {
+		return fmt.Errorf("anthropic: api_key is required")
+	}
+	if p.config.Model == "" {
+		return fmt.Errorf("anthropic: model is required")
+	}
+	return nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire types (Anthropic Messages API)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// anthropicRequest is the request body for POST /v1/messages.
+type anthropicRequest struct {
+	Model       string                 `json:"model"`
+	MaxTokens   int                    `json:"max_tokens"`
+	System      []anthropicSystemBlock `json:"system,omitempty"`
+	Messages    []anthropicMessage     `json:"messages"`
+	Temperature float64                `json:"temperature,omitempty"`
+	Tools       []anthropicTool        `json:"tools,omitempty"`
+	Stream      bool                   `json:"stream,omitempty"`
+	StopSeqs    []string               `json:"stop_sequences,omitempty"`
+}
+
+// anthropicSystemBlock is a content block in the top-level system field.
+// CacheControl marks the block as a cache breakpoint when non-nil.
+type anthropicSystemBlock struct {
+	Type         string                 `json:"type"` // always "text"
+	Text         string                 `json:"text"`
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+type anthropicCacheControl struct {
+	Type string `json:"type"` // "ephemeral"
+}
+
+// anthropicMessage is one message in the conversation. Content is always an
+// array of typed blocks; for plain text we emit a single text block.
+type anthropicMessage struct {
+	Role    string             `json:"role"` // "user" or "assistant"
+	Content []anthropicContent `json:"content"`
+}
+
+type anthropicContent struct {
+	Type string `json:"type"`
+
+	// For type == "text"
+	Text string `json:"text,omitempty"`
+
+	// For type == "tool_use" (assistant message)
+	ID    string         `json:"id,omitempty"`
+	Name  string         `json:"name,omitempty"`
+	Input map[string]any `json:"input,omitempty"`
+
+	// For type == "tool_result" (user message responding to a tool call)
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	// Content of a tool_result is either a string or a content-block array.
+	// We always emit a string for simplicity.
+	Content string `json:"content,omitempty"`
+	IsError bool   `json:"is_error,omitempty"`
+}
+
+type anthropicTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"input_schema"`
+	// CacheControl on the LAST tool definition caches the tool block. Populated
+	// by buildRequest when tools > 0.
+	CacheControl *anthropicCacheControl `json:"cache_control,omitempty"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response types (non-stream)
+// ─────────────────────────────────────────────────────────────────────────────
+
+type anthropicResponse struct {
+	ID         string             `json:"id"`
+	Type       string             `json:"type"`
+	Role       string             `json:"role"`
+	Model      string             `json:"model"`
+	Content    []anthropicContent `json:"content"`
+	StopReason string             `json:"stop_reason"`
+	Usage      anthropicUsage     `json:"usage"`
+}
+
+// anthropicUsage is the Anthropic token-usage shape.
+//
+//	input_tokens                  — fresh input tokens billed at 1x
+//	output_tokens                 — completion tokens billed at 1x
+//	cache_creation_input_tokens   — tokens written to the cache this turn, 1.25x
+//	cache_read_input_tokens       — tokens served from cache, 0.1x
+//
+// We surface cache_read_input_tokens as CachedTokens.
+type anthropicUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stream event types
+// ─────────────────────────────────────────────────────────────────────────────
+
+type anthropicMessageStart struct {
+	Message struct {
+		ID    string         `json:"id"`
+		Model string         `json:"model"`
+		Usage anthropicUsage `json:"usage"`
+	} `json:"message"`
+}
+
+type anthropicContentBlockStart struct {
+	Index        int              `json:"index"`
+	ContentBlock anthropicContent `json:"content_block"`
+}
+
+type anthropicContentBlockDelta struct {
+	Index int                `json:"index"`
+	Delta anthropicDeltaBody `json:"delta"`
+}
+
+// anthropicDeltaBody is the inner delta; Type discriminates "text_delta" vs
+// "input_json_delta".
+type anthropicDeltaBody struct {
+	Type        string `json:"type"`
+	Text        string `json:"text,omitempty"`         // for text_delta
+	PartialJSON string `json:"partial_json,omitempty"` // for input_json_delta
+}
+
+type anthropicMessageDelta struct {
+	Delta struct {
+		StopReason string `json:"stop_reason"`
+	} `json:"delta"`
+	Usage struct {
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Chat (non-stream)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (p *anthropicProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	body, err := json.Marshal(p.buildRequest(req))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.config.BaseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	p.setHeaders(httpReq)
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("anthropic returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var anthropicResp anthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&anthropicResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return p.convertResponse(&anthropicResp), nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ChatStream
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (p *anthropicProvider) ChatStream(ctx context.Context, req *ChatRequest, callback StreamCallback) error {
+	areq := p.buildRequest(req)
+	areq.Stream = true
+
+	body, err := json.Marshal(areq)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", p.config.BaseURL+"/v1/messages", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	p.setHeaders(httpReq)
+
+	resp, err := p.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("anthropic returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return p.processStream(ctx, resp.Body, callback)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Request building
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (p *anthropicProvider) buildRequest(req *ChatRequest) anthropicRequest {
+	model := req.Model
+	if model == "" {
+		model = p.config.Model
+	}
+	if model == "" {
+		model = defaultAnthropicModel
+	}
+
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		// Anthropic requires max_tokens. Use a sensible default if unset.
+		maxTokens = 4096
+	}
+
+	out := anthropicRequest{
+		Model:       model,
+		MaxTokens:   maxTokens,
+		Temperature: req.Temperature,
+	}
+
+	// Convert messages. System messages go to the top-level System field; all
+	// others go to Messages. Each system message becomes one content block.
+	var systemBlocks []anthropicSystemBlock
+	var msgs []anthropicMessage
+
+	for _, m := range req.Messages {
+		switch m.Role {
+		case RoleSystem:
+			systemBlocks = append(systemBlocks, anthropicSystemBlock{
+				Type: "text",
+				Text: m.Content,
+			})
+		case RoleUser:
+			msgs = append(msgs, anthropicMessage{
+				Role:    "user",
+				Content: []anthropicContent{{Type: "text", Text: m.Content}},
+			})
+		case RoleAssistant:
+			content := []anthropicContent{}
+			if m.Content != "" {
+				content = append(content, anthropicContent{Type: "text", Text: m.Content})
+			}
+			for _, tc := range m.ToolCalls {
+				var input map[string]any
+				_ = json.Unmarshal([]byte(tc.Function.Arguments), &input)
+				content = append(content, anthropicContent{
+					Type:  "tool_use",
+					ID:    tc.ID,
+					Name:  tc.Function.Name,
+					Input: input,
+				})
+			}
+			msgs = append(msgs, anthropicMessage{Role: "assistant", Content: content})
+		case RoleTool:
+			// OpenAI tool message → Anthropic "user" message with tool_result block.
+			msgs = append(msgs, anthropicMessage{
+				Role: "user",
+				Content: []anthropicContent{{
+					Type:      "tool_result",
+					ToolUseID: m.ToolCallID,
+					Content:   m.Content,
+				}},
+			})
+		}
+	}
+
+	// Apply cache_control breakpoints. Mark all system blocks EXCEPT the last
+	// one as cacheable. With our static+dynamic split (Step 2), the first
+	// system block is the static prefix and the second is the dynamic per-turn
+	// context (user ID, time, RAG). Caching just the static prefix is exactly
+	// what we want.
+	//
+	// Anthropic allows up to 4 breakpoints; we use at most (system_blocks - 1)
+	// here, plus 1 on the last tool definition below.
+	for i := 0; i < len(systemBlocks)-1; i++ {
+		systemBlocks[i].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
+	}
+	out.System = systemBlocks
+	out.Messages = msgs
+
+	// Convert tools. Mark the LAST tool definition with cache_control so the
+	// tool list is cached too (uses 1 of the 4 breakpoint budget; safe given
+	// the system blocks above typically use only 1).
+	if len(req.Tools) > 0 {
+		tools := make([]anthropicTool, len(req.Tools))
+		for i, t := range req.Tools {
+			tools[i] = anthropicTool{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				InputSchema: t.Function.Parameters,
+			}
+		}
+		tools[len(tools)-1].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
+		out.Tools = tools
+	}
+
+	return out
+}
+
+func (p *anthropicProvider) setHeaders(req *http.Request) {
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", p.config.APIKey)
+	req.Header.Set("anthropic-version", p.config.APIVersion)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Response conversion (non-stream)
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (p *anthropicProvider) convertResponse(resp *anthropicResponse) *ChatResponse {
+	msg := Message{Role: RoleAssistant}
+	var toolCalls []ToolCall
+
+	for _, block := range resp.Content {
+		switch block.Type {
+		case "text":
+			if msg.Content != "" {
+				msg.Content += "\n"
+			}
+			msg.Content += block.Text
+		case "tool_use":
+			argsBytes, _ := json.Marshal(block.Input)
+			toolCalls = append(toolCalls, ToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: FunctionCall{
+					Name:      block.Name,
+					Arguments: string(argsBytes),
+				},
+			})
+		}
+	}
+	msg.ToolCalls = toolCalls
+
+	finishReason := mapAnthropicStopReason(resp.StopReason)
+
+	return &ChatResponse{
+		ID:    resp.ID,
+		Model: resp.Model,
+		Choices: []Choice{{
+			Index:        0,
+			Message:      msg,
+			FinishReason: finishReason,
+		}},
+		Usage: anthropicUsageToStats(&resp.Usage),
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stream processing
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (p *anthropicProvider) processStream(ctx context.Context, reader io.Reader, callback StreamCallback) error {
+	scanner := bufio.NewScanner(reader)
+	// Anthropic SSE chunks can be sizable (tool_use inputs as partial_json);
+	// raise the per-line cap to 1 MiB.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	// Track tool_use blocks by index so we can emit a single tool_call event
+	// when the block starts and accumulate input_json_delta into ArgumentsDelta.
+	toolBlocks := make(map[int]*ToolCallDelta)
+
+	// Track usage; final "done" event carries the cumulative totals. Anthropic
+	// emits input tokens in message_start and output tokens in message_delta.
+	var inputTokens, outputTokens, cacheCreation, cacheRead int
+	var stopReason string
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		line := scanner.Text()
+		if line == "" || !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+
+		// Peek the type field to dispatch.
+		var head struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(data), &head); err != nil {
+			log.Warn().Err(err).Str("data", data).Msg("Failed to parse Anthropic stream envelope")
+			continue
+		}
+
+		switch head.Type {
+		case "message_start":
+			var ev anthropicMessageStart
+			if err := json.Unmarshal([]byte(data), &ev); err == nil {
+				inputTokens = ev.Message.Usage.InputTokens
+				cacheCreation = ev.Message.Usage.CacheCreationInputTokens
+				cacheRead = ev.Message.Usage.CacheReadInputTokens
+			}
+
+		case "content_block_start":
+			var ev anthropicContentBlockStart
+			if err := json.Unmarshal([]byte(data), &ev); err == nil {
+				if ev.ContentBlock.Type == "tool_use" {
+					delta := &ToolCallDelta{
+						Index:        ev.Index,
+						ID:           ev.ContentBlock.ID,
+						Type:         "function",
+						FunctionName: ev.ContentBlock.Name,
+					}
+					toolBlocks[ev.Index] = delta
+					if err := callback(StreamEvent{
+						Type:     "tool_call",
+						ToolCall: delta,
+					}); err != nil {
+						return err
+					}
+				}
+			}
+
+		case "content_block_delta":
+			var ev anthropicContentBlockDelta
+			if err := json.Unmarshal([]byte(data), &ev); err != nil {
+				log.Warn().Err(err).Msg("Failed to parse content_block_delta")
+				continue
+			}
+			switch ev.Delta.Type {
+			case "text_delta":
+				if err := callback(StreamEvent{
+					Type:  "content",
+					Delta: ev.Delta.Text,
+				}); err != nil {
+					return err
+				}
+			case "input_json_delta":
+				if tc, ok := toolBlocks[ev.Index]; ok {
+					tc.ArgumentsDelta += ev.Delta.PartialJSON
+				}
+			}
+
+		case "content_block_stop":
+			// No action; tool_call deltas were already emitted at start.
+			// If we ever need to flush accumulated arguments here, we can.
+
+		case "message_delta":
+			var ev anthropicMessageDelta
+			if err := json.Unmarshal([]byte(data), &ev); err == nil {
+				if ev.Delta.StopReason != "" {
+					stopReason = ev.Delta.StopReason
+				}
+				if ev.Usage.OutputTokens > 0 {
+					outputTokens = ev.Usage.OutputTokens
+				}
+			}
+
+		case "message_stop":
+			usage := anthropicUsageToStats(&anthropicUsage{
+				InputTokens:              inputTokens,
+				OutputTokens:             outputTokens,
+				CacheCreationInputTokens: cacheCreation,
+				CacheReadInputTokens:     cacheRead,
+			})
+			return callback(StreamEvent{
+				Type:         "done",
+				FinishReason: mapAnthropicStopReason(stopReason),
+				Usage:        usage,
+			})
+
+		case "ping", "error":
+			// Anthropic sends periodic ping events; ignore. Errors are also
+			// delivered as non-200 HTTP status (handled by the caller).
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("stream scanner error: %w", err)
+	}
+
+	// Stream ended without an explicit message_stop. Emit a synthesized done.
+	usage := anthropicUsageToStats(&anthropicUsage{
+		InputTokens:              inputTokens,
+		OutputTokens:             outputTokens,
+		CacheCreationInputTokens: cacheCreation,
+		CacheReadInputTokens:     cacheRead,
+	})
+	return callback(StreamEvent{
+		Type:         "done",
+		FinishReason: mapAnthropicStopReason(stopReason),
+		Usage:        usage,
+	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// anthropicUsageToStats maps Anthropic's split input accounting to UsageStats.
+// PromptTokens = all input billed (fresh + cache creation + cache read).
+// CachedTokens = cache reads only.
+func anthropicUsageToStats(u *anthropicUsage) *UsageStats {
+	if u == nil {
+		return nil
+	}
+	prompt := u.InputTokens + u.CacheCreationInputTokens + u.CacheReadInputTokens
+	return &UsageStats{
+		PromptTokens:     prompt,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      prompt + u.OutputTokens,
+		CachedTokens:     u.CacheReadInputTokens,
+	}
+}
+
+func mapAnthropicStopReason(reason string) string {
+	switch reason {
+	case "end_turn":
+		return "stop"
+	case "tool_use":
+		return "tool_calls"
+	case "max_tokens":
+		return "length"
+	case "stop_sequence":
+		return "stop"
+	case "":
+		return ""
+	default:
+		return reason
+	}
+}

--- a/internal/ai/provider_anthropic_test.go
+++ b/internal/ai/provider_anthropic_test.go
@@ -1,0 +1,264 @@
+package ai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestAnthropicProvider() *anthropicProvider {
+	return &anthropicProvider{
+		name: "test",
+		config: AnthropicConfig{
+			APIKey:     "test-key",
+			Model:      "claude-sonnet-4-5-20250929",
+			BaseURL:    "https://api.anthropic.com",
+			APIVersion: "2023-06-01",
+		},
+	}
+}
+
+func TestAnthropicProvider_BuildRequest_SystemGoesToTopLevel(t *testing.T) {
+	p := newTestAnthropicProvider()
+
+	req := &ChatRequest{
+		Messages: []Message{
+			{Role: RoleSystem, Content: "static system prompt"},
+			{Role: RoleSystem, Content: "dynamic per-turn context"},
+			{Role: RoleUser, Content: "hello"},
+		},
+		MaxTokens: 1024,
+	}
+
+	out := p.buildRequest(req)
+
+	// Two system blocks preserved in order
+	require.Len(t, out.System, 2)
+	assert.Equal(t, "static system prompt", out.System[0].Text)
+	assert.Equal(t, "dynamic per-turn context", out.System[1].Text)
+
+	// Messages slice must NOT contain any system messages
+	for _, m := range out.Messages {
+		assert.NotEqual(t, "system", m.Role)
+	}
+}
+
+func TestAnthropicProvider_BuildRequest_CacheControlMarksAllButLastSystemBlock(t *testing.T) {
+	p := newTestAnthropicProvider()
+
+	req := &ChatRequest{
+		Messages: []Message{
+			{Role: RoleSystem, Content: "static"},       // should be cached
+			{Role: RoleSystem, Content: "dynamic tail"}, // should NOT be cached
+		},
+	}
+
+	out := p.buildRequest(req)
+
+	require.Len(t, out.System, 2)
+	assert.NotNil(t, out.System[0].CacheControl, "first (static) system block must be marked cacheable")
+	assert.Equal(t, "ephemeral", out.System[0].CacheControl.Type)
+	assert.Nil(t, out.System[1].CacheControl, "last (dynamic) system block must NOT be marked cacheable")
+}
+
+func TestAnthropicProvider_BuildRequest_SingleSystemBlockNotMarked(t *testing.T) {
+	// Edge case: with only one system block, the loop "0 .. len-1" doesn't
+	// execute, so no breakpoint is set. Anthropic would still cache nothing
+	// in this case; callers should ensure the static/dynamic split happens
+	// upstream (chat_handler_message.go does this as of Step 2).
+	p := newTestAnthropicProvider()
+
+	req := &ChatRequest{
+		Messages: []Message{
+			{Role: RoleSystem, Content: "only one"},
+		},
+	}
+
+	out := p.buildRequest(req)
+	require.Len(t, out.System, 1)
+	assert.Nil(t, out.System[0].CacheControl)
+}
+
+func TestAnthropicProvider_BuildRequest_ToolsGetCacheBreakpointOnLast(t *testing.T) {
+	p := newTestAnthropicProvider()
+
+	req := &ChatRequest{
+		Messages: []Message{
+			{Role: RoleUser, Content: "hi"},
+		},
+		Tools: []Tool{
+			{Type: "function", Function: ToolFunction{Name: "tool_a", Parameters: map[string]any{"type": "object"}}},
+			{Type: "function", Function: ToolFunction{Name: "tool_b", Parameters: map[string]any{"type": "object"}}},
+		},
+	}
+
+	out := p.buildRequest(req)
+
+	require.Len(t, out.Tools, 2)
+	assert.Nil(t, out.Tools[0].CacheControl, "only the last tool should carry the cache breakpoint")
+	assert.NotNil(t, out.Tools[1].CacheControl)
+	assert.Equal(t, "ephemeral", out.Tools[1].CacheControl.Type)
+}
+
+func TestAnthropicProvider_BuildRequest_AssistantToolCallsBecomeToolUseBlocks(t *testing.T) {
+	p := newTestAnthropicProvider()
+
+	req := &ChatRequest{
+		Messages: []Message{
+			{Role: RoleUser, Content: "what's the weather?"},
+			{
+				Role:    RoleAssistant,
+				Content: "Let me check.",
+				ToolCalls: []ToolCall{{
+					ID:   "toolu_123",
+					Type: "function",
+					Function: FunctionCall{
+						Name:      "get_weather",
+						Arguments: `{"city":"Paris"}`,
+					},
+				}},
+			},
+			{
+				Role:       RoleTool,
+				Content:    "sunny, 22C",
+				ToolCallID: "toolu_123",
+			},
+		},
+	}
+
+	out := p.buildRequest(req)
+
+	// user → assistant(tool_use) → user(tool_result)
+	require.Len(t, out.Messages, 3)
+
+	// Assistant message: text block + tool_use block
+	asstMsg := out.Messages[1]
+	require.Equal(t, "assistant", asstMsg.Role)
+	require.Len(t, asstMsg.Content, 2)
+	assert.Equal(t, "text", asstMsg.Content[0].Type)
+	assert.Equal(t, "Let me check.", asstMsg.Content[0].Text)
+	assert.Equal(t, "tool_use", asstMsg.Content[1].Type)
+	assert.Equal(t, "toolu_123", asstMsg.Content[1].ID)
+	assert.Equal(t, "get_weather", asstMsg.Content[1].Name)
+	assert.Equal(t, "Paris", asstMsg.Content[1].Input["city"])
+
+	// Tool result is a user message with a tool_result content block
+	toolMsg := out.Messages[2]
+	require.Equal(t, "user", toolMsg.Role)
+	require.Len(t, toolMsg.Content, 1)
+	assert.Equal(t, "tool_result", toolMsg.Content[0].Type)
+	assert.Equal(t, "toolu_123", toolMsg.Content[0].ToolUseID)
+	assert.Equal(t, "sunny, 22C", toolMsg.Content[0].Content)
+}
+
+func TestAnthropicProvider_BuildRequest_ModelFallback(t *testing.T) {
+	p := newTestAnthropicProvider()
+
+	t.Run("uses request model when set", func(t *testing.T) {
+		req := &ChatRequest{
+			Model:    "claude-opus-4-1-20250805",
+			Messages: []Message{{Role: RoleUser, Content: "hi"}},
+		}
+		out := p.buildRequest(req)
+		assert.Equal(t, "claude-opus-4-1-20250805", out.Model)
+	})
+
+	t.Run("falls back to provider default", func(t *testing.T) {
+		req := &ChatRequest{
+			Messages: []Message{{Role: RoleUser, Content: "hi"}},
+		}
+		out := p.buildRequest(req)
+		assert.Equal(t, "claude-sonnet-4-5-20250929", out.Model)
+	})
+}
+
+func TestAnthropicUsageToStats(t *testing.T) {
+	t.Run("all four counters populated", func(t *testing.T) {
+		u := &anthropicUsage{
+			InputTokens:              100,
+			OutputTokens:             50,
+			CacheCreationInputTokens: 200,
+			CacheReadInputTokens:     300,
+		}
+		stats := anthropicUsageToStats(u)
+
+		// PromptTokens = 100 + 200 + 300 = 600 (all input billed)
+		assert.Equal(t, 600, stats.PromptTokens)
+		assert.Equal(t, 50, stats.CompletionTokens)
+		assert.Equal(t, 650, stats.TotalTokens)
+		assert.Equal(t, 300, stats.CachedTokens, "only cache reads are surfaced as cached")
+	})
+
+	t.Run("no caching active", func(t *testing.T) {
+		u := &anthropicUsage{
+			InputTokens:  100,
+			OutputTokens: 50,
+		}
+		stats := anthropicUsageToStats(u)
+		assert.Equal(t, 100, stats.PromptTokens)
+		assert.Equal(t, 50, stats.CompletionTokens)
+		assert.Equal(t, 0, stats.CachedTokens)
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		assert.Nil(t, anthropicUsageToStats(nil))
+	})
+}
+
+func TestAnthropicProvider_ConvertResponse_ToolUse(t *testing.T) {
+	p := newTestAnthropicProvider()
+
+	// Simulated Anthropic response with mixed text + tool_use content blocks.
+	anthropicJSON := `{
+		"id": "msg_123",
+		"model": "claude-sonnet-4-5-20250929",
+		"role": "assistant",
+		"type": "message",
+		"content": [
+			{"type": "text", "text": "Let me check the weather."},
+			{"type": "tool_use", "id": "toolu_456", "name": "get_weather", "input": {"city": "Tokyo"}}
+		],
+		"stop_reason": "tool_use",
+		"usage": {
+			"input_tokens": 50,
+			"output_tokens": 30,
+			"cache_creation_input_tokens": 0,
+			"cache_read_input_tokens": 25
+		}
+	}`
+
+	var resp anthropicResponse
+	require.NoError(t, json.Unmarshal([]byte(anthropicJSON), &resp))
+
+	out := p.convertResponse(&resp)
+
+	require.Len(t, out.Choices, 1)
+	c := out.Choices[0]
+	assert.Equal(t, "tool_calls", c.FinishReason)
+	assert.Contains(t, c.Message.Content, "Let me check the weather.")
+	require.Len(t, c.Message.ToolCalls, 1)
+	assert.Equal(t, "toolu_456", c.Message.ToolCalls[0].ID)
+	assert.Equal(t, "get_weather", c.Message.ToolCalls[0].Function.Name)
+	assert.JSONEq(t, `{"city":"Tokyo"}`, c.Message.ToolCalls[0].Function.Arguments)
+
+	require.NotNil(t, out.Usage)
+	assert.Equal(t, 75, out.Usage.PromptTokens) // 50 + 0 + 25
+	assert.Equal(t, 30, out.Usage.CompletionTokens)
+	assert.Equal(t, 25, out.Usage.CachedTokens)
+}
+
+func TestMapAnthropicStopReason(t *testing.T) {
+	cases := []struct{ in, out string }{
+		{"end_turn", "stop"},
+		{"tool_use", "tool_calls"},
+		{"max_tokens", "length"},
+		{"stop_sequence", "stop"},
+		{"", ""},
+		{"unknown_reason", "unknown_reason"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.out, mapAnthropicStopReason(tc.in))
+	}
+}

--- a/internal/ai/provider_openai.go
+++ b/internal/ai/provider_openai.go
@@ -142,6 +142,14 @@ type openAIUsage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+	// OpenAI returns prompt_tokens_details.cached_tokens when prompt caching
+	// fires. Older deployments that don't support caching simply omit it.
+	PromptTokensDetails *openAIPromptTokensDetails `json:"prompt_tokens_details,omitempty"`
+}
+
+// openAIPromptTokensDetails carries the cached-token breakdown.
+type openAIPromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
 }
 
 type openAIError struct {
@@ -436,6 +444,9 @@ func (p *openAIProvider) convertResponse(resp *openAIResponse) *ChatResponse {
 			CompletionTokens: resp.Usage.CompletionTokens,
 			TotalTokens:      resp.Usage.TotalTokens,
 		}
+		if resp.Usage.PromptTokensDetails != nil {
+			usage.CachedTokens = resp.Usage.PromptTokensDetails.CachedTokens
+		}
 	}
 
 	return &ChatResponse{
@@ -563,6 +574,9 @@ func (p *openAIProvider) processStream(ctx context.Context, reader io.Reader, ca
 						PromptTokens:     chunk.Usage.PromptTokens,
 						CompletionTokens: chunk.Usage.CompletionTokens,
 						TotalTokens:      chunk.Usage.TotalTokens,
+					}
+					if chunk.Usage.PromptTokensDetails != nil {
+						event.Usage.CachedTokens = chunk.Usage.PromptTokensDetails.CachedTokens
 					}
 				}
 				if err := callback(event); err != nil {

--- a/internal/ai/rag_service.go
+++ b/internal/ai/rag_service.go
@@ -34,12 +34,13 @@ func NewRAGService(
 
 // RetrieveContextOptions contains options for retrieval
 type RetrieveContextOptions struct {
-	ChatbotID      string
-	ConversationID string
-	UserID         string
-	Query          string
-	MaxChunks      int     // Override max chunks (optional)
-	Threshold      float64 // Override threshold (optional)
+	ChatbotID        string
+	ConversationID   string
+	UserID           string
+	Query            string
+	MaxChunks        int     // Override max chunks (optional)
+	Threshold        float64 // Override threshold (optional)
+	GraphBoostWeight float64 // Optional: >0 enables entity-based re-ranking
 }
 
 // RetrieveContextResult contains the retrieval results
@@ -74,8 +75,16 @@ func (r *RAGService) RetrieveContext(ctx context.Context, opts RetrieveContextOp
 		searchOpts.UserID = &opts.UserID
 	}
 
-	// Search for relevant chunks with user isolation
-	chunks, err := r.storage.SearchChatbotKnowledgeWithOptions(ctx, opts.ChatbotID, queryEmbedding, searchOpts)
+	// Search for relevant chunks. When graph boost is requested and the
+	// knowledge graph + entity extractor are wired, take the graph-boosted
+	// path which over-fetches and re-ranks by entity salience. Otherwise use
+	// the standard cross-KB search.
+	var chunks []RetrievalResult
+	if opts.GraphBoostWeight > 0 && r.knowledgeGraph != nil && r.entityExtractor != nil {
+		chunks, err = r.retrieveContextWithGraphBoost(ctx, opts, queryEmbedding)
+	} else {
+		chunks, err = r.storage.SearchChatbotKnowledgeWithOptions(ctx, opts.ChatbotID, queryEmbedding, searchOpts)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to search knowledge: %w", err)
 	}
@@ -126,6 +135,70 @@ func (r *RAGService) RetrieveContext(ctx context.Context, opts RetrieveContextOp
 		DurationMs:       duration.Milliseconds(),
 		EmbeddingModel:   r.embeddingService.DefaultModel(),
 	}, nil
+}
+
+// retrieveContextWithGraphBoost runs the chat retrieval path with graph-boosted
+// re-ranking. Mirrors the standard cross-KB search but calls SearchChunksWithGraphBoost
+// per linked KB, preserving user isolation via the MetadataFilter.
+func (r *RAGService) retrieveContextWithGraphBoost(ctx context.Context, opts RetrieveContextOptions, queryEmbedding []float32) ([]RetrievalResult, error) {
+	links, err := r.storage.GetChatbotKnowledgeBases(ctx, opts.ChatbotID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get linked knowledge bases: %w", err)
+	}
+	if len(links) == 0 {
+		return nil, nil
+	}
+
+	maxChunks := opts.MaxChunks
+	if maxChunks <= 0 {
+		maxChunks = 5
+	}
+	threshold := opts.Threshold
+	if threshold <= 0 {
+		threshold = 0.7
+	}
+
+	// Build the same user-isolation filter SearchChatbotKnowledgeWithOptions uses.
+	var userFilter *MetadataFilter
+	if opts.UserID != "" {
+		userFilter = &MetadataFilter{
+			UserID:        &opts.UserID,
+			IncludeGlobal: true,
+		}
+	}
+
+	var allResults []RetrievalResult
+	for _, link := range links {
+		if !link.Enabled {
+			continue
+		}
+
+		graphOpts := GraphBoostOptions{
+			QueryEmbedding:   queryEmbedding,
+			QueryText:        opts.Query,
+			Limit:            maxChunks,
+			Threshold:        threshold,
+			GraphBoostWeight: opts.GraphBoostWeight,
+			Filter:           userFilter,
+		}
+
+		results, err := r.storage.SearchChunksWithGraphBoost(ctx, link.KnowledgeBaseID, r.knowledgeGraph, r.entityExtractor, graphOpts)
+		if err != nil {
+			log.Warn().Err(err).Str("kb_id", link.KnowledgeBaseID).Msg("Graph-boosted search failed, skipping KB")
+			continue
+		}
+
+		// Stamp KB name onto results for context formatting.
+		if kb, getErr := r.storage.GetKnowledgeBase(ctx, link.KnowledgeBaseID); getErr == nil && kb != nil {
+			for i := range results {
+				results[i].KnowledgeBaseName = kb.Name
+			}
+		}
+
+		allResults = append(allResults, results...)
+	}
+
+	return allResults, nil
 }
 
 // formatContext formats retrieved chunks into a string for the LLM prompt

--- a/internal/ai/schema_builder.go
+++ b/internal/ai/schema_builder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -483,8 +482,10 @@ func (s *SchemaBuilder) BuildSystemPromptWithAuth(ctx context.Context, chatbot *
 
 	sb.WriteString("\n")
 	fmt.Fprintf(&sb, "Allowed operations: %s\n", strings.Join(chatbot.AllowedOperations, ", "))
-	fmt.Fprintf(&sb, "Current user ID: %s\n", userID)
-	fmt.Fprintf(&sb, "Current date and time: %s\n", time.Now().UTC().Format("Monday, January 2, 2006 at 3:04 PM MST"))
+	// ponytail: "Current user ID" and "Current date and time" intentionally
+	// omitted from the static prompt — they vary per user / per second and
+	// would defeat provider prompt caching. Injected as a separate dynamic
+	// system message by the chat handler so the static prefix stays byte-stable.
 
 	// Add response language instruction
 	sb.WriteString("\n## Response Language\n\n")

--- a/internal/ai/user_kb_handler_documents.go
+++ b/internal/ai/user_kb_handler_documents.go
@@ -303,6 +303,15 @@ func (h *UserKnowledgeBaseHandler) DeleteMyDocument(c fiber.Ctx) error {
 		})
 	}
 
+	// Clean up orphaned entities (those only referenced by this document) before
+	// deleting, mirroring the admin path. Without this the FK CASCADE removes
+	// document_entities rows but leaves entity rows as orphans forever.
+	if h.knowledgeGraph != nil {
+		if err := h.knowledgeGraph.DeleteOrphanedEntitiesByDocument(ctx, docID); err != nil {
+			log.Warn().Err(err).Str("doc_id", docID).Msg("Failed to delete orphaned entities (continuing)")
+		}
+	}
+
 	// Delete document
 	if err := h.storage.DeleteDocument(ctx, docID); err != nil {
 		log.Error().Err(err).Str("doc_id", docID).Msg("Failed to delete document")
@@ -407,6 +416,8 @@ func (h *UserKnowledgeBaseHandler) DeleteMyDocumentsByFilter(c fiber.Ctx) error 
 		Metadata: req.Metadata,
 	}
 
+	// ponytail: bulk delete does not clean up orphaned entities (single-doc
+	// path does). Add per-doc cleanup if entity-table bloat becomes an issue.
 	deletedCount, err := h.storage.DeleteDocumentsByFilter(ctx, kbID, filter)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{

--- a/internal/api/handler_groups.go
+++ b/internal/api/handler_groups.go
@@ -58,6 +58,7 @@ type AIHandlers struct {
 	Metrics         *observability.Metrics
 	KnowledgeBase   *ai.KnowledgeBaseHandler
 	KBStorage       *ai.KnowledgeBaseStorage
+	KnowledgeGraph  *ai.KnowledgeGraph
 	DocProcessor    *ai.DocumentProcessor
 	TableExportSync *ai.TableExportSyncService
 	VectorManager   *VectorManager

--- a/internal/api/module_ai.go
+++ b/internal/api/module_ai.go
@@ -62,6 +62,7 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 	var aiMetrics *observability.Metrics
 	var knowledgeBaseHandler *ai.KnowledgeBaseHandler
 	var kbStorage *ai.KnowledgeBaseStorage
+	var knowledgeGraph *ai.KnowledgeGraph
 	var docProcessor *ai.DocumentProcessor
 	var tableExportSyncService *ai.TableExportSyncService
 	var ocrService *ai.OCRService
@@ -73,6 +74,7 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 
 		aiLoader := ai.NewLoader(cfg.AI.ChatbotsDir)
 		aiConversations = ai.NewConversationManager(db, cfg.AI.ConversationCacheTTL, cfg.AI.MaxConversationTurns)
+		aiConversations.SetMetrics(aiMetrics)
 		aiHandler = ai.NewHandler(aiStorage, aiLoader, &cfg.AI, vectorManager)
 
 		var embeddingService *ai.EmbeddingService
@@ -81,6 +83,10 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		}
 
 		aiChatHandler = ai.NewChatHandler(db, aiStorage, aiConversations, aiMetrics, &cfg.AI, embeddingService, loggingSvc)
+
+		// Wire chat handler back into the admin handler so provider mutations
+		// invalidate the chat path's provider cache.
+		aiHandler.SetChatHandler(aiChatHandler)
 
 		if secretsSvc != nil {
 			settingsResolver := ai.NewSettingsResolver(secretsSvc, 5*time.Minute)
@@ -114,7 +120,7 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		}
 
 		kbStorage = ai.NewKnowledgeBaseStorage(db)
-		knowledgeGraph := ai.NewKnowledgeGraph(kbStorage)
+		knowledgeGraph = ai.NewKnowledgeGraph(kbStorage)
 		log.Info().Msg("Knowledge graph initialized")
 
 		entityExtractor := ai.NewRuleBasedExtractor()
@@ -175,6 +181,7 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		Metrics:         aiMetrics,
 		KnowledgeBase:   knowledgeBaseHandler,
 		KBStorage:       kbStorage,
+		KnowledgeGraph:  knowledgeGraph,
 		DocProcessor:    docProcessor,
 		TableExportSync: tableExportSyncService,
 		VectorManager:   vectorManager,

--- a/internal/api/routes/ai.go
+++ b/internal/api/routes/ai.go
@@ -17,6 +17,7 @@ type AIDeps struct {
 	GetUserConversation    fiber.Handler
 	DeleteUserConversation fiber.Handler
 	UpdateUserConversation fiber.Handler
+	GetUserUsage           fiber.Handler // GET /api/v1/ai/usage/:chatbotId — per-user daily quota
 }
 
 func BuildAIRoutes(deps *AIDeps) *RouteGroup {
@@ -87,6 +88,13 @@ func BuildAIRoutes(deps *AIDeps) *RouteGroup {
 				Path:    "/api/v1/ai/conversations/:id",
 				Handler: deps.UpdateUserConversation,
 				Summary: "Update user conversation",
+				Auth:    AuthRequired,
+			},
+			{
+				Method:  "GET",
+				Path:    "/api/v1/ai/usage/:chatbotId",
+				Handler: deps.GetUserUsage,
+				Summary: "Get the current user's daily quota for a chatbot",
 				Auth:    AuthRequired,
 			},
 		},

--- a/internal/api/routes_ai.go
+++ b/internal/api/routes_ai.go
@@ -25,6 +25,7 @@ func (s *Server) buildAIRouteDeps() *routes.AIDeps {
 		GetUserConversation:    s.AI.Handler.GetUserConversation,
 		DeleteUserConversation: s.AI.Handler.DeleteUserConversation,
 		UpdateUserConversation: s.AI.Handler.UpdateUserConversation,
+		GetUserUsage:           s.AI.Chat.GetUserUsage,
 	}
 }
 
@@ -68,9 +69,19 @@ func (s *Server) buildKnowledgeBaseRouteDeps() *routes.KnowledgeBaseDeps {
 		return deps
 	}
 
-	handler := ai.NewUserKnowledgeBaseHandler(s.AI.KBStorage)
-	if s.AI.DocProcessor != nil {
+	// Use the graph-aware constructor when the knowledge graph is available so
+	// user-side entity/graph routes are wired. Without this the SDK methods
+	// (listEntities, getKnowledgeGraph, etc.) 404.
+	var handler *ai.UserKnowledgeBaseHandler
+	switch {
+	case s.AI.DocProcessor != nil && s.AI.KnowledgeGraph != nil:
+		handler = ai.NewUserKnowledgeBaseHandlerWithProcessorAndGraph(s.AI.KBStorage, s.AI.DocProcessor, s.AI.KnowledgeGraph)
+	case s.AI.DocProcessor != nil:
 		handler = ai.NewUserKnowledgeBaseHandlerWithProcessor(s.AI.KBStorage, s.AI.DocProcessor)
+	case s.AI.KnowledgeGraph != nil:
+		handler = ai.NewUserKnowledgeBaseHandlerWithGraph(s.AI.KBStorage, s.AI.KnowledgeGraph)
+	default:
+		handler = ai.NewUserKnowledgeBaseHandler(s.AI.KBStorage)
 	}
 
 	deps.ListKBs = handler.ListMyKnowledgeBases
@@ -86,7 +97,19 @@ func (s *Server) buildKnowledgeBaseRouteDeps() *routes.KnowledgeBaseDeps {
 		deps.AddDocument = handler.AddMyDocument
 		deps.UploadDocument = handler.UploadMyDocument
 		deps.DeleteDocument = handler.DeleteMyDocument
+		deps.UpdateDocument = handler.UpdateMyDocument
+		deps.DeleteDocsByFilter = handler.DeleteMyDocumentsByFilter
 		deps.SearchKB = handler.SearchMyKB
+		deps.DebugSearch = handler.DebugSearchMyKB
+	}
+
+	// Entity/graph routes — only populated when the handler has a knowledge graph.
+	if s.AI.KnowledgeGraph != nil {
+		deps.ListEntities = handler.ListMyEntities
+		deps.SearchEntities = handler.SearchMyEntities
+		deps.GetEntityRelationships = handler.GetMyEntityRelationships
+		deps.GetKnowledgeGraph = handler.GetMyKnowledgeGraph
+		deps.ListLinkedChatbots = handler.ListMyLinkedChatbots
 	}
 
 	return deps

--- a/internal/database/schema/schemas/ai.sql
+++ b/internal/database/schema/schemas/ai.sql
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS knowledge_bases (
     pipeline_type text DEFAULT 'none' NOT NULL,
     pipeline_config jsonb DEFAULT '{}' NOT NULL,
     transformation_function text,
+    entity_extraction_enabled boolean DEFAULT true NOT NULL,
     tenant_id uuid,
     CONSTRAINT knowledge_bases_pkey PRIMARY KEY (id),
     CONSTRAINT unique_knowledge_base_name_namespace UNIQUE (name, namespace),
@@ -62,6 +63,9 @@ COMMENT ON COLUMN ai.knowledge_bases.chunk_strategy IS 'Chunking strategy: recur
 
 
 COMMENT ON COLUMN ai.knowledge_bases.visibility IS 'private=owner only, shared=explicit permissions, public=all authenticated users';
+
+
+COMMENT ON COLUMN ai.knowledge_bases.entity_extraction_enabled IS 'When true (default), documents are processed by the rule-based entity extractor on insert/reprocess. Set to false to skip extraction (no entities, no relationships, no graph-boost signal).';
 
 
 COMMENT ON COLUMN ai.knowledge_bases.quota_max_documents IS 'Maximum documents allowed in this KB';
@@ -696,7 +700,7 @@ CREATE TABLE IF NOT EXISTS providers (
     tenant_id uuid,
     CONSTRAINT providers_pkey PRIMARY KEY (id),
     CONSTRAINT providers_name_key UNIQUE (name),
-    CONSTRAINT providers_provider_type_check CHECK (provider_type IN ('openai'::text, 'azure'::text, 'ollama'::text))
+    CONSTRAINT providers_provider_type_check CHECK (provider_type IN ('openai'::text, 'azure'::text, 'ollama'::text, 'anthropic'::text))
 );
 
 

--- a/sdk/src/ai.test.ts
+++ b/sdk/src/ai.test.ts
@@ -979,8 +979,60 @@ describe('FluxbaseAIChat', () => {
 
       expect(onDone).toHaveBeenCalledWith(
         { total_tokens: 150, prompt_tokens: 100, completion_tokens: 50 },
-        'conv-123'
+        'conv-123',
+        // extras is always passed as the third argument; both fields are
+        // undefined when the server omits them (preserves backward compat
+        // for callbacks that only declare two params).
+        { daily_quota: undefined, matched_intent_rules: undefined }
       );
+    });
+
+    it('should forward daily_quota and matched_intent_rules via onDone extras', async () => {
+      const onDone = vi.fn();
+      const chat = new FluxbaseAIChat({
+        wsUrl: 'ws://localhost:8080/ai/ws',
+        onDone,
+      });
+
+      const connectPromise = chat.connect();
+      mockWs.simulateOpen();
+      await connectPromise;
+
+      const dailyQuota = {
+        requests: { used: 12, limit: 500 },
+        tokens: { used: 4500, limit: 100000 },
+        resets_at: '2026-07-01T00:00:00Z',
+      };
+      const matchedRules = [
+        { keyword: 'restaurant', required_table: 'my_place_visits' },
+      ];
+
+      mockWs.simulateMessage({
+        type: 'done',
+        conversation_id: 'conv-456',
+        usage: {
+          total_tokens: 200,
+          prompt_tokens: 150,
+          completion_tokens: 50,
+          cached_tokens: 120,
+        },
+        daily_quota: dailyQuota,
+        matched_intent_rules: matchedRules,
+      });
+
+      expect(onDone).toHaveBeenCalledTimes(1);
+      const [usage, conversationId, extras] = onDone.mock.calls[0];
+      expect(usage).toEqual({
+        total_tokens: 200,
+        prompt_tokens: 150,
+        completion_tokens: 50,
+        cached_tokens: 120,
+      });
+      expect(conversationId).toBe('conv-456');
+      expect(extras).toEqual({
+        daily_quota: dailyQuota,
+        matched_intent_rules: matchedRules,
+      });
     });
 
     it('should handle error messages', async () => {

--- a/sdk/src/ai.ts
+++ b/sdk/src/ai.ts
@@ -10,6 +10,8 @@ import type {
   AIChatServerMessage,
   AIUsageStats,
   AIUserConversationDetail,
+  AIDailyQuotaSnapshot,
+  AIMatchedIntentRule,
   ListConversationsOptions,
   ListConversationsResult,
   UpdateConversationOptions,
@@ -72,7 +74,18 @@ export interface AIChatOptions {
     conversationId: string,
   ) => void;
   /** Callback when message is complete */
-  onDone?: (usage: AIUsageStats | undefined, conversationId: string) => void;
+  onDone?: (
+    usage: AIUsageStats | undefined,
+    conversationId: string,
+    /**
+     * Turn metadata (Ask 2/4/5). Optional third argument — old callbacks
+     * that only declare two params keep working unchanged.
+     */
+    extras?: {
+      matched_intent_rules?: AIMatchedIntentRule[];
+      daily_quota?: AIDailyQuotaSnapshot;
+    },
+  ) => void;
   /** Callback for errors */
   onError?: (
     error: string,
@@ -388,7 +401,14 @@ export class FluxbaseAIChat {
 
         case "done":
           if (message.conversation_id) {
-            this.options.onDone?.(message.usage, message.conversation_id);
+            this.options.onDone?.(
+              message.usage,
+              message.conversation_id,
+              {
+                matched_intent_rules: message.matched_intent_rules,
+                daily_quota: message.daily_quota,
+              },
+            );
           }
           break;
 
@@ -698,6 +718,41 @@ export class FluxbaseAI {
       const response = await this.fetch.patch<AIUserConversationDetail>(
         `/api/v1/ai/conversations/${id}`,
         updates,
+      );
+      return { data: response, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  /**
+   * Get the current user's daily quota for a chatbot (Ask 2).
+   *
+   * Returns requests used/limit and tokens used/limit, plus the RFC3339
+   * timestamp of when the counters reset. Best-effort: counters are in-memory
+   * and reset on server restart; per-instance in multi-replica deployments.
+   *
+   * For per-turn updates without an extra round-trip, read `daily_quota` from
+   * the `onDone` callback's third argument.
+   *
+   * @param chatbotId - Chatbot ID
+   * @returns Promise resolving to { data, error } with the quota snapshot
+   *
+   * @example
+   * ```typescript
+   * const { data, error } = await ai.getUsage('chatbot-uuid')
+   * if (data) {
+   *   console.log(`${data.requests.limit - data.requests.used} requests left today`)
+   *   console.log(`${data.tokens.limit - data.tokens.used} tokens left today`)
+   * }
+   * ```
+   */
+  async getUsage(
+    chatbotId: string,
+  ): Promise<{ data: AIDailyQuotaSnapshot | null; error: Error | null }> {
+    try {
+      const response = await this.fetch.get<AIDailyQuotaSnapshot>(
+        `/api/v1/ai/usage/${chatbotId}`,
       );
       return { data: response, error: null };
     } catch (error) {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -465,6 +465,9 @@ export type {
   AIChatClientMessage,
   AIChatServerMessage,
   AIUsageStats,
+  AIMatchedIntentRule,
+  AIDailyQuotaSnapshot,
+  AIQuota,
   AIConversation,
   AIConversationMessage,
 

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -3123,6 +3123,10 @@ export interface AIChatServerMessage {
   row_count?: number;
   data?: Record<string, unknown>[];
   usage?: AIUsageStats;
+  /** Intent rules that fired for this turn (Ask 5). Empty when none match. */
+  matched_intent_rules?: AIMatchedIntentRule[];
+  /** Per-user daily quota snapshot at turn end (Ask 2). Omitted when no limits configured. */
+  daily_quota?: AIDailyQuotaSnapshot;
   error?: string;
   code?: string;
 }
@@ -3134,6 +3138,43 @@ export interface AIUsageStats {
   prompt_tokens: number;
   completion_tokens: number;
   total_tokens?: number;
+  /**
+   * Subset of prompt_tokens served from the provider's prompt cache
+   * (OpenAI automatic prefix caching, Anthropic prompt caching). 0 when
+   * caching didn't fire or the provider doesn't report it. (Ask 4)
+   */
+  cached_tokens?: number;
+}
+
+/**
+ * One intent rule that fired for a user message (Ask 5). Mirrors the
+ * chatbot's @fluxbase:intent-rules entry plus the specific keyword that matched.
+ */
+export interface AIMatchedIntentRule {
+  keyword: string;
+  required_table?: string;
+  forbidden_table?: string;
+  required_tool?: string;
+  forbidden_tool?: string;
+}
+
+/**
+ * Per-user daily quota snapshot returned in the done event (Ask 2) and by
+ * fluxbase.ai.getUsage(). Counts are best-effort in-memory; they reset on
+ * server restart and are per-instance in multi-replica deployments.
+ */
+export interface AIDailyQuotaSnapshot {
+  requests: AIQuota;
+  tokens: AIQuota;
+  /** RFC3339 timestamp of when the counters roll over to zero. */
+  resets_at?: string;
+}
+
+/** One half of AIDailyQuotaSnapshot. */
+export interface AIQuota {
+  used: number;
+  /** Configured limit; 0 means unlimited. */
+  limit: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

A batch of AI subsystem improvements driven by both internal investigation (chatbot bug fixes, knowledge graph wiring) and downstream app asks (Wayli). All changes are **strictly additive** — old SDK versions and existing chatbot definitions keep working unchanged.

The branch covers two related but separable threads that landed together:

1. **Chatbot runtime fixes + knowledge graph wiring** (investigation-driven)
2. **Five Wayli asks** (prompt caching, per-user quota, intent rule observability, MCP code sharing, execute_sql streaming hardening)

## What changed

### Chatbot runtime bug fixes (Phase 0)
- `chat_handler_message.go` — send `chatbot.Model` in `ChatRequest` (the `@fluxbase:model` annotation was parsed but never sent to the provider)
- `chat_handler_message.go` — call `CheckDailyTokenBudget` before streaming (was defined but never called — daily token budget was effectively documentation-only)
- `chat_handler_tools.go` — both SQL error paths now use `FormatErrorForLLM` so the model gets recovery hints instead of a raw error string
- `chat_handler_message.go` + `conversation.go` + `module_ai.go` — emit `RecordAIProviderRequest` (provider latency) and `UpdateAIConversations` (active gauge) — both were dead code
- `chat_handler.go` + `handler.go` + `module_ai.go` — `ChatHandler.InvalidateProvider(id)` called from admin Update/Delete/SetDefault so rotated API keys take effect immediately

### Knowledge graph wiring
- `handler_groups.go` + `module_ai.go` + `routes_ai.go` — exposed `KnowledgeGraph` on `AIHandlers`, switched to `NewUserKnowledgeBaseHandlerWithProcessorAndGraph`, populated all 5 entity/graph deps. SDK methods (`listEntities`, `getKnowledgeGraph`, etc.) no longer 404. Also wired `UpdateDocument`, `DeleteDocsByFilter`, `DebugSearch` for users (same gap, same fix)
- `chatbot.go` + `kb_storage_search.go` + `rag_service.go` + `chat_handler_message.go` — wired graph-boosted retrieval. New `@fluxbase:rag-graph-boost-weight` annotation (0–1, default 0 = off). Chatbot annotation wins; falls back to `FLUXBASE_AI_RAG_GRAPH_BOOST_WEIGHT`. `GraphBoostOptions.Filter` preserves user isolation on the boost path
- `user_kb_handler_documents.go` — `DeleteMyDocument` now calls `DeleteOrphanedEntitiesByDocument` (mirrors admin path). Bulk-delete paths marked with `ponytail:` known-gap notes
- `knowledge_graph.go` + `document_processor.go` — new `DeleteDocumentEntitiesByDocument` called at the top of `extractAndStoreEntities` so reprocessing no longer leaves stale entity mentions
- `knowledge_graph.go` — deleted dead `BatchAddEntities` (zero callers)
- `ai.sql` + `knowledge_base.go` + `document_processor.go` + storage round-trip — new per-KB `entity_extraction_enabled` toggle (default true). Lets users opt out for KBs where the regex `person` rule would create noise

### CLI
- New commands: `kb documents` (`--limit`), `kb upload` (multipart), `kb entities` (`--type`, `--search`, `--limit`), `kb graph`, `kb chatbots`
- New flag: `kb update --entity-extraction=false`
- `mcp tools sync` now bundles `_shared/*.ts` via Deno (parity with edge functions and jobs). Backward-compatible — tools without imports skip the bundler

### Wayli ask 1 — execute_sql streaming
- `chat_handler_tools.go` — MCP path now emits `Type: "query_result"` (was `tool_result`) when structured query data is present, matching the legacy path. Old SDKs that only handled `query_result` now receive it on both paths
- `chat_handler_tools.go` — when MCP tools return `IsError`, emit an error `tool_result` frame (was silent — only the LLM-facing error string was returned)
- `chat_handler_tools.go` — structured query fields now stream for `query_table` too (was parsed-for-persistence only)

### Wayli ask 2 — per-user daily quota
- `chatbot_limiter.go` — new `GetDailyUsage` returns a point-in-time snapshot
- `provider.go` (`UsageStats`) + `chat_handler.go` (`ServerMessage`) — new additive fields. `done` event now carries `daily_quota` when the chatbot has limits configured
- `chat_handler_usage.go` (new) — `GET /api/v1/ai/usage/:chatbotId` returns the same snapshot
- SDK: new `client.ai.getUsage(chatbotId)` method + `AIDailyQuotaSnapshot` / `AIQuota` types
- Best-effort in-memory counters; distributed backing is a separate future task

### Wayli ask 4 — prompt caching
- `schema_builder.go` + `chat_handler_message.go` — split static system prompt from dynamic context (user ID, time, RAG) into two messages so the static prefix is byte-stable across turns. RAG no longer concatenated into the system prompt
- `provider.go` (`UsageStats`) — new `CachedTokens` field
- `provider_openai.go` + `provider_azure.go` — parse `prompt_tokens_details.cached_tokens` (was silently dropped)
- `provider_anthropic.go` (new) — native Anthropic Claude provider. Explicit `cache_control: {type: "ephemeral"}` breakpoints on the static system block + last tool definition. Parses `cache_read_input_tokens` into `CachedTokens`. Full streaming support (`message_start`, `content_block_delta`, `message_delta`, `message_stop`)
- `ai.sql` — added `'anthropic'` to the `providers.provider_type` CHECK constraint (declarative; applied on startup)
- `chat_handler_message.go` — daily budget now charges `effective = (prompt_tokens - cached_tokens) + completion_tokens` — cached input billed at 0x

### Wayli ask 5 — intent rule observability
- `intent_validator.go` — new `MatchedRules` field on `IntentValidationResult`; new public `GetMatchedRules` method
- `chat_handler_message.go` + `chat_handler.go` — accumulate matched rules across the turn; `done` event carries `matched_intent_rules`
- SDK: new `AIMatchedIntentRule` type

### Tests
- `provider_anthropic_test.go` (new) — request building, cache_control placement, tool/tool_result block conversion, model fallback, usage mapping, stop-reason mapping
- `chatbot_limiter_test.go` (new) — `GetDailyUsage` counter behavior and reset-time computation
- `intent_validator_test.go` — `GetMatchedRules` coverage

### Docs
- `knowledge-bases.md` — entity types table honest (removed `concept`/`event` which are never extracted; added detection column), relationship types split into "auto-inferred" vs "schema-supported manual-only", new "Graph-Boosted Retrieval" section, per-KB extraction toggle docs, CLI commands section fixed
- `commands.md` — swept to match shipped CLI (removed false `kb status`, `kb add`, `kb search`, `kb export-table`, `kb tables`, `kb capabilities`; added real `kb documents`, `kb upload`)
- `ai-chatbots.md` — new `@fluxbase:rag-graph-boost-weight` annotation row, "Turn Metadata" section (daily_quota, matched_intent_rules, cached_tokens), "Prompt Caching" section, Anthropic provider example
- `mcp/custom-mcp-tools.md` — new "Sharing Code Between Tools (_shared/)" section
- `CLAUDE.md` — "Enhanced AI/Knowledge Base" section expanded to list the new files

## Public API additions

All additive — existing clients that ignore new fields keep working unchanged.

| Surface | Addition |
|---|---|
| `ServerMessage.Usage` | `cached_tokens` field |
| `ServerMessage` | `matched_intent_rules []MatchedIntentRule`, `daily_quota *DailyQuotaSnapshot` |
| Wire format | MCP `execute_sql` emits `query_result`; MCP tool errors stream; `query_table` streams |
| Provider factory | `ProviderTypeAnthropic = "anthropic"`; `NewAnthropicProvider` |
| `mcp.custom_tools.provider_type` CHECK | adds `'anthropic'` |
| `knowledge_bases` table | new `entity_extraction_enabled` column (default true) |
| REST | `GET /api/v1/ai/usage/:chatbotId` |
| CLI | `kb documents`, `kb upload`, `kb entities`, `kb graph`, `kb chatbots`; `kb update --entity-extraction`; `mcp tools sync` now bundles `_shared/` |
| SDK | `client.ai.getUsage()`; types `AIMatchedIntentRule`, `AIDailyQuotaSnapshot`, `AIQuota`, `UsageStats.cached_tokens`; `onDone` optional 3rd `extras` argument |
| Annotation | `@fluxbase:rag-graph-boost-weight` (0–1, default 0 = off) |

## Verification

- `go build ./...` — clean
- `go test ./internal/ai/... ./internal/api/routes/... ./cli/...` — all pass
- `golangci-lint run ./internal/... ./cli/...` — 0 issues
- SDK / SDK-React / admin `tsc --noEmit` — all pass

### Pre-existing (unrelated to this PR)
- `golangci-lint run ./...` reports ~127 typecheck errors in `test/e2e` and 1 in `internal/database/schema_inspector_internal_test.go` — these fail identically on `main` (verified via stash) due to the `//go:build integration` tag not being active in the default lint invocation. Recommend a separate follow-up to add `--build-tags integration` to the lint Makefile target.
- `TestOTPFlow` / `TestReauthenticate` / `TestIdentityRoutes` in `internal/api` require a running PostgreSQL — fail identically on `main`.

## Backward compatibility

- All new `done` event fields are pointer/omitempty; old SDK versions are unaffected
- The static-prefix split changes the on-wire message structure (two system messages instead of one). OpenAI/Azure/Ollama/Anthropic all handle multiple system messages. Custom OpenAI-compatible proxies should forward the full messages array
- Graph boost defaults to 0 (off) — existing chatbots see no behavior change
- Per-KB `entity_extraction_enabled` defaults to true — existing KBs see no behavior change
- The schema CHECK constraint expansion is additive (no migration needed beyond the declarative apply)

## Out of scope (noted for follow-up)

- Distributed quota (cross-replica accuracy) — Phase 3.S3 in the master plan
- Server-side MCP tool bundling (admin UI authoring with live bundling) — CLI covers the git-based workflow
- LLM-based entity extractor (better quality than the rule-based one for non-tech KBs)
- Real per-entity salience (currently flat 0.5; graph boost is an entity-presence signal)