### PR TITLE
fix: storage signed-download 0 bytes, embedded-worker reaping, default-bucket FK

### DIFF
--- a/internal/api/storage_default_buckets.go
+++ b/internal/api/storage_default_buckets.go
@@ -28,6 +28,20 @@ func EnsureDefaultBucketRecords(ctx context.Context, db *pgxpool.Pool, bucketNam
 		defaultTenantID = &tenantIDStr
 	}
 
+	// Self-heal: earlier versions seeded default buckets with id = gen_random_uuid()
+	// while every INSERT into storage.objects uses the bucket NAME as bucket_id.
+	// That mismatch violated objects_bucket_id_fkey on fresh instances. Align
+	// id = name so existing rows resolve. Safe: the FK bug blocked all object
+	// inserts on these buckets, so nothing references the old UUID ids.
+	if _, err := db.Exec(ctx, `
+		UPDATE storage.buckets
+		SET id = name
+		WHERE name = ANY($1::text[])
+		  AND id <> name
+	`, bucketNames); err != nil {
+		return fmt.Errorf("failed to align default bucket ids with names: %w", err)
+	}
+
 	for _, name := range bucketNames {
 		var exists bool
 		err := db.QueryRow(ctx, `
@@ -44,10 +58,12 @@ func EnsureDefaultBucketRecords(ctx context.Context, db *pgxpool.Pool, bucketNam
 			continue
 		}
 
-		// Use gen_random_uuid() for the bucket ID
+		// Use the bucket name as its id. storage.objects.bucket_id is always
+		// populated with the name (from the URL path), so id must equal name
+		// for objects_bucket_id_fkey to resolve. This matches CreateBucket.
 		_, err = db.Exec(ctx, `
 			INSERT INTO storage.buckets (id, name, public, tenant_id)
-			VALUES (gen_random_uuid(), $1, false, $2)
+			VALUES ($1, $1, false, $2)
 			ON CONFLICT (name) DO NOTHING
 		`, name, defaultTenantID)
 		if err != nil {

--- a/internal/api/storage_signed.go
+++ b/internal/api/storage_signed.go
@@ -176,8 +176,10 @@ func (h *StorageHandler) DownloadSignedObject(c fiber.Ctx) error {
 		log.Error().Err(err).Str("bucket", tokenResult.Bucket).Str("key", tokenResult.Key).Msg("Failed to download file via signed URL")
 		return SendInternalError(c, "Failed to download file")
 	}
-	defer func() { _ = reader.Close() }()
-
+	// Don't defer reader.Close() here. SendStream hands reader to fasthttp,
+	// which streams the bytes then closes it after writing (reader is io.Closer).
+	// A deferred close here runs on handler return — before fasthttp streams —
+	// yielding a 0-byte body with correct headers (Content-Length set, empty content).
 	contentType := object.ContentType
 	contentLength := object.Size
 
@@ -223,6 +225,10 @@ func (h *StorageHandler) DownloadSignedObject(c fiber.Ctx) error {
 					filename = strings.TrimSuffix(filename, filepath.Ext(filename)) + ext
 				}
 				c.Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", sanitizeContentDispositionFilename(filename)))
+
+				// TransformReader fully consumed the original reader; close it now
+				// (transformedReader is an independent buffered reader).
+				_ = reader.Close()
 
 				return c.SendStream(transformedReader)
 			}

--- a/internal/config/config_jobs.go
+++ b/internal/config/config_jobs.go
@@ -81,6 +81,12 @@ func (jc *JobsConfig) Validate() error {
 	if jc.WorkerTimeout <= 0 {
 		return fmt.Errorf("worker_timeout must be positive, got: %v", jc.WorkerTimeout)
 	}
+	// Worker timeout must comfortably exceed the heartbeat interval, otherwise
+	// a worker can be reaped between heartbeats. Require at least 2x so a
+	// single missed heartbeat never triggers cleanup.
+	if jc.WorkerTimeout < 2*jc.WorkerHeartbeatInterval {
+		return fmt.Errorf("worker_timeout (%v) must be at least 2x worker_heartbeat_interval (%v)", jc.WorkerTimeout, jc.WorkerHeartbeatInterval)
+	}
 
 	// Warn if max_max_duration is very high (over 1 hour)
 	if jc.MaxMaxDuration > time.Hour {

--- a/internal/jobs/storage_workers.go
+++ b/internal/jobs/storage_workers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/database"
 )
@@ -41,8 +42,20 @@ func (s *Storage) UpdateWorkerHeartbeat(ctx context.Context, workerID uuid.UUID,
 	`
 
 	return database.WrapWithServiceRole(ctx, s.DB, func(tx pgx.Tx) error {
-		_, err := tx.Exec(ctx, query, currentJobCount, workerID)
-		return err
+		result, err := tx.Exec(ctx, query, currentJobCount, workerID)
+		if err != nil {
+			return err
+		}
+		// Surface the silent no-op that happens once a worker row has been
+		// reaped by the stale-worker sweep: the UPDATE affects 0 rows and the
+		// loop keeps ticking uselessly. Without this, "heartbeats never update"
+		// is invisible.
+		if result.RowsAffected() == 0 {
+			log.Warn().
+				Str("worker_id", workerID.String()).
+				Msg("Heartbeat updated 0 rows - worker not found (likely already reaped by stale cleanup)")
+		}
+		return nil
 	})
 }
 
@@ -128,11 +141,15 @@ func (s *Storage) ListWorkers(ctx context.Context) ([]*WorkerRecord, error) {
 	return workers, nil
 }
 
-// CleanupStaleWorkers removes workers that haven't sent a heartbeat in a while
+// CleanupStaleWorkers removes workers that haven't sent a heartbeat in a while.
+// A worker is only reaped if BOTH its heartbeat is stale AND it has been
+// registered longer than the timeout — this guarantees a freshly-registered
+// worker is never swept before its first heartbeat lands.
 func (s *Storage) CleanupStaleWorkers(ctx context.Context, timeout time.Duration) (int64, error) {
 	query := `
 		DELETE FROM jobs.workers
 		WHERE last_heartbeat_at < NOW() - $1::INTERVAL
+		  AND started_at < NOW() - $1::INTERVAL
 	`
 
 	var result pgconn.CommandTag

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -277,26 +277,20 @@ func (w *Worker) pollLoop(ctx context.Context) {
 
 // heartbeatLoop sends periodic heartbeats
 func (w *Worker) heartbeatLoop(ctx context.Context) {
-	defer func() {
-		if rec := recover(); rec != nil {
-			log.Error().
-				Interface("panic", rec).
-				Str("worker_id", w.ID.String()).
-				Str("goroutine", "heartbeatLoop").
-				Msg("Panic in heartbeat loop - recovered")
-		}
-	}()
-
 	ticker := time.NewTicker(w.Config.WorkerHeartbeatInterval)
 	defer ticker.Stop()
+
+	// Send a heartbeat immediately so the worker's row is fresh right after
+	// registration, then on every tick. This closes the gap between registration
+	// (which seeds last_heartbeat_at via DB default) and the first ticker fire
+	// (one full interval later), so a freshly-registered worker can never be
+	// mistaken for stale before its first heartbeat lands.
+	w.sendHeartbeat(ctx)
 
 	for {
 		select {
 		case <-ticker.C:
-			count := w.getCurrentJobCount()
-			if err := w.Storage.UpdateWorkerHeartbeat(ctx, w.ID, count); err != nil {
-				log.Error().Err(err).Str("worker_id", w.ID.String()).Msg("Failed to send heartbeat")
-			}
+			w.sendHeartbeat(ctx)
 		case <-w.shutdownChan:
 			// Send final heartbeat with stopped status
 			if err := w.Storage.UpdateWorkerStatus(ctx, w.ID, WorkerStatusStopped); err != nil {
@@ -304,6 +298,25 @@ func (w *Worker) heartbeatLoop(ctx context.Context) {
 			}
 			return
 		}
+	}
+}
+
+// sendHeartbeat updates the worker's heartbeat timestamp and recovers from
+// panics per call so a single failure never permanently silences the loop.
+func (w *Worker) sendHeartbeat(ctx context.Context) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Error().
+				Interface("panic", rec).
+				Str("worker_id", w.ID.String()).
+				Str("goroutine", "heartbeatLoop").
+				Msg("Panic sending heartbeat - recovered, will retry next tick")
+		}
+	}()
+
+	count := w.getCurrentJobCount()
+	if err := w.Storage.UpdateWorkerHeartbeat(ctx, w.ID, count); err != nil {
+		log.Error().Err(err).Str("worker_id", w.ID.String()).Msg("Failed to send heartbeat")
 	}
 }
 


### PR DESCRIPTION
## Three independent stability fixes

### 1. Signed-URL downloads returned 0 bytes (non-transform path)
`internal/api/storage_signed.go` — `DownloadSignedObject` did `defer reader.Close()` before `c.SendStream(reader)`. In Fiber/fasthttp, `SendStream` sets the body stream and the bytes are read **after** the handler returns; the deferred close ran on return — *before* fasthttp streamed — so clients got correct headers (`Content-Length`, `Content-Disposition` with the object filename) but an **empty body**. Browsers saved a 0-byte file. The export zip (`application/zip`) hit this path exclusively (image transforms were unaffected).

fasthttp closes the body stream itself after writing when the reader implements `io.Closer` (`closeBodyStream`), which is how the sibling `DownloadFile` already works (`storage_files.go:398`). Mirror it: drop the defer, close the original reader explicitly in the transform branch (`TransformReader` eagerly buffers the result), let `SendStream` own the close on the main path.

### 2. Embedded workers reaped as stale shortly after startup
`internal/jobs/{worker,storage_workers}.go`, `internal/config/config_jobs.go` — embedded workers registered, then got deleted by the stale-worker sweep around the first heartbeat window, leaving `jobs.workers` empty and new jobs stuck in `pending`. Structural defects:

1. `heartbeatLoop`'s `recover()` exited the goroutine **permanently** on one panic — no resume.
2. `UpdateWorkerHeartbeat` ignored `RowsAffected`, so once a row was reaped every subsequent heartbeat was a **silent** no-op.
3. No validation relating `worker_timeout` to `worker_heartbeat_interval`.
4. `CleanupStaleWorkers` deleted any worker with a stale heartbeat, with no grace for just-registered workers.

Fixes:
- Extract tick work into `sendHeartbeat` with per-call `recover`; the loop **resumes** after a panic. Fire one heartbeat **immediately** on loop entry (closes the registration→first-tick gap).
- Warn when `UpdateWorkerHeartbeat` affects 0 rows.
- `CleanupStaleWorkers` now also requires `started_at < NOW() - timeout`, so a freshly-registered worker is never swept.
- Validate `worker_timeout >= 2 * worker_heartbeat_interval` at startup.

### 3. Default buckets used UUID ids, breaking `objects_bucket_id_fkey`
`internal/api/storage_default_buckets.go` — `EnsureDefaultBucketRecords` seeded default buckets with `id = gen_random_uuid()`, but every INSERT into `storage.objects` uses the bucket **name** as `bucket_id`. The FK → `buckets(id)` then failed on fresh instances (`temp-files`, `uploads`, `public`) with SQLSTATE 23503; uploads appeared to succeed but no DB row was written, downloads 404'd. API-created buckets already used `id = name`.

- Seed with `id = name`, matching `CreateBucket` and how `objects.bucket_id` is populated.
- **Self-heal** existing instances: align `id = name` for default buckets on boot (safe — the FK bug blocked all object inserts on these buckets, so nothing references the old UUID ids).

## Verification
- `go build ./...`, `go vet ./internal/jobs/... ./internal/api/... ./internal/config/...` — clean
- `gofmt -l` on all changed files — clean
- `go test ./internal/config/... ./internal/jobs/...` and `go test -short ./internal/api/...` — pass

## Notes
- An e2e/streaming regression test for fix #1 is blocked by an existing Fiber test-framework limitation with file streams (see `storage_files_test.go:221` `t.Skip`), so it is not included.
- Fix #2: with stock defaults (timeout=30s, heartbeat=10s) the reaping-at-16s symptom is mathematically impossible for a healthy worker, so the trigger in affected deployments is likely a non-default ratio or a heartbeat panic — either way the fix above is robust to both.
- Fix #3: existing UUID-id buckets are repaired automatically on next boot; no separate migration required.