### PR TITLE
docs: fix accuracy defects and broken examples across guides

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -337,6 +337,13 @@ export default defineConfig({
           autogenerate: { directory: "sdk" },
         },
         {
+          label: "React SDK",
+          collapsed: true,
+          items: [
+            { label: "Getting Started", link: "/sdk-react/getting-started/" },
+          ],
+        },
+        {
           label: "CLI",
           collapsed: true,
           items: [
@@ -354,6 +361,7 @@ export default defineConfig({
                 { label: "Storage", link: "/cli/commands/#storage-commands" },
                 { label: "Chatbots", link: "/cli/commands/#chatbot-commands" },
                 { label: "Knowledge Bases (kb)", link: "/cli/commands/#knowledge-base-commands" },
+                { label: "AI Providers", link: "/cli/commands/#ai-providers-commands" },
                 { label: "Tables", link: "/cli/commands/#table-commands" },
                 { label: "Types", link: "/cli/commands/#type-generation-commands" },
                 { label: "GraphQL", link: "/cli/commands/#graphql-commands" },
@@ -361,6 +369,7 @@ export default defineConfig({
                 { label: "Webhooks", link: "/cli/commands/#webhook-commands" },
                 { label: "Client Keys", link: "/cli/commands/#client-key-commands" },
                 { label: "Migrations", link: "/cli/commands/#migration-commands" },
+                { label: "Internal Schema", link: "/cli/commands/#internal-schema-commands" },
                 { label: "Extensions", link: "/cli/commands/#extension-commands" },
                 { label: "Realtime", link: "/cli/commands/#realtime-commands" },
                 { label: "Settings", link: "/cli/commands/#settings-commands" },

--- a/docs/src/content/docs/api-cookbook.md
+++ b/docs/src/content/docs/api-cookbook.md
@@ -64,7 +64,7 @@ await client.auth.signOut();
 ### Get Current User
 
 ```typescript
-const user = await client.auth.getCurrentUser();
+const { user } = await client.auth.getCurrentUser();
 if (user) {
   console.log("Logged in as:", user.email);
 }
@@ -73,14 +73,12 @@ if (user) {
 ### Password Reset
 
 ```typescript
-// Request reset
-await client.auth.resetPassword({ email: "user@example.com" });
+// Request a password-reset email
+await client.auth.sendPasswordReset("user@example.com");
+// `resetPasswordForEmail(email)` is a Supabase-compatible alias
 
-// User receives email with token, then:
-await client.auth.confirmPasswordReset({
-  token: "reset-token",
-  password: "NewPassword123",
-});
+// The user receives an email with a token, then confirms the new password:
+await client.auth.resetPassword("reset-token-from-email", "NewPassword123");
 ```
 
 ## Database Operations
@@ -359,7 +357,8 @@ await client.storage.from("avatars").remove(["user-123.png"]);
 ### Get Public URL
 
 ```typescript
-const url = client.storage.from("public-bucket").getPublicUrl("logo.svg");
+const { data } = client.storage.from("public-bucket").getPublicUrl("logo.svg");
+console.log("Public URL:", data.publicUrl);
 ```
 
 ### Create Signed URL (Private Files)
@@ -367,7 +366,7 @@ const url = client.storage.from("public-bucket").getPublicUrl("logo.svg");
 ```typescript
 const { data } = await client.storage
   .from("private-docs")
-  .createSignedUrl("document.pdf", 3600); // 1 hour expiry
+  .createSignedUrl("document.pdf", { expiresIn: 3600 }); // 1 hour expiry
 
 console.log("Temporary URL:", data.signedUrl);
 ```
@@ -613,7 +612,7 @@ try {
 ## Related Documentation
 
 - [Authentication Guide](/guides/authentication)
-- [TypeScript SDK Reference](/api/sdk/)
+- [TypeScript SDK Reference](/api/sdk/readme/)
 - [Realtime](/guides/realtime)
 - [Storage](/guides/storage)
 - [Row-Level Security](/guides/row-level-security)

--- a/docs/src/content/docs/api/http/graphql/index.md
+++ b/docs/src/content/docs/api/http/graphql/index.md
@@ -17,9 +17,10 @@ The GraphQL API provides:
 
 ## Endpoint
 
-```
-POST /api/v1/graphql
-```
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/graphql` | Execute GraphQL queries and mutations |
+| `GET` | `/api/v1/graphql` | Return the GraphQL introspection schema (when `graphql.introspection` is enabled) |
 
 ## Authentication
 
@@ -137,7 +138,16 @@ The GraphQL API supports PostgREST-compatible filter operators, specified as fla
 | `_in` | In list | `{ status_in: ["active", "pending"] }` |
 | `_is_null` | Is null | `{ deletedAt_is_null: true }` |
 
-Multiple conditions in a single filter object are combined with AND.
+Multiple conditions in a single filter object are combined with AND. Each filter type also exposes logical combinators — `AND`, `OR`, and `NOT` — so you can nest arbitrarily:
+
+```graphql
+query {
+  users(filter: { OR: [{ status_eq: "active" }, { featured_eq: true }] }) {
+    id
+    email
+  }
+}
+```
 
 ## Mutations
 

--- a/docs/src/content/docs/api/http/index.md
+++ b/docs/src/content/docs/api/http/index.md
@@ -152,27 +152,28 @@ A full GraphQL API auto-generated from your database schema.
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `POST` | `/graphql` | Execute GraphQL queries and mutations |
+| `GET` | `/graphql` | Return the GraphQL introspection schema (when enabled) |
 
 See the [GraphQL API documentation](/api/http/graphql) for complete details on queries, mutations, filtering, and SDK usage.
 
 ### Database Tables
 
-Auto-generated CRUD endpoints for your PostgreSQL tables.
+Auto-generated, PostgREST-style CRUD for your PostgreSQL tables. Paths are schema-scoped (`/tables/{schema}/{table}`); `/tables/{schema}` addresses all tables in a schema, and `/tables/` lists tables.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/tables/{table}` | List records with filtering |
-| `POST` | `/tables/{table}` | Create record(s) |
-| `PATCH` | `/tables/{table}` | Batch update records |
-| `DELETE` | `/tables/{table}` | Batch delete records |
-| `GET` | `/tables/{table}/{id}` | Get record by ID |
-| `PUT` | `/tables/{table}/{id}` | Replace record |
-| `PATCH` | `/tables/{table}/{id}` | Update record |
-| `DELETE` | `/tables/{table}/{id}` | Delete record |
-| `POST` | `/tables/{table}/bulk` | Bulk insert |
-| `PATCH` | `/tables/{table}/bulk` | Bulk update |
-| `DELETE` | `/tables/{table}/bulk` | Bulk delete |
-| `GET` | `/tables/{table}/export` | Export table data (CSV/JSON) |
+| `GET` | `/tables/` | List all tables |
+| `POST` | `/tables/{schema}/{table}/query` | Query with a complex filter body |
+| `GET` | `/tables/{schema}/{table}` | List records (filters via query params) |
+| `POST` | `/tables/{schema}/{table}` | Create record(s) — send a JSON array for bulk insert |
+| `PATCH` | `/tables/{schema}/{table}` | Update records matching a query filter |
+| `DELETE` | `/tables/{schema}/{table}` | Delete records matching a query filter |
+| `GET` | `/tables/{schema}/{table}/{id}` | Get a record by primary key |
+| `PUT` | `/tables/{schema}/{table}/{id}` | Replace a record |
+| `PATCH` | `/tables/{schema}/{table}/{id}` | Update a record |
+| `DELETE` | `/tables/{schema}/{table}/{id}` | Delete a record |
+
+Batch update/delete use query-parameter filters (see [Query Parameters](#query-parameters)); there are no dedicated `/bulk` or `/export` routes.
 
 ### Tenant Management
 
@@ -328,13 +329,18 @@ Manage database branches for isolated dev/test environments. All routes require 
 
 ### Migrations
 
+All migration endpoints require a service key or `admin`/`instance_admin`/`tenant_admin` role and are gated by the migrations IP allowlist.
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/admin/migrations` | List migrations |
 | `POST` | `/admin/migrations` | Create migration |
 | `GET` | `/admin/migrations/{name}` | Get migration details |
+| `PUT` | `/admin/migrations/{name}` | Update migration |
+| `DELETE` | `/admin/migrations/{name}` | Delete migration |
 | `POST` | `/admin/migrations/{name}/apply` | Apply migration |
 | `POST` | `/admin/migrations/{name}/rollback` | Rollback migration |
+| `GET` | `/admin/migrations/{name}/executions` | Get execution history |
 | `POST` | `/admin/migrations/apply-pending` | Apply all pending migrations |
 | `POST` | `/admin/migrations/sync` | Sync migrations (batch upload) |
 
@@ -358,25 +364,52 @@ Manage secrets for edge functions and background jobs.
 | `GET` | `/secrets/by-name/{name}/versions` | Get secret versions by name |
 | `POST` | `/secrets/by-name/{name}/rollback/{version}` | Rollback secret by name |
 
-### AI Chatbots & Knowledge Bases
+### AI Chatbots (Public)
+
+Public chatbot discovery and the conversational WebSocket. Chat is streaming over a WebSocket — there is no REST `POST .../chat` endpoint.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/chatbots` | List chatbots |
-| `POST` | `/chatbots` | Create chatbot |
-| `GET` | `/chatbots/{id}` | Get chatbot details |
-| `PUT` | `/chatbots/{id}` | Update chatbot |
-| `DELETE` | `/chatbots/{id}` | Delete chatbot |
-| `POST` | `/chatbots/{id}/chat` | Send message (WebSocket upgrade or HTTP) |
-| `GET` | `/knowledge-bases` | List knowledge bases |
-| `POST` | `/knowledge-bases` | Create knowledge base |
-| `GET` | `/knowledge-bases/{id}` | Get knowledge base details |
-| `PUT` | `/knowledge-bases/{id}` | Update knowledge base |
-| `DELETE` | `/knowledge-bases/{id}` | Delete knowledge base |
-| `POST` | `/knowledge-bases/{id}/documents` | Upload document |
-| `GET` | `/knowledge-bases/{id}/documents` | List documents |
-| `DELETE` | `/knowledge-bases/{id}/documents/{doc_id}` | Delete document |
-| `POST` | `/knowledge-bases/{id}/search` | Search knowledge base |
+| `GET` | `/ai/chatbots` | List enabled (public) chatbots |
+| `GET` | `/ai/chatbots/by-name/{name}` | Look up a chatbot by name |
+| `GET` | `/ai/chatbots/{id}` | Get a public chatbot |
+| `GET` | `/ai/ws` | Chat WebSocket (streaming responses) |
+| `GET` | `/ai/conversations` | List the current user's conversations |
+| `GET` | `/ai/conversations/{id}` | Get a conversation |
+| `PATCH` | `/ai/conversations/{id}` | Update a conversation (e.g. title) |
+| `DELETE` | `/ai/conversations/{id}` | Delete a conversation |
+| `GET` | `/ai/usage/{chatbotId}` | Current user's daily quota snapshot |
+
+:::note[Chatbot management]
+Creating, updating, deleting, and toggling chatbots is admin-only via `/admin/ai/chatbots/*` (see the Admin AI section).
+:::
+
+### Knowledge Bases
+
+User-facing knowledge-base routes. All require authentication, and the caller must have access to the given knowledge base.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/ai/knowledge-bases` | List the user's knowledge bases |
+| `POST` | `/ai/knowledge-bases` | Create a knowledge base |
+| `GET` | `/ai/knowledge-bases/{id}` | Get a knowledge base |
+| `POST` | `/ai/knowledge-bases/{id}/share` | Share a knowledge base with a user |
+| `GET` | `/ai/knowledge-bases/{id}/permissions` | List KB permissions |
+| `DELETE` | `/ai/knowledge-bases/{id}/permissions/{user_id}` | Revoke KB permission |
+| `POST` | `/ai/knowledge-bases/{id}/documents` | Add a document (JSON) |
+| `POST` | `/ai/knowledge-bases/{id}/documents/upload` | Upload a document file |
+| `GET` | `/ai/knowledge-bases/{id}/documents` | List documents |
+| `GET` | `/ai/knowledge-bases/{id}/documents/{doc_id}` | Get a document |
+| `PATCH` | `/ai/knowledge-bases/{id}/documents/{doc_id}` | Update a document |
+| `DELETE` | `/ai/knowledge-bases/{id}/documents/{doc_id}` | Delete a document |
+| `POST` | `/ai/knowledge-bases/{id}/documents/delete-by-filter` | Delete documents by filter |
+| `POST` | `/ai/knowledge-bases/{id}/search` | Semantic search |
+| `POST` | `/ai/knowledge-bases/{id}/debug-search` | Debug search (scores/explanation) |
+| `GET` | `/ai/knowledge-bases/{id}/entities` | List entities |
+| `GET` | `/ai/knowledge-bases/{id}/entities/search` | Search entities |
+| `GET` | `/ai/knowledge-bases/{id}/entities/{entity_id}/relationships` | Get entity relationships |
+| `GET` | `/ai/knowledge-bases/{id}/graph` | Get the full knowledge graph |
+| `GET` | `/ai/knowledge-bases/{id}/chatbots` | List chatbots linked to the KB |
 
 ### Realtime
 
@@ -391,7 +424,6 @@ Channels: `table:{schema}.{table}`, `presence:{room}`, `broadcast:{channel}`
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/realtime/stats` | Get realtime connection statistics |
-| `POST` | `/realtime/broadcast` | Broadcast message to connected clients |
 
 ### Public Settings
 
@@ -575,15 +607,21 @@ Table endpoints support PostgREST-compatible query parameters:
 | `Content-Type` | Request body format (`application/json`, `multipart/form-data`) |
 | `Prefer` | Response preferences (`return=representation`, `count=exact`) |
 
-## OpenAPI Specification
+## API Reference & OpenAPI
 
-A live OpenAPI 3.0 specification is available at:
+An interactive API reference (Scalar) is served at:
+
+```
+GET /api-docs
+```
+
+A live OpenAPI 3.0 specification is also available:
 
 ```
 GET /openapi.json
 ```
 
-This specification is generated dynamically based on your database schema and includes all available endpoints with their request/response schemas.
+The specification is generated dynamically from the registered routes and your database schema, and includes request/response schemas for all endpoints.
 
 ## Error Responses
 

--- a/docs/src/content/docs/cli/commands.md
+++ b/docs/src/content/docs/cli/commands.md
@@ -2028,6 +2028,92 @@ After installation, restart your shell or source the completion file to enable a
 
 ---
 
+## AI Providers Commands
+
+Manage AI providers (OpenAI, Azure, Ollama) used by chatbots, embeddings, and vector search. The command group is `providers` (alias `provider`).
+
+:::note
+The command is `fluxbase providers`, **not** `fluxbase ai providers`. (Some older examples referenced an `ai` parent that does not exist.)
+:::
+
+### `fluxbase providers list`
+
+List configured AI providers.
+
+```bash
+fluxbase providers list
+fluxbase providers list -o json
+```
+
+### `fluxbase providers get [id]`
+
+Get a provider by ID.
+
+### `fluxbase providers create [name]`
+
+Create a new provider.
+
+```bash
+fluxbase providers create openai \
+  --type openai \
+  --display-name "OpenAI" \
+  --api-key sk-... \
+  --model gpt-4o \
+  --default
+```
+
+**Flags:** `--type` (`openai`, `azure`, `ollama`), `--display-name`, `--api-key`, `--base-url` (Ollama/custom), `--model`, `--default` (set as default), `--enabled` (default `true`).
+
+### `fluxbase providers update [id]`
+
+Update a provider. **Flags:** `--display-name`, `--api-key`, `--base-url`, `--model`, `--embedding-model`, `--enabled`, `--set-enabled`.
+
+### `fluxbase providers delete [id]`
+
+Delete a provider (aliases: `rm`, `remove`).
+
+### `fluxbase providers set-default [id]`
+
+Set a provider as the default for chat/completions.
+
+### `fluxbase providers set-embedding [id]` / `clear-embedding [id]`
+
+Set or clear the provider used for embeddings.
+
+### `fluxbase providers metrics`
+
+Show AI usage metrics (token spend, request counts).
+
+## Internal Schema Commands
+
+Manage Fluxbase's internal database schemas (auth, storage, jobs, functions, realtime, ai, rpc, platform, etc.) declaratively. Powered by pgschema diff/apply.
+
+### `fluxbase internal-schema dump`
+
+Dump the current internal schema to SQL.
+
+### `fluxbase internal-schema plan`
+
+Show the planned changes between the desired and live internal schema.
+
+### `fluxbase internal-schema apply`
+
+Apply planned changes. **Flags:** `--auto-approve` (skip confirmation), `--allow-destructive` (permit `DROP`/`ALTER`).
+
+### `fluxbase internal-schema validate`
+
+Validate the internal schema against the live database. **Flag:** `--fail-on-drift` (exit non-zero if drift is detected — useful in CI).
+
+### `fluxbase internal-schema status`
+
+Show the current internal-schema status.
+
+### `fluxbase internal-schema migrate`
+
+One-time migration from imperative internal migrations to the declarative schema. **Flag:** `--keep-old-migrations` (retain the old migration records).
+
+**Persistent flag:** `--file` — path to a schema file (for backward compatibility).
+
 ## Command Aliases
 
 Many commands have shorter aliases for convenience:

--- a/docs/src/content/docs/deployment/scaling.md
+++ b/docs/src/content/docs/deployment/scaling.md
@@ -47,7 +47,7 @@ resources:
     memory: 16Gi
 ```
 
-### Horizontal Scaling (Scale Out) {#horizontal-scaling}
+### Horizontal Scaling
 
 **When to use**: Long-term growth, high availability needs
 
@@ -1287,4 +1287,4 @@ kubectl logs <pod> -n fluxbase | grep "connection pool"
 
 - [Production Checklist](/deployment/production-checklist/) - Pre-deployment verification
 - [Monitoring Guide](/guides/monitoring-observability/) - Set up observability
-- [API Reference](/api/sdk/) - SDK documentation and best practices
+- [API Reference](/api/sdk/readme/) - SDK documentation and best practices

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -179,7 +179,7 @@ See the [Row-Level Security Guide](/guides/row-level-security/).
 - [First API Tutorial](/guides/tutorials/first-api/) - Complete beginner walkthrough
 - [Developer Guide](/guides/developer-guide/) - Understand the codebase architecture
 - [Multi-Tenancy](/guides/multi-tenancy/) - Build multi-tenant SaaS applications
-- [TypeScript SDK Reference](/api/sdk/) - SDK reference and examples
+- [TypeScript SDK Reference](/api/sdk/readme/) - SDK reference and examples
 - [Authentication Guide](/guides/authentication/) - User authentication options
 - [Edge Functions](/guides/edge-functions/) - Deploy serverless functions
 - [Configuration Reference](/reference/configuration/) - All configuration options

--- a/docs/src/content/docs/guides/admin/user-impersonation.md
+++ b/docs/src/content/docs/guides/admin/user-impersonation.md
@@ -64,7 +64,7 @@ View data with service-level permissions.
 
 **How it works:**
 
-- Generates a JWT with `role: "service"`
+- Generates a JWT with `role: "service_role"` (or `role: "tenant_service"` when tenant-scoped)
 - May bypass RLS (depending on configuration)
 - Elevated permissions for admin tasks
 
@@ -165,7 +165,7 @@ Every impersonation session is logged in the `auth.impersonation_sessions` table
 
 ### Access Control
 
-- ✅ Only users with `role = 'admin'` can impersonate
+- ✅ Requires `admin`, `instance_admin`, or `tenant_admin` role
 - ✅ Self-impersonation is prevented (for user mode)
 - ✅ Reason field is required (cannot be empty)
 - ✅ Only one active session per admin at a time

--- a/docs/src/content/docs/guides/ai-chatbots.md
+++ b/docs/src/content/docs/guides/ai-chatbots.md
@@ -292,6 +292,31 @@ Available metadata annotations:
 | `@fluxbase:required-settings`        | Setting keys to load for template resolution                       | -                         |
 | `@fluxbase:mcp-tools`                | Comma-separated MCP tools to enable (see [MCP Tools](#mcp-tools))  | `""` (legacy execute_sql) |
 | `@fluxbase:use-mcp-schema`           | Fetch schema from MCP resources instead of direct DB introspection | `false`                   |
+| `@fluxbase:model`                    | LLM model override (e.g. `gpt-4o`, `claude-3-5-sonnet`)            | provider default          |
+| `@fluxbase:reasoning-mode`           | `react` (think-before-act), `strict`, or `none`                    | `react`                   |
+| `@fluxbase:max-iterations`           | Max tool-call iterations per turn                                  | `5`                       |
+| `@fluxbase:show-reasoning`           | Expose the agent's reasoning steps to the user                     | `false`                   |
+| `@fluxbase:intent-rules`             | JSON array of keyword → required/forbidden table/tool rules        | `[]`                      |
+
+### Reasoning Mode
+
+The `@fluxbase:reasoning-mode` annotation controls how the chatbot uses tools:
+
+- **`react`** (default) — the chatbot runs the `think` tool to plan before calling data tools (ReAct pattern). Recommended for accuracy.
+- **`strict`** — stricter planning discipline; the chatbot must produce an explicit plan and stays within it.
+- **`none`** — no `think` step; tools may be called directly. Faster but less reliable for multi-step questions.
+
+Combine with `@fluxbase:max-iterations` (tool-call rounds, default `5`) and `@fluxbase:show-reasoning true` to surface the planning steps in the streamed response.
+
+### Intent Rules
+
+`@fluxbase:intent-rules` accepts a JSON array that gates the conversation based on the user's message. When a keyword matches, you can require a specific table or forbid a tool:
+
+```typescript
+ * @fluxbase:intent-rules [{"keywords":["restaurant","cafe"],"requiredTable":"public.places"},{"keywords":["payment"],"forbiddenTool":"execute_sql"}]
+```
+
+Matched rules are surfaced in the chat done event's `matched_intent_rules` field.
 
 ### HTTP Tool
 

--- a/docs/src/content/docs/guides/ai-chatbots.md
+++ b/docs/src/content/docs/guides/ai-chatbots.md
@@ -207,9 +207,9 @@ Create a chatbot file (e.g., `chatbots/my-assistant/index.ts`):
  * @fluxbase:persist-conversations true
  * @fluxbase:conversation-ttl 24
  * @fluxbase:max-turns 50
- * @fluxbase:rate-limit 20
+ * @fluxbase:rate-limit 20/min
  * @fluxbase:daily-limit 500
- * @fluxbase:token-budget 100000
+ * @fluxbase:token-budget 100000/day
  * @fluxbase:allow-unauthenticated false
  * @fluxbase:public true
  */
@@ -279,9 +279,9 @@ Available metadata annotations:
 | `@fluxbase:persist-conversations`    | Save conversation history                                          | `false`                   |
 | `@fluxbase:conversation-ttl`         | Conversation TTL in hours                                          | `24`                      |
 | `@fluxbase:max-turns`                | Max messages in conversation                                       | `50`                      |
-| `@fluxbase:rate-limit`               | Requests per minute                                                | `10`                      |
-| `@fluxbase:daily-limit`              | Requests per day                                                   | `100`                     |
-| `@fluxbase:token-budget`             | Max tokens per day                                                 | `50000`                   |
+| `@fluxbase:rate-limit`               | Requests per minute (write as `N/min`)                            | `20`                      |
+| `@fluxbase:daily-limit`              | Requests per day                                                   | `500`                     |
+| `@fluxbase:token-budget`             | Max tokens per day (write as `N/day`)                              | `100000`                  |
 | `@fluxbase:allow-unauthenticated`    | Allow anonymous access                                             | `false`                   |
 | `@fluxbase:public`                   | Show in public chatbot list                                        | `true`                    |
 | `@fluxbase:http-allowed-domains`     | Domains chatbot can fetch (comma-separated)                        | `""` (disabled)           |
@@ -741,9 +741,9 @@ Protect your API with rate limits and token budgets:
 
 ```typescript
 /**
- * @fluxbase:rate-limit 20        # 20 requests per minute
- * @fluxbase:daily-limit 500      # 500 requests per day
- * @fluxbase:token-budget 100000  # 100k tokens per day
+ * @fluxbase:rate-limit 20/min        # 20 requests per minute
+ * @fluxbase:daily-limit 500          # 500 requests per day
+ * @fluxbase:token-budget 100000/day  # 100k tokens per day
  */
 ```
 

--- a/docs/src/content/docs/guides/ai-chatbots.md
+++ b/docs/src/content/docs/guides/ai-chatbots.md
@@ -894,7 +894,7 @@ The static prefix is cached up to the first differing token. To maximize cache h
 ## Next Steps
 
 - [Knowledge Bases & RAG](/guides/knowledge-bases) - Create knowledge bases for RAG-powered chatbots
-- [TypeScript SDK Reference](/api/sdk) - Full SDK API documentation
+- [TypeScript SDK Reference](/api/sdk/readme/) - Full SDK API documentation
 - [Row-Level Security](/guides/row-level-security) - Secure your data access
 - [Authentication](/guides/authentication) - User authentication setup
 - [Rate Limiting](/guides/rate-limiting) - Configure rate limits

--- a/docs/src/content/docs/guides/authentication.md
+++ b/docs/src/content/docs/guides/authentication.md
@@ -140,7 +140,7 @@ if (error) throw error;
 
 ## OAuth / Social Login
 
-**Supported providers:** Google, GitHub, Microsoft, GitLab, Bitbucket, Facebook, Twitter/X, Discord, Slack
+**Supported providers:** Google, GitHub, Microsoft, Apple, GitLab, Bitbucket, Facebook, Twitter/X, LinkedIn
 
 **Configuration:**
 
@@ -164,12 +164,11 @@ if (data) window.location.href = data.url;
 
 ## Anonymous Authentication
 
-```typescript
-const { data, error } = await client.auth.signInAnonymously();
-if (error) throw error;
-```
+Anonymous access uses the `anon` role, activated by making requests with the publishable/anon client key (no user JWT). There is no `signInAnonymously` endpoint — anonymous requests are simply unauthenticated requests scoped by RLS policies written for the `anon` role.
 
-> **Note:** Anonymous sessions cannot be converted to permanent accounts. Users must sign up separately and link manually.
+:::note
+Anonymous sessions are not upgraded to authenticated accounts automatically. Users must sign up separately; link any anon-created data via a shared identifier if you need continuity.
+:::
 
 ## Two-Factor Authentication
 
@@ -386,7 +385,7 @@ Fluxbase supports multiple CAPTCHA providers:
 security:
   captcha:
     enabled: true
-    provider: turnstile # recaptcha, hcaptcha, turnstile, captcha-v2, cap
+    provider: turnstile # hcaptcha, recaptcha_v3, turnstile, cap
     site_key: your-site-key
     secret_key: your-secret-key
 ```
@@ -408,10 +407,7 @@ Administrators can impersonate other users for debugging and support purposes.
 
 ### Enable Impersonation
 
-```yaml
-auth:
-  impersonation_enabled: true
-```
+Impersonation is gated by role, not a config toggle — no `impersonation_enabled` setting exists. The `POST /api/v1/auth/impersonate*` routes require the `admin`, `instance_admin`, or `tenant_admin` role.
 
 ### Usage (Admin Dashboard)
 
@@ -429,10 +425,9 @@ await client.admin.impersonation.stop();
 
 ⚠️ **Impersonation is a powerful feature - use with caution:**
 
-- Only enable `impersonation_enabled` for admin users
 - All impersonation actions are logged
-- Requires dashboard admin role
-- Cannot impersonate other admins (prevents privilege escalation)
+- Requires `admin`, `instance_admin`, or `tenant_admin` role
+- Three modes: user, anonymous, and service impersonation (see [User Impersonation](/guides/admin/user-impersonation/))
 
 ## Next Steps
 

--- a/docs/src/content/docs/guides/branching/index.md
+++ b/docs/src/content/docs/guides/branching/index.md
@@ -135,7 +135,7 @@ branching:
 
 | Option                    | Default       | Description                                                     |
 | ------------------------- | ------------- | --------------------------------------------------------------- |
-| `enabled`                 | `false`       | Enable database branching                                       |
+| `enabled`                 | `true`        | Enable database branching                                       |
 | `max_total_branches`      | `50`          | Maximum total branches across all users                         |
 | `default_data_clone_mode` | `schema_only` | Default cloning mode (schema_only, full_clone, seed_data)       |
 | `auto_delete_after`       | `0`           | Auto-delete preview branches after this duration (0 = disabled) |
@@ -149,7 +149,7 @@ branching:
 | ------------- | -------------------------------------------------------------------- |
 | `schema_only` | Copy schema only, no data (fast)                                     |
 | `full_clone`  | Copy schema and all data (slower, useful for testing with real data) |
-| `seed_data`   | Copy schema with seed data (coming soon)                             |
+| `seed_data`   | Copy schema with seed data from `seeds_path` (see [Workflows](/guides/branching/workflows/)) |
 
 ### How It Works
 

--- a/docs/src/content/docs/guides/captcha.md
+++ b/docs/src/content/docs/guides/captcha.md
@@ -915,7 +915,7 @@ classDiagram
 | `internal/auth/captcha_turnstile.go` | Cloudflare Turnstile provider                               |
 | `internal/auth/captcha_cap.go`       | Self-hosted Cap provider with SSRF protection               |
 | `internal/api/auth_handler.go`       | Auth endpoint handlers with CAPTCHA verification            |
-| `internal/config/config.go`          | CAPTCHA configuration structures                            |
+| `internal/config/config_security.go`  | CAPTCHA configuration structures (`CaptchaConfig`, `AdaptiveTrustConfig`) |
 
 ## Next Steps
 

--- a/docs/src/content/docs/guides/captcha.md
+++ b/docs/src/content/docs/guides/captcha.md
@@ -428,6 +428,10 @@ security:
 | `FLUXBASE_SECURITY_CAPTCHA_SECRET_KEY`      | Secret key for verification                  |
 | `FLUXBASE_SECURITY_CAPTCHA_SCORE_THRESHOLD` | Score threshold (reCAPTCHA v3 only)          |
 | `FLUXBASE_SECURITY_CAPTCHA_ENDPOINTS`       | Comma-separated list of endpoints            |
+| `FLUXBASE_SECURITY_CAPTCHA_ADAPTIVE_TRUST_ENABLED`          | Enable adaptive trust (skip CAPTCHA for trusted users) |
+| `FLUXBASE_SECURITY_CAPTCHA_ADAPTIVE_TRUST_CAPTCHA_THRESHOLD` | Trust score below this requires CAPTCHA (default `50`) |
+| `FLUXBASE_SECURITY_CAPTCHA_ADAPTIVE_TRUST_TRUST_TOKEN_TTL`  | How long a solved CAPTCHA is trusted (default `15m`) |
+| `FLUXBASE_SECURITY_CAPTCHA_ADAPTIVE_TRUST_WEIGHT_*`         | Trust-signal weights: `weight_known_ip` (30), `weight_known_device` (25), `weight_recent_captcha` (40) |
 
 ### Cap Provider Configuration
 

--- a/docs/src/content/docs/guides/database-migrations.md
+++ b/docs/src/content/docs/guides/database-migrations.md
@@ -20,7 +20,7 @@ graph LR
     end
 
     subgraph "User Schema (Imperative)"
-        U1[Migration Files] --> U2[migrations.app]
+        U1[Migration Files] --> U2[platform.migrations]
         U2 --> U3[Application Tables]
     end
 
@@ -37,7 +37,7 @@ The internal Fluxbase schema (auth, storage, functions, jobs, etc.) is managed d
 - **bootstrap.sql** - Creates schemas, extensions, roles, and default privileges (idempotent)
 - **pgschema** - Compares desired schema files to actual database state and applies diffs
 
-**Tracking:** `migrations.declarative_state` table stores schema fingerprint
+**Tracking:** `platform.declarative_state` table stores schema fingerprint
 
 **Execution:** Automatically applied on server startup
 
@@ -63,7 +63,7 @@ The internal Fluxbase schema (auth, storage, functions, jobs, etc.) is managed d
 
 User migrations allow you to add your own custom database schema using traditional imperative migration files.
 
-**Tracking:** `migrations.app` table
+**Tracking:** `platform.migrations` table
 
 **Execution:** Run on startup if `FLUXBASE_DATABASE_USER_MIGRATIONS_PATH` is configured
 
@@ -383,10 +383,10 @@ If a migration fails partway through, check the logs and fix the issue:
 psql -h localhost -U fluxbase -d fluxbase
 
 -- Check migration state
-SELECT * FROM migrations.app WHERE status = 'failed';
+SELECT * FROM platform.migrations WHERE status = 'failed';
 
 -- After fixing the issue, mark as pending to retry
-UPDATE migrations.app SET status = 'pending', error_message = '' WHERE name = 'failed_migration';
+UPDATE platform.migrations SET status = 'pending', error_message = '' WHERE name = 'failed_migration';
 ```
 
 ### Migration Not Running
@@ -405,7 +405,7 @@ To see which user migrations have been applied:
 
 ```sql
 -- Check user migrations
-SELECT * FROM migrations.app ORDER BY applied_at DESC;
+SELECT * FROM platform.migrations ORDER BY applied_at DESC;
 ```
 
 ### Checking Declarative Schema Status
@@ -414,7 +414,7 @@ To check the internal declarative schema status:
 
 ```sql
 -- Check declarative state
-SELECT * FROM migrations.declarative_state;
+SELECT * FROM platform.declarative_state;
 ```
 
 Or use the admin API:

--- a/docs/src/content/docs/guides/edge-functions.md
+++ b/docs/src/content/docs/guides/edge-functions.md
@@ -1163,6 +1163,21 @@ async function handler(req) {
 
 Control how many requests each user or IP can make to your function within a time window.
 
+**Resource & Permissions Annotations**
+
+| Annotation | Description | Default |
+| --- | --- | --- |
+| `@fluxbase:timeout <seconds>` | Execution timeout | `30` |
+| `@fluxbase:memory <mb>` | Memory limit in MB | `128` |
+| `@fluxbase:disable-logs` / `@fluxbase:disable-execution-logs` | Disable verbose step-by-step execution logging | `false` |
+| `@fluxbase:allowed-domains <csv>` | Domains the function may call (SSRF allowlist) | server default (blocks metadata endpoints) |
+| `@fluxbase:allow-net` / `@fluxbase:deny-net` | Network access flags | net allowed by default |
+| `@fluxbase:allow-env` / `@fluxbase:deny-env` | Environment-variable access flags | env denied by default |
+
+:::note
+`FLUXBASE_SECRET_*` secrets and a curated allowlist of runtime env vars are always injected; sensitive vars (DB URL, JWT secret, email API keys) are blocked. See [Secrets Management](/guides/secrets-management/).
+:::
+
 **`@fluxbase:rate-limit`** - Limit requests per user/IP with format `N/unit` where unit is `min`, `hour`, or `day`:
 
 ```typescript

--- a/docs/src/content/docs/guides/edge-functions.md
+++ b/docs/src/content/docs/guides/edge-functions.md
@@ -114,7 +114,7 @@ async function handler(req) {
   // Create a service client using the per-request token
   // Edge functions receive FLUXBASE_SERVICE_TOKEN (tenant-scoped) automatically
   const client = createClient(
-    Deno.env.get("FLUXBASE_BASE_URL")!,
+    Deno.env.get("FLUXBASE_URL")!,
     Deno.env.get("FLUXBASE_SERVICE_TOKEN")!,
   );
 
@@ -180,7 +180,7 @@ async function handler(req) {
 ```typescript
 async function handler(req) {
   // Use the Fluxbase SDK via environment variables for database access
-  const baseUrl = Deno.env.get("FLUXBASE_BASE_URL") || "http://localhost:8080";
+  const baseUrl = Deno.env.get("FLUXBASE_URL") || "http://localhost:8080";
   const token = Deno.env.get("FLUXBASE_SERVICE_TOKEN") || Deno.env.get("FLUXBASE_USER_TOKEN");
 
   // Query using the REST API
@@ -370,7 +370,7 @@ Common bundling errors:
 
 - **Package not found** - Check package name and version
 - **Network timeout** - npm registry may be slow/unavailable
-- **Bundle too large** - Limit is 5MB after bundling
+- **Bundle too large** - Limit is 50MB after bundling
 - **Blocked package** - Using a restricted security package
 
 ### Air-Gapped / Private Registry Environments
@@ -1298,8 +1298,8 @@ executions.forEach((exec) => {
 
 ## Limitations
 
-- Maximum execution time: 60 seconds (configurable)
-- Maximum response size: 6MB
+- Maximum execution time: 30s default / 300s max (`functions.max_timeout`)
+- Maximum response size: 10MB (`functions.max_output_size`)
 - No filesystem persistence (use database or external storage)
 - Limited Deno permissions by default (configurable)
 
@@ -1460,7 +1460,7 @@ When a function calls `secrets.get("openai_api_key")`:
 
 ## REST API
 
-For direct HTTP access without the SDK, see the [SDK Documentation](/api/sdk).
+For direct HTTP access without the SDK, see the [SDK Documentation](/api/sdk/readme/).
 
 ## Troubleshooting
 
@@ -1662,4 +1662,4 @@ async function handler(req) {
 
 - [Authentication](/guides/authentication) - Secure function access
 - [Webhooks](/guides/webhooks) - Trigger functions from events
-- [SDK Documentation](/api/sdk) - Complete SDK documentation
+- [SDK Documentation](/api/sdk/readme/) - Complete SDK documentation

--- a/docs/src/content/docs/guides/email-services.md
+++ b/docs/src/content/docs/guides/email-services.md
@@ -129,9 +129,11 @@ FLUXBASE_EMAIL_SES_REGION=us-east-1
 
 ## Email Templates
 
-Fluxbase includes default HTML templates for magic links, email verification, and password resets.
+Fluxbase ships default HTML/text templates for transactional emails: **magic link**, **email verification**, and **password reset**. Each template exposes `Subject`, `HTMLBody`, and `TextBody`.
 
-**Custom templates:**
+### File-based overrides
+
+Point config at custom template files:
 
 ```yaml
 email:
@@ -140,10 +142,47 @@ email:
   password_reset_template: /path/to/password-reset.html
 ```
 
-**Template variables:**
+### Template variables
 
-- `{{.Link}}` - Full action URL
-- `{{.Token}}` - Token only
+| Variable | Meaning |
+|----------|---------|
+| `{{.AppName}}` | Application name (from settings) |
+| `{{.MagicLink}}` | Full magic-link sign-in URL (magic-link template) |
+| `{{.VerificationLink}}` | Full email-verification URL (verification template) |
+| `{{.Link}}` | Full action URL (generic) |
+| `{{.Token}}` | The bare token |
+
+### Template Management API
+
+Manage templates at runtime (requires `admin`/`instance_admin`/`tenant_admin`). Paths are under `/api/v1/admin/email`:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/templates` | List all templates (defaults + overrides) |
+| `GET` | `/templates/:name` | Get a template |
+| `PUT` | `/templates/:name` | Create/update a custom override |
+| `POST` | `/templates/:name/test` | Send a test email using the template |
+| `POST` | `/templates/:name/reset` | Reset a template to its default |
+
+Example — override the magic-link template:
+
+```bash
+curl -X PUT http://localhost:8080/api/v1/admin/email/templates/magic_link \
+  -H "Authorization: Bearer <service-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"subject": "Your sign-in link", "html_body": "<a href=\"{{.MagicLink}}\">Sign in</a>"}'
+```
+
+### Per-Tenant Email Overrides
+
+Tenants can override the instance email configuration (provider, credentials, sender). Requires `admin`/`instance_admin`/`tenant_admin`:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/v1/admin/email/settings/tenant` | Get the tenant's email settings |
+| `PUT` | `/api/v1/admin/email/settings/tenant` | Set/update tenant overrides |
+| `DELETE` | `/api/v1/admin/email/settings/tenant/:field` | Clear a single override field |
+| `POST` | `/api/v1/admin/email/settings/tenant/test` | Send a test email using the tenant's config |
 
 ---
 

--- a/docs/src/content/docs/guides/image-transformations.md
+++ b/docs/src/content/docs/guides/image-transformations.md
@@ -216,14 +216,10 @@ function ResponsiveImage({ path }: { path: string }) {
 
 ## Signed URLs with Transforms
 
-:::note[Coming Soon]
-Signed URL transforms are not yet implemented. Currently, transforms only work with public bucket URLs. Signed URL transform support is planned for a future release.
-:::
-
-When available, transform parameters will be included in the signed URL signature, preventing tampering:
+Signed URLs support transform options. Transform parameters are included in the signed URL signature, preventing tampering:
 
 ```typescript
-// PLANNED: Create signed URL with transforms
+// Create signed URL with transforms
 const { data } = await storage
   .from('private-bucket')
   .createSignedUrl('image.jpg', {
@@ -235,8 +231,8 @@ const { data } = await storage
     }
   })
 
-// Signed URL will include transform params in signature
-// Modifying ?w=400 to ?w=800 will invalidate the signature
+// The signed URL includes the transform params in the signature;
+// modifying ?w=400 to ?w=800 invalidates the signature.
 ```
 
 ## Configuration

--- a/docs/src/content/docs/guides/jobs.md
+++ b/docs/src/content/docs/guides/jobs.md
@@ -33,11 +33,13 @@ FLUXBASE_JOBS_AUTO_LOAD_ON_BOOT=true
 # Number of embedded worker threads
 FLUXBASE_JOBS_EMBEDDED_WORKER_COUNT=4
 
-# Default timeout for job execution (seconds)
-FLUXBASE_JOBS_DEFAULT_TIMEOUT=300
+# Default max duration for job execution
+FLUXBASE_JOBS_DEFAULT_MAX_DURATION=5m
 
-# Default maximum retry attempts
-FLUXBASE_JOBS_DEFAULT_MAX_RETRIES=3
+# Maximum allowed job duration
+FLUXBASE_JOBS_MAX_MAX_DURATION=1h
+
+# Retries are configured per-job via the @fluxbase:max-retries annotation (default: 0)
 ```
 
 ## Worker Architecture

--- a/docs/src/content/docs/guides/jobs.md
+++ b/docs/src/content/docs/guides/jobs.md
@@ -527,7 +527,13 @@ Control job behavior with JSDoc-style annotations:
 - `@fluxbase:require-role <role>` - Require specific user role (admin, authenticated, custom)
 - `@fluxbase:timeout <seconds>` - Maximum execution time (default: 300)
 - `@fluxbase:max-retries <count>` - Number of retry attempts (default: 0)
+- `@fluxbase:memory <mb>` - Memory limit in MB (default: 256)
+- `@fluxbase:progress-timeout <duration>` - Max gap between progress reports before the job is considered stuck (default: 60s)
 - `@fluxbase:schedule <cron>` - Cron expression for scheduled execution
+- `@fluxbase:schedule-params <json>` - JSON object injected as `_schedule_params` when the scheduler triggers the job
+- `@fluxbase:enabled <bool>` - Whether the job is enabled (default: true)
+- `@fluxbase:allow-net` / `@fluxbase:deny-net` - Network access flags
+- `@fluxbase:allow-env` / `@fluxbase:allow-read` / `@fluxbase:allow-write` - Capability flags
 - `@fluxbase:description <text>` - Human-readable job description
 
 ### Admin-Only Job

--- a/docs/src/content/docs/guides/jobs.md
+++ b/docs/src/content/docs/guides/jobs.md
@@ -526,7 +526,7 @@ Control job behavior with JSDoc-style annotations:
 - `@fluxbase:namespace <name>` - Specify namespace (overrides CLI `--namespace` flag)
 - `@fluxbase:require-role <role>` - Require specific user role (admin, authenticated, custom)
 - `@fluxbase:timeout <seconds>` - Maximum execution time (default: 300)
-- `@fluxbase:max-retries <count>` - Number of retry attempts (default: 3)
+- `@fluxbase:max-retries <count>` - Number of retry attempts (default: 0)
 - `@fluxbase:schedule <cron>` - Cron expression for scheduled execution
 - `@fluxbase:description <text>` - Human-readable job description
 
@@ -739,7 +739,7 @@ See the [Edge Functions guide](/guides/edge-functions/#secrets) for full secrets
 :::note[SDK Configuration]
 The SDK clients are automatically configured using `FLUXBASE_URL`. If your `fluxbase` or `fluxbaseService` parameters are `null`, check that:
 
-1. `FLUXBASE_BASE_URL` is set in your server configuration
+1. `FLUXBASE_URL` is set in your server configuration
 2. `FLUXBASE_AUTH_JWT_SECRET` is configured
 3. Check server logs for "Initializing jobs manager" message
 

--- a/docs/src/content/docs/guides/knowledge-bases.md
+++ b/docs/src/content/docs/guides/knowledge-bases.md
@@ -186,7 +186,7 @@ curl -X POST http://localhost:8080/api/v1/admin/ai/knowledge-bases/KB_ID/documen
 
 ### Best Practices for File Uploads
 
-1. **Clean PDFs**: Ensure PDFs are text-based, not scanned images (OCR not supported)
+1. **Scanned PDFs**: Image-based and scanned PDFs are supported via OCR (Tesseract). Enable with `ai.ocr_enabled` and configure languages via `ai.ocr_languages` (default `["eng"]`). Text-based PDFs extract faster and more accurately, so prefer them when available
 2. **Simple formatting**: Documents with simpler formatting extract more cleanly
 3. **File size**: Smaller files process faster; split very large documents if needed
 4. **Text density**: Avoid uploading files with mostly images or charts
@@ -842,4 +842,4 @@ fluxbase kb chatbots <kb-id>
 
 - [AI Chatbots](/guides/ai-chatbots) - Chatbot configuration and usage
 - [Vector Search](/guides/vector-search) - Direct vector search operations
-- [TypeScript SDK Reference](/api/sdk/) - Full SDK documentation
+- [TypeScript SDK Reference](/api/sdk/readme/) - Full SDK documentation

--- a/docs/src/content/docs/guides/logging.md
+++ b/docs/src/content/docs/guides/logging.md
@@ -1133,6 +1133,15 @@ Authorization: Bearer <admin-token>
 
 Manually flush buffered logs to storage. Useful before shutting down or for immediate log persistence.
 
+### Generate Test Logs
+
+```bash
+POST /api/v1/admin/logs/test
+Authorization: Bearer <admin-token>
+```
+
+Emits sample log entries across categories — handy for verifying pipeline configuration and backend connectivity.
+
 ---
 
 ## Summary

--- a/docs/src/content/docs/guides/logging.md
+++ b/docs/src/content/docs/guides/logging.md
@@ -81,7 +81,7 @@ Configure your logging backend in `fluxbase.yaml`:
 logging:
   backend: postgres
   batch_size: 100
-  flush_interval: 5s
+  flush_interval: 1s
 ```
 
 #### TimescaleDB

--- a/docs/src/content/docs/guides/mcp/index.mdx
+++ b/docs/src/content/docs/guides/mcp/index.mdx
@@ -112,7 +112,7 @@ Enable the MCP server in your `fluxbase.yaml`:
 mcp:
   enabled: true
   base_path: /mcp
-  session_timeout: 3600s
+  session_timeout: 30m
   max_message_size: 10485760 # 10MB
   rate_limit_per_min: 100
   allowed_tools: [] # Empty = all tools enabled
@@ -123,9 +123,9 @@ mcp:
 
 | Option               | Default    | Description                     |
 | -------------------- | ---------- | ------------------------------- |
-| `enabled`            | `false`    | Enable the MCP server endpoint  |
+| `enabled`            | `true`     | Enable the MCP server endpoint  |
 | `base_path`          | `/mcp`     | URL path for MCP endpoints      |
-| `session_timeout`    | `3600s`    | Session timeout for connections |
+| `session_timeout`    | `30m`      | Session timeout for connections |
 | `max_message_size`   | `10485760` | Maximum request size in bytes   |
 | `rate_limit_per_min` | `100`      | Requests per minute per client  |
 | `allowed_tools`      | `[]`       | Whitelist of allowed tools      |

--- a/docs/src/content/docs/guides/mcp/integration-guide.md
+++ b/docs/src/content/docs/guides/mcp/integration-guide.md
@@ -245,7 +245,7 @@ Function executed successfully. The welcome email has been sent to user@example.
 
 **Claude**: Let me check the storage.
 
-_Uses `list_files` tool_
+_Uses `list_objects` tool_
 
 Found 3 files in the uploads bucket:
 
@@ -259,7 +259,7 @@ Found 3 files in the uploads bucket:
 
 **Claude**: I'll search your knowledge base.
 
-_Uses `vector_search` tool_
+_Uses `search_vectors` tool_
 
 Found 3 relevant documents:
 
@@ -269,34 +269,39 @@ Found 3 relevant documents:
 
 ## Available Tools
 
+The MCP server exposes 46 built-in tools. The most common ones:
+
 | Tool              | Scope Required      | Description             |
 | ----------------- | ------------------- | ----------------------- |
-| `query_table`     | `read:tables`       | Query database tables   |
-| `insert_record`   | `write:tables`      | Create new records      |
-| `update_record`   | `write:tables`      | Update existing records |
-| `delete_record`   | `write:tables`      | Delete records          |
-| `invoke_function` | `execute:functions` | Call edge functions     |
-| `invoke_rpc`      | `execute:rpc`       | Execute SQL procedures  |
-| `list_files`      | `read:storage`      | List storage files      |
-| `download_file`   | `read:storage`      | Get file contents       |
-| `upload_file`     | `write:storage`     | Upload files            |
-| `delete_file`     | `write:storage`     | Remove files            |
+| `query_table`     | `tables:read`       | Query database tables   |
+| `insert_record`   | `tables:write`      | Create new records      |
+| `update_record`   | `tables:write`      | Update existing records |
+| `delete_record`   | `tables:write`      | Delete records          |
+| `invoke_function` | `functions:execute` | Call edge functions     |
+| `invoke_rpc`      | `rpc:execute`       | Execute SQL procedures  |
+| `list_objects`    | `storage:read`      | List storage objects    |
+| `download_object` | `storage:read`      | Get object contents     |
+| `upload_object`   | `storage:write`     | Upload objects          |
+| `delete_object`   | `storage:write`     | Remove objects          |
 | `submit_job`      | `execute:jobs`      | Start background jobs   |
 | `get_job_status`  | `execute:jobs`      | Check job status        |
-| `vector_search`   | `read:vectors`      | Similarity search       |
+| `search_vectors`  | `read:vectors`      | Similarity search       |
+
+See the full [Tools Reference](/guides/mcp/tools/) for all 46 tools (including DDL, branching, knowledge-graph, sync, `think`, and `http_request`).
 
 ## Available Resources
 
 Resources provide context information to the AI:
 
-| Resource                  | Description                 |
-| ------------------------- | --------------------------- |
-| `schema://tables`         | Database schema information |
-| `schema://tables/{table}` | Specific table structure    |
-| `functions://list`        | Deployed edge functions     |
-| `functions://{name}`      | Function details            |
-| `storage://buckets`       | Storage bucket list         |
-| `rpc://list`              | Available RPC procedures    |
+| Resource                                  | Description                 |
+| ----------------------------------------- | --------------------------- |
+| `fluxbase://schema/tables`                | Database schema information |
+| `fluxbase://schema/tables/{schema}/{table}` | Specific table structure  |
+| `fluxbase://functions`                    | Deployed edge functions     |
+| `fluxbase://storage/buckets`              | Storage bucket list         |
+| `fluxbase://rpc`                          | Available RPC procedures    |
+
+See [Resources](/guides/mcp/resources/) for details.
 
 ## Troubleshooting
 

--- a/docs/src/content/docs/guides/mcp/tools.md
+++ b/docs/src/content/docs/guides/mcp/tools.md
@@ -1,17 +1,82 @@
 ---
 title: "Tools Reference"
-description: "Complete reference of MCP tools for database, storage, functions, and jobs"
+description: "Complete reference of the 46 built-in MCP tools across database, DDL, storage, functions, jobs, vectors, knowledge graph, branching, GitHub, sync, and utility domains"
 ---
 
-The MCP server provides 12 tools for interacting with Fluxbase.
+The MCP server exposes **46 built-in tools** for interacting with Fluxbase. Each tool requires one or more [scopes](/guides/mcp/) granted to the calling client.
+
+## Tool Index
+
+| Tool | Scope | Description |
+|------|-------|-------------|
+| **Database** | | |
+| `query_table` | `tables:read` | Query a table with filters, ordering, pagination |
+| `insert_record` | `tables:write` | Insert a new record |
+| `update_record` | `tables:write` | Update records matching a filter |
+| `delete_record` | `tables:write` | Delete records matching a filter |
+| `execute_sql` | `execute:sql` | Run a read-only SQL query |
+| **DDL** | | |
+| `list_schemas` | `tables:read` | List database schemas |
+| `create_schema` | `admin:ddl` | Create a new schema |
+| `create_table` | `admin:ddl` | Create a table with columns |
+| `drop_table` | `admin:ddl` | Drop a table |
+| `rename_table` | `admin:ddl` | Rename a table |
+| `add_column` | `admin:ddl` | Add a column to a table |
+| `drop_column` | `admin:ddl` | Drop a column from a table |
+| **Storage** | | |
+| `list_objects` | `storage:read` | List objects in a bucket |
+| `download_object` | `storage:read` | Download a file |
+| `upload_object` | `storage:write` | Upload a file |
+| `delete_object` | `storage:write` | Delete a file |
+| **Functions & RPC** | | |
+| `invoke_function` | `functions:execute` | Invoke an edge function |
+| `invoke_rpc` | `rpc:execute` | Invoke an RPC procedure |
+| **Jobs** | | |
+| `submit_job` | `execute:jobs` | Submit a background job |
+| `get_job_status` | `execute:jobs` | Get job status |
+| **Vectors** | | |
+| `search_vectors` | `read:vectors` | Semantic similarity search |
+| **Knowledge Graph** | | |
+| `query_knowledge_graph` | `read:vectors` | Query entities with filters |
+| `browse_knowledge_graph` | `read:vectors` | Browse the full knowledge graph |
+| `find_related_entities` | `read:vectors` | Find entities related to a given entity |
+| **Branching — Access** | | |
+| `list_branches` | `branch:read` | List branches |
+| `get_branch` | `branch:read` | Get branch details |
+| `get_active_branch` | `branch:read` | Get the active branch |
+| `grant_branch_access` | `branch:access` | Grant a user branch access |
+| `revoke_branch_access` | `branch:access` | Revoke branch access |
+| **Branching — Lifecycle** | | |
+| `create_branch` | `branch:write` | Create a new branch |
+| `delete_branch` | `branch:write` | Delete a branch |
+| `reset_branch` | `branch:write` | Reset a branch to its template |
+| `set_active_branch` | `branch:write` | Set the active branch |
+| **GitHub** | | |
+| `list_github_issues` | `github:read` | List issues in a repository |
+| `get_github_issue` | `github:read` | Get issue details |
+| `create_github_issue` | `github:write` | Create an issue |
+| `create_github_issue_comment` | `github:write` | Comment on an issue |
+| `update_github_issue_labels` | `github:write` | Add/remove issue labels |
+| `trigger_claude_fix` | `github:write` | Trigger Claude Fix automation |
+| **Sync** | | |
+| `sync_chatbot` | `sync:chatbots` | Create/update a chatbot from code |
+| `sync_function` | `sync:functions` | Deploy/update an edge function |
+| `sync_job` | `sync:jobs` | Create/update a background job |
+| `sync_rpc` | `sync:rpc` | Create/update an RPC procedure |
+| `sync_migration` | `sync:migrations` | Create/apply a migration |
+| **Utility** | | |
+| `think` | _(none)_ | Plan an investigation before acting |
+| `http_request` | `execute:http` | HTTP GET to a whitelisted domain |
+
+:::note[Tool availability]
+Custom tools (see [Custom MCP Tools](/guides/mcp/custom-mcp-tools/)) are registered in the same registry and appear alongside these built-in tools. Tools can be restricted globally via `mcp.allowed_tools`.
+:::
 
 ## Database Tools
 
 ### query_table
 
-Query a database table with filters, ordering, and pagination.
-
-**Scope Required:** `read:tables`
+Query a database table with filters, ordering, and pagination. **Scope:** `tables:read`
 
 ```json
 {
@@ -30,34 +95,18 @@ Query a database table with filters, ordering, and pagination.
 }
 ```
 
-**Filter Operators:**
-- `eq` - Equals
-- `neq` - Not equals
-- `gt` - Greater than
-- `gte` - Greater than or equal
-- `lt` - Less than
-- `lte` - Less than or equal
-- `like` - Pattern match (case-sensitive)
-- `ilike` - Pattern match (case-insensitive)
-- `is` - IS NULL/NOT NULL
-- `in` - In array
+**Filter operators:** `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `like`, `ilike`, `is`, `in`.
 
 ### insert_record
 
-Insert a new record into a table.
-
-**Scope Required:** `write:tables`
+Insert a new record. **Scope:** `tables:write`
 
 ```json
 {
   "name": "insert_record",
   "arguments": {
     "table": "public.products",
-    "data": {
-      "name": "Widget",
-      "price": 29.99,
-      "category": "electronics"
-    },
+    "data": { "name": "Widget", "price": 29.99, "category": "electronics" },
     "returning": "id,created_at"
   }
 }
@@ -65,95 +114,109 @@ Insert a new record into a table.
 
 ### update_record
 
-Update records matching a filter.
-
-**Scope Required:** `write:tables`
+Update records matching a filter. **Scope:** `tables:write`
 
 ```json
 {
   "name": "update_record",
   "arguments": {
     "table": "public.products",
-    "data": {
-      "price": 24.99
-    },
-    "filter": {
-      "id": "eq.123"
-    },
+    "data": { "price": 24.99 },
+    "filter": { "id": "eq.123" },
     "returning": "id,price,updated_at"
   }
 }
 ```
 
-**Note:** The `filter` parameter is required to prevent accidental bulk updates.
+:::warning
+The `filter` parameter is required to prevent accidental bulk updates.
+:::
 
 ### delete_record
 
-Delete records matching a filter.
-
-**Scope Required:** `write:tables`
+Delete records matching a filter. **Scope:** `tables:write`
 
 ```json
 {
   "name": "delete_record",
   "arguments": {
     "table": "public.products",
-    "filter": {
-      "id": "eq.123"
-    },
+    "filter": { "id": "eq.123" },
     "returning": "id"
   }
 }
 ```
 
-**Note:** The `filter` parameter is required to prevent accidental bulk deletes.
+:::warning
+The `filter` parameter is required to prevent accidental bulk deletes.
+:::
+
+### execute_sql
+
+Run a read-only SQL query against the database. Only `SELECT` queries are allowed by default. **Scope:** `execute:sql`
+
+```json
+{
+  "name": "execute_sql",
+  "arguments": {
+    "sql": "SELECT count(*) FROM public.users WHERE created_at > now() - interval '7 days'",
+    "description": "Count new users in the last 7 days"
+  }
+}
+```
+
+`sql` and `description` are both required (the description explains the query's intent).
+
+## DDL Tools
+
+All DDL tools (except `list_schemas`) require the `admin:ddl` scope.
+
+### create_table
+
+Create a new table with the given columns. **Scope:** `admin:ddl`
+
+```json
+{
+  "name": "create_table",
+  "arguments": {
+    "name": "public.tasks",
+    "columns": [
+      { "name": "id", "type": "uuid", "primary_key": true, "default": "gen_random_uuid()" },
+      { "name": "title", "type": "text", "nullable": false },
+      { "name": "done", "type": "boolean", "default": "false" }
+    ]
+  }
+}
+```
+
+`drop_table`, `rename_table`, `add_column` (requires `table`, `name`, `type`), and `drop_column` follow the same shape. `list_schemas` takes no arguments (`tables:read`).
 
 ## Storage Tools
 
 ### list_objects
 
-List objects in a storage bucket.
-
-**Scope Required:** `read:storage`
+List objects in a bucket. **Scope:** `storage:read`
 
 ```json
 {
   "name": "list_objects",
-  "arguments": {
-    "bucket": "uploads",
-    "prefix": "images/",
-    "limit": 100,
-    "start_after": "images/file099.jpg"
-  }
+  "arguments": { "bucket": "uploads", "prefix": "images/", "limit": 100, "start_after": "images/file099.jpg" }
 }
 ```
 
 ### download_object
 
-Download a file from storage.
-
-**Scope Required:** `read:storage`
+Download a file. **Scope:** `storage:read`
 
 ```json
-{
-  "name": "download_object",
-  "arguments": {
-    "bucket": "uploads",
-    "key": "documents/report.pdf"
-  }
-}
+{ "name": "download_object", "arguments": { "bucket": "uploads", "key": "documents/report.pdf" } }
 ```
 
-**Notes:**
-- Text files are returned as-is
-- Binary files are returned as base64
-- Maximum file size: 10MB
+Text files are returned as-is; binary files are returned base64-encoded (max 10MB).
 
 ### upload_object
 
-Upload a file to storage.
-
-**Scope Required:** `write:storage`
+Upload a file. **Scope:** `storage:write`
 
 ```json
 {
@@ -168,33 +231,21 @@ Upload a file to storage.
 }
 ```
 
-**Encoding Options:**
-- `text` - Plain text content
-- `base64` - Base64-encoded binary content
+`encoding` is `text` (plain) or `base64` (binary).
 
 ### delete_object
 
-Delete a file from storage.
-
-**Scope Required:** `write:storage`
+Delete a file. **Scope:** `storage:write`
 
 ```json
-{
-  "name": "delete_object",
-  "arguments": {
-    "bucket": "uploads",
-    "key": "documents/old-report.pdf"
-  }
-}
+{ "name": "delete_object", "arguments": { "bucket": "uploads", "key": "documents/old-report.pdf" } }
 ```
 
-## Function Tools
+## Function & RPC Tools
 
 ### invoke_function
 
-Invoke an edge function.
-
-**Scope Required:** `execute:functions`
+Invoke an edge function. **Scope:** `functions:execute`
 
 ```json
 {
@@ -203,65 +254,32 @@ Invoke an edge function.
     "name": "send-email",
     "namespace": "default",
     "method": "POST",
-    "body": {
-      "to": "user@example.com",
-      "subject": "Hello",
-      "body": "Message content"
-    },
-    "headers": {
-      "X-Custom-Header": "value"
-    }
+    "body": { "to": "user@example.com", "subject": "Hello" },
+    "headers": { "X-Custom-Header": "value" }
   }
 }
 ```
 
-**Response:**
-
-```json
-{
-  "status": 200,
-  "headers": {"content-type": "application/json"},
-  "body": {"success": true},
-  "execution_id": "exec-123"
-}
-```
+**Response:** `{ "status", "headers", "body", "execution_id" }`.
 
 ### invoke_rpc
 
-Execute an RPC procedure.
-
-**Scope Required:** `execute:rpc`
+Invoke an RPC procedure. **Scope:** `rpc:execute`
 
 ```json
 {
   "name": "invoke_rpc",
-  "arguments": {
-    "name": "calculate_total",
-    "namespace": "default",
-    "params": {
-      "order_id": "ord-123"
-    }
-  }
+  "arguments": { "name": "calculate_total", "namespace": "default", "params": { "order_id": "ord-123" } }
 }
 ```
 
-**Response:**
-
-```json
-{
-  "data": [{"total": 149.99}],
-  "rows_returned": 1,
-  "duration_ms": 15
-}
-```
+**Response:** `{ "data", "rows_returned", "duration_ms" }`.
 
 ## Job Tools
 
 ### submit_job
 
-Submit a background job.
-
-**Scope Required:** `execute:jobs`
+Submit a background job. **Scope:** `execute:jobs`
 
 ```json
 {
@@ -269,60 +287,26 @@ Submit a background job.
   "arguments": {
     "job_name": "process-report",
     "namespace": "default",
-    "payload": {
-      "report_id": "rpt-123",
-      "format": "pdf"
-    },
+    "payload": { "report_id": "rpt-123", "format": "pdf" },
     "priority": 5,
     "scheduled_at": "2024-01-15T10:00:00Z"
   }
 }
 ```
 
-**Response:**
-
-```json
-{
-  "job_id": "job-456",
-  "created_at": "2024-01-15T09:00:00Z"
-}
-```
-
 ### get_job_status
 
-Get the status of a background job.
-
-**Scope Required:** `execute:jobs`
+Get the status of a background job. **Scope:** `execute:jobs`
 
 ```json
-{
-  "name": "get_job_status",
-  "arguments": {
-    "job_id": "job-456"
-  }
-}
-```
-
-**Response:**
-
-```json
-{
-  "status": "completed",
-  "attempts": 1,
-  "started_at": "2024-01-15T10:00:00Z",
-  "completed_at": "2024-01-15T10:00:15Z",
-  "result": {"output": "Report generated"},
-  "progress": 100
-}
+{ "name": "get_job_status", "arguments": { "job_id": "job-456" } }
 ```
 
 ## Vector Search Tools
 
 ### search_vectors
 
-Perform semantic similarity search.
-
-**Scope Required:** `read:vectors`
+Perform semantic similarity search. **Scope:** `read:vectors`
 
 ```json
 {
@@ -338,154 +322,105 @@ Perform semantic similarity search.
 }
 ```
 
-**Response:**
+## Knowledge Graph Tools
+
+All knowledge-graph tools require the `read:vectors` scope and take a `knowledge_base_id`.
+
+### query_knowledge_graph
+
+Query entities with optional filtering by entity type and a search query.
 
 ```json
 {
-  "results": [
-    {
-      "content": "To reset your password, click...",
-      "similarity": 0.92,
-      "metadata": {"source": "faq.md"}
-    }
-  ]
+  "name": "query_knowledge_graph",
+  "arguments": { "knowledge_base_id": "kb-123", "type": "person", "search": "Ada" }
 }
 ```
 
+`browse_knowledge_graph` returns the full graph for a knowledge base; `find_related_entities` returns entities related to a given entity (requires `knowledge_base_id` and `entity_id`).
+
+## Branching Tools
+
+### create_branch
+
+Create an isolated database branch. **Scope:** `branch:write`
+
+```json
+{
+  "name": "create_branch",
+  "arguments": {
+    "name": "feature-x",
+    "parent_branch_id": "main",
+    "data_clone_mode": "schema_only"
+  }
+}
+```
+
+`delete_branch` and `reset_branch` take `branch_id` or `slug` (`branch:write`). `list_branches`, `get_branch`, and `get_active_branch` are read-only (`branch:read`). `set_active_branch` (`branch:write`) takes a branch id/slug. `grant_branch_access` and `revoke_branch_access` (`branch:access`) manage per-user branch grants.
+
 ## GitHub Tools
 
-Tools for interacting with GitHub issues and pull requests. Requires a GitHub token to be configured.
+Require a configured GitHub token. Listing and reading use `github:read`; creating, commenting, relabeling, and triggering use `github:write`.
 
 ### list_github_issues
-
-List issues in a repository with filtering options.
-
-**Scope Required:** `github:read`
 
 ```json
 {
   "name": "list_github_issues",
-  "arguments": {
-    "repository": "owner/repo",
-    "state": "open",
-    "labels": "bug,priority:high",
-    "assignee": "username",
-    "limit": 30
-  }
+  "arguments": { "repository": "owner/repo", "state": "open", "labels": "bug,priority:high", "limit": 30 }
 }
 ```
 
-**Response:**
+Other GitHub tools: `get_github_issue`, `create_github_issue`, `create_github_issue_comment`, `update_github_issue_labels`, and `trigger_claude_fix` (adds the `claude-fix` label to kick off automation).
 
-```json
-[
-  {
-    "number": 42,
-    "title": "Fix authentication bug",
-    "state": "open",
-    "labels": ["bug", "priority:high"],
-    "assignees": ["developer"],
-    "html_url": "https://github.com/..."
-  }
-]
-```
+## Sync Tools
 
-### get_github_issue
+Deploy or update definitions from code. Each parses `@fluxbase:` annotations from the supplied code.
 
-Get details of a specific issue.
-
-**Scope Required:** `github:read`
+| Tool | Scope | Required args |
+|------|-------|---------------|
+| `sync_function` | `sync:functions` | `name`, `code` |
+| `sync_job` | `sync:jobs` | `name`, `code` (with `@fluxbase:schedule`) |
+| `sync_chatbot` | `sync:chatbots` | `name`, `code` |
+| `sync_rpc` | `sync:rpc` | `name`, `sql_code` |
+| `sync_migration` | `sync:migrations` | `name`, `up_sql` |
 
 ```json
 {
-  "name": "get_github_issue",
-  "arguments": {
-    "repository": "owner/repo",
-    "issue_number": 42
-  }
+  "name": "sync_function",
+  "arguments": { "name": "send-email", "code": "/** @fluxbase:public */ export default async () => { ... }" }
 }
 ```
 
-### create_github_issue
+`sync_migration` defaults to `auto_apply: false` and `dry_run: true` for safety.
 
-Create a new issue.
+## Utility Tools
 
-**Scope Required:** `github:write`
+### think
+
+Plan your investigation approach before executing queries — analyze the question, break it into steps, and choose tools. **No scope required** (always available).
 
 ```json
 {
-  "name": "create_github_issue",
-  "arguments": {
-    "repository": "owner/repo",
-    "title": "Bug: Login fails with special characters",
-    "body": "## Description\n\nLogin fails when...",
-    "labels": "bug,triage",
-    "assignees": "developer"
-  }
+  "name": "think",
+  "arguments": { "analysis": "...", "plan": "...", "tool_choice": "..." }
 }
 ```
 
-### create_github_issue_comment
+`analysis`, `plan`, and `tool_choice` are all required.
 
-Add a comment to an issue.
+### http_request
 
-**Scope Required:** `github:write`
+Make an HTTP GET request to an external API. Only domains whitelisted for the current context are permitted; JSON responses only. **Scope:** `execute:http`
 
 ```json
 {
-  "name": "create_github_issue_comment",
-  "arguments": {
-    "repository": "owner/repo",
-    "issue_number": 42,
-    "body": "I've investigated this issue and found..."
-  }
+  "name": "http_request",
+  "arguments": { "url": "https://api.example.com/data", "headers": { "Accept": "application/json" } }
 }
 ```
 
-### update_github_issue_labels
-
-Add or remove labels from an issue.
-
-**Scope Required:** `github:write`
-
-```json
-{
-  "name": "update_github_issue_labels",
-  "arguments": {
-    "repository": "owner/repo",
-    "issue_number": 42,
-    "add_labels": "in-progress,assigned",
-    "remove_labels": "triage"
-  }
-}
-```
-
-### trigger_claude_fix
-
-Trigger the Claude Fix automation for an issue by adding the `claude-fix` label.
-
-**Scope Required:** `github:write`
-
-```json
-{
-  "name": "trigger_claude_fix",
-  "arguments": {
-    "repository": "owner/repo",
-    "issue_number": 42
-  }
-}
-```
-
-**Response:**
-
-```json
-{
-  "status": "triggered",
-  "issue_number": 42,
-  "repository": "owner/repo",
-  "message": "Claude fix workflow triggered..."
-}
-```
+`url` is required.
 
 ## Error Handling
 
@@ -493,20 +428,16 @@ All tools return errors in a consistent format:
 
 ```json
 {
-  "content": [
-    {
-      "type": "text",
-      "text": "Error message here"
-    }
-  ],
+  "content": [{ "type": "text", "text": "Error message here" }],
   "isError": true
 }
 ```
 
 Common error codes:
-- `-32002` - Resource not found
-- `-32003` - Tool not found
-- `-32004` - Tool execution error
-- `-32005` - Unauthorized
-- `-32006` - Forbidden
-- `-32007` - Rate limited
+
+- `-32002` — Resource not found
+- `-32003` — Tool not found
+- `-32004` — Tool execution error
+- `-32005` — Unauthorized
+- `-32006` — Forbidden
+- `-32007` — Rate limited

--- a/docs/src/content/docs/guides/monitoring-observability.md
+++ b/docs/src/content/docs/guides/monitoring-observability.md
@@ -116,19 +116,20 @@ curl http://localhost:8080/api/v1/monitoring/metrics -H "Authorization: Bearer T
 
 ## Health Checks
 
-Endpoint: `/api/v1/monitoring/health`
+Endpoint: `/api/v1/monitoring/health` — requires authentication and the `monitoring:read` scope.
 
 ```bash
-curl http://localhost:8080/api/v1/monitoring/health
+curl -H "Authorization: Bearer <service-key>" \
+     http://localhost:8080/api/v1/monitoring/health
 ```
 
 Returns `200 OK` if healthy, `503` if unhealthy. Checks database, realtime, and storage services.
 
-**Docker Compose:**
+**Docker Compose healthcheck:** use the public, unauthenticated `/health` endpoint (the `/monitoring/health` endpoint requires auth and will fail a bare healthcheck):
 
 ```yaml
 healthcheck:
-  test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/monitoring/health"]
+  test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
   interval: 30s
   timeout: 5s
   retries: 3

--- a/docs/src/content/docs/guides/multi-tenancy.md
+++ b/docs/src/content/docs/guides/multi-tenancy.md
@@ -292,6 +292,27 @@ await client.tenant.repair(tenant.id);
 await client.tenant.migrate(tenant.id);
 ```
 
+### Members & Admins
+
+```typescript
+// List tenant admins
+const { data: admins } = await client.tenant.listAdmins(tenant.id);
+
+// Assign / remove an admin
+await client.tenant.assignAdmin(tenant.id, { user_id: "..." });
+await client.tenant.removeAdmin(tenant.id, userId);
+```
+
+General membership is managed over HTTP:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/admin/tenants/:id/members` | List members |
+| `POST` | `/admin/tenants/:id/members` | Add a member |
+| `DELETE` | `/admin/tenants/:id/members/:user_id` | Remove a member |
+
+Tenant settings also support single-key operations via `GET` and `DELETE /admin/tenants/:id/settings/*` (in addition to the bulk `GET`/`PATCH`).
+
 ### Service Key Management
 
 ```typescript

--- a/docs/src/content/docs/guides/oauth-providers.md
+++ b/docs/src/content/docs/guides/oauth-providers.md
@@ -34,6 +34,10 @@ Fluxbase includes built-in support for well-known providers and custom OIDC prov
 | Authelia           | Custom OIDC | Requires `issuer_url` |
 | Any OIDC Provider  | Custom OIDC | Requires `issuer_url` |
 
+:::note[`issuer_url` requirement]
+Config validation currently requires `issuer_url` for all providers **except** Google, Apple, and Microsoft. Even for providers Fluxbase knows about (GitHub, GitLab, Bitbucket, Facebook, Twitter/X, LinkedIn), supply `issuer_url` (or the provider's OAuth endpoints) — otherwise config validation rejects the provider.
+:::
+
 ### Provider-Specific Configuration
 
 Each OAuth provider has different requirements for scopes and refresh tokens:

--- a/docs/src/content/docs/guides/oauth-providers.md
+++ b/docs/src/content/docs/guides/oauth-providers.md
@@ -189,6 +189,9 @@ FLUXBASE_AUTH_OAUTH_PROVIDERS_2_CLIENT_SECRET=your-keycloak-secret
 | `/api/v1/auth/oauth/providers`           | GET    | List available OAuth providers (public)     |
 | `/api/v1/auth/oauth/:provider/authorize` | GET    | Initiate OAuth flow (redirects to provider) |
 | `/api/v1/auth/oauth/:provider/callback`  | GET    | OAuth callback handler                      |
+| `/api/v1/auth/oauth/:provider/token`     | GET    | Retrieve the provider access token (authenticated) |
+| `/api/v1/auth/oauth/:provider/logout`    | POST   | Initiate provider-side logout (OIDC/RP)     |
+| `/api/v1/auth/oauth/:provider/logout/callback` | GET | OAuth logout callback                  |
 | `/api/v1/admin/oauth/providers`          | GET    | List all providers (admin)                  |
 | `/api/v1/admin/oauth/providers`          | POST   | Create new provider (admin)                 |
 | `/api/v1/admin/oauth/providers/:id`      | PUT    | Update provider (admin)                     |

--- a/docs/src/content/docs/guides/rate-limiting.md
+++ b/docs/src/content/docs/guides/rate-limiting.md
@@ -373,7 +373,7 @@ When creating client keys, you can set custom rate limits:
 
 ```bash
 # Create API key with custom rate limit
-curl -X POST http://localhost:8080/api/v1/admin/client-keys \
+curl -X POST http://localhost:8080/api/v1/client-keys \
   -H "Authorization: Bearer admin-token" \
   -H "Content-Type: application/json" \
   -d '{
@@ -601,7 +601,7 @@ For integrations requiring high throughput:
 
 ```bash
 # Create API key with appropriate limits
-curl -X POST /api/v1/admin/client-keys \
+curl -X POST /api/v1/client-keys \
   -d '{"name": "Partner API", "rate_limit_rpm": 5000}'
 ```
 
@@ -624,7 +624,7 @@ curl -X POST /api/v1/admin/client-keys \
 
 ```bash
 # Create API key with higher limit
-curl -X POST /api/v1/admin/client-keys \
+curl -X POST /api/v1/client-keys \
   -H "Authorization: Bearer admin-token" \
   -d '{"name": "High Traffic Client", "rate_limit_rpm": 10000}'
 ```
@@ -696,7 +696,7 @@ Rate limiting adds minimal overhead:
 - **In-memory storage**: < 1ms per request
 - **Memory usage**: ~100 bytes per unique key
 
-**Note**: Fluxbase rate limiting is **in-memory only and per-instance**. There is no Redis or external storage backend. In multi-instance deployments, each instance maintains independent rate limit counters. Use a reverse proxy or API gateway for centralized rate limiting (see [Multi-Instance Deployments](#multi-instance-deployments)).
+**Note**: Fluxbase rate limiting supports three storage backends: `local` (in-memory, per-instance, default), `postgres`, and `redis` (also Dragonfly). For multi-instance deployments, set `scaling.backend: postgres` or `redis` so all instances share counters — a reverse proxy / API gateway is then **not** required for centralized limiting (see [Multi-Instance Deployments](#multi-instance-deployments)).
 
 **Benchmarks** (single instance):
 

--- a/docs/src/content/docs/guides/realtime.md
+++ b/docs/src/content/docs/guides/realtime.md
@@ -556,14 +556,7 @@ const anonChannel = client.realtime
 
 ### Rate Limiting
 
-Presence tracking is subject to rate limits:
-
-```yaml
-realtime:
-  presence:
-    max_presences_per_channel: 1000  # Max users tracking presence in a channel
-    max_channels_per_connection: 10   # Max presence channels per connection
-```
+Presence tracking is subject to the connection limits in [Configuration](/reference/configuration/#realtime) (`max_connections`, `max_connections_per_user`, `max_connections_per_ip`). There are no `realtime.presence.*` config keys.
 
 ## Security
 

--- a/docs/src/content/docs/guides/row-level-security.md
+++ b/docs/src/content/docs/guides/row-level-security.md
@@ -179,7 +179,7 @@ Background job processing. Users can view, submit, and cancel their own jobs. Da
 
 #### migrations
 
-Internal migration tracking. System migrations are tracked in `migrations.fluxbase`. All user-facing migrations (filesystem and API-managed) are tracked in `migrations.app` with different namespaces (`filesystem` for local files, custom namespaces for API). Only the service role has access. This schema is not exposed to regular users.
+Internal migration tracking. Internal declarative-schema state is tracked in `platform.declarative_state`; all user-facing migrations (filesystem and API-managed) are tracked in `platform.migrations` with different namespaces (`filesystem` for local files, custom namespaces for API). Only the service role has access. This schema is not exposed to regular users.
 
 #### public
 
@@ -610,5 +610,5 @@ const allUsers = await adminClient.from("users").select("*");
 ## Related Documentation
 
 - [Authentication](/guides/authentication) - JWT tokens and roles
-- [SDK Reference](/api/sdk/) - Table management and querying
+- [SDK Reference](/api/sdk/readme/) - Table management and querying
 - [Security](/security/overview) - Overall security best practices

--- a/docs/src/content/docs/guides/rpc.md
+++ b/docs/src/content/docs/guides/rpc.md
@@ -64,6 +64,8 @@ OFFSET COALESCE($offset, 0);
 | `@fluxbase:require-role`       | Required role to execute (e.g., `authenticated`, `admin`) | None     |
 | `@fluxbase:public`             | Show in public procedure list                             | `false`  |
 | `@fluxbase:version`            | Procedure version number                                  | `1`      |
+| `@fluxbase:schedule`           | Cron expression to execute on a schedule (e.g. `0 * * * *`) | None  |
+| `@fluxbase:disable-execution-logs` | Disable verbose step-by-step execution logging       | `false`  |
 
 ### Schema Types
 
@@ -165,6 +167,20 @@ console.log("Final result:", final.result);
 ```
 
 > **Note:** Even with `@fluxbase:disable-execution-logs` enabled, async executions will still create execution records so that `getStatus()` works. The flag only disables the verbose step-by-step log messages.
+
+### Scheduled Execution (Cron)
+
+Add a `@fluxbase:schedule` annotation with a standard cron expression and the procedure runs automatically on that schedule. Scheduled procedures are registered with the RPC scheduler when synced and re-registered on server restart.
+
+```sql
+-- @fluxbase:name nightly-rollup
+-- @fluxbase:schedule 0 2 * * *
+-- @fluxbase:input {"date?": "date"}
+
+SELECT rollup_for_day(COALESCE($date, current_date - 1));
+```
+
+Update or remove the annotation and re-sync to change or stop the schedule. Scheduler-triggered executions appear alongside manual ones in [Monitoring Executions](#monitoring-executions) and the execution logs.
 
 ### Execution Logs
 
@@ -370,12 +386,14 @@ JOIN products ON order_items.product_id = products.id;
 
 | Variable                                  | Description                   | Default |
 | ----------------------------------------- | ----------------------------- | ------- |
-| `FLUXBASE_RPC_ENABLED`                    | Enable RPC functionality      | `true`  |
-| `FLUXBASE_RPC_PROCEDURES_DIR`             | Directory for procedure files | `./rpc` |
-| `FLUXBASE_RPC_AUTO_LOAD_ON_BOOT`          | Load procedures on startup    | `true`  |
-| `FLUXBASE_RPC_DEFAULT_MAX_EXECUTION_TIME` | Default timeout               | `30s`   |
-| `FLUXBASE_RPC_MAX_MAX_EXECUTION_TIME`     | Maximum allowed timeout       | `5m`    |
-| `FLUXBASE_RPC_DEFAULT_MAX_ROWS`           | Default max rows returned     | `1000`  |
+| `FLUXBASE_RPC_ENABLED`           | Enable RPC functionality      | `true`  |
+| `FLUXBASE_RPC_PROCEDURES_DIR`    | Directory for procedure files | `./rpc` |
+| `FLUXBASE_RPC_AUTO_LOAD_ON_BOOT` | Load procedures on startup    | `true`  |
+| `FLUXBASE_RPC_DEFAULT_MAX_ROWS`  | Default max rows returned     | `1000`  |
+
+:::note
+Per-procedure execution-time limits are set via the `@fluxbase:max-execution-time` annotation (default `30s`), not a global config key.
+:::
 
 ## Examples
 

--- a/docs/src/content/docs/guides/rpc.md
+++ b/docs/src/content/docs/guides/rpc.md
@@ -315,6 +315,7 @@ await client.admin.rpc.cancelExecution("execution-uuid");
 | `POST`   | `/api/v1/admin/rpc/sync`                        | Sync procedures     |
 | `GET`    | `/api/v1/admin/rpc/executions`                  | List executions     |
 | `GET`    | `/api/v1/admin/rpc/executions/:id`              | Get execution       |
+| `POST`   | `/api/v1/admin/rpc/executions/:id/cancel`       | Cancel execution    |
 | `GET`    | `/api/v1/admin/rpc/executions/:id/logs`         | Get execution logs  |
 
 ### Invoke Request

--- a/docs/src/content/docs/guides/storage.md
+++ b/docs/src/content/docs/guides/storage.md
@@ -21,7 +21,7 @@ Fluxbase provides file storage supporting local filesystem or S3-compatible stor
 storage:
   provider: "local" # or "s3"
   local_path: "./storage"
-  max_upload_size: 10485760 # 10MB
+  max_upload_size: 2147483648 # 2GB (default)
 
   # S3 Configuration (when provider: "s3")
   s3_endpoint: "s3.amazonaws.com"
@@ -36,7 +36,7 @@ storage:
 ```bash
 FLUXBASE_STORAGE_PROVIDER=local  # or s3
 FLUXBASE_STORAGE_LOCAL_PATH=./storage
-FLUXBASE_STORAGE_MAX_UPLOAD_SIZE=10485760
+FLUXBASE_STORAGE_MAX_UPLOAD_SIZE=2147483648
 
 # S3 Configuration
 FLUXBASE_STORAGE_S3_ENDPOINT=s3.amazonaws.com
@@ -478,27 +478,9 @@ fluxbase server
 
 ### Secret Management Systems (Recommended for Production)
 
-#### HashiCorp Vault
-
-```yaml
-# fluxbase.yaml
-storage:
-  provider: "s3"
-  s3_endpoint: "{{ vault `secret/storage/s3#endpoint` }}"
-  s3_access_key: "{{ vault `secret/storage/s3#access_key` }}"
-  s3_secret_key: "{{ vault `secret/storage/s3#secret_key` }}"
-```
-
-#### AWS Secrets Manager
-
-```yaml
-# fluxbase.yaml
-storage:
-  provider: "s3"
-  s3_endpoint: "{{ aws_secret `fluxbase/storage/s3_endpoint` }}"
-  s3_access_key: "{{ aws_secret `fluxbase/storage/access_key` }}"
-  s3_secret_key: "{{ aws_secret `fluxbase/storage/secret_key` }}"
-```
+:::note
+Fluxbase does **not** support inline secret templating (e.g. `{{ vault ... }}`) in `fluxbase.yaml`. Inject credentials via environment variables (loaded from `.env`), your orchestrator's secret mechanism (Docker Secrets, Kubernetes Secrets), or IAM roles.
+:::
 
 #### Docker Secrets
 
@@ -572,114 +554,9 @@ Regularly rotate S3 credentials:
 
 Automation tools like AWS Secrets Manager or HashiCorp Vault can automate this process.
 
-## Malware Scanning Integration
+## Malware Scanning
 
-Fluxbase supports integration with malware scanning services to automatically scan uploaded files for viruses, malware, and malicious content.
-
-### ClamAV (Self-Hosted)
-
-Install ClamAV and configure Fluxbase to scan files:
-
-```yaml
-# fluxbase.yaml
-storage:
-  malware_scanning:
-    enabled: true
-    provider: "clamav"
-    clamav_socket: "/var/run/clamav/clamd.ctl"
-    scan_on_upload: true
-    quarantine_infected: true
-    quarantine_bucket: "quarantine"
-```
-
-Install ClamAV:
-
-```bash
-# Ubuntu/Debian
-sudo apt-get install clamav clamav-daemon
-
-# Start ClamAV daemon
-sudo systemctl start clamav-daemon
-sudo systemctl enable clamav-daemon
-```
-
-### AWS Advanced Virus Protection
-
-For AWS S3 buckets, enable AWS Advanced Virus Protection:
-
-```yaml
-# fluxbase.yaml
-storage:
-  malware_scanning:
-    enabled: true
-    provider: "aws_avp"
-    aws_region: "us-east-1"
-    scan_on_upload: true
-    quarantine_infected: true
-```
-
-Enable in AWS S3:
-
-```bash
-# Enable AVP for S3 bucket
-aws s3api put-bucket-configuration \
-  --bucket my-app-storage \
-  --configuration '{
-    "AdvancedVirusProtectionConfiguration": {
-      "AdvancedVirusProtection": "Enabled"
-    }
-  }'
-```
-
-### VirusTotal API
-
-Use VirusTotal API for cloud-based scanning:
-
-```yaml
-# fluxbase.yaml
-storage:
-  malware_scanning:
-    enabled: true
-    provider: "virustotal"
-    virustotal_api_key: "${VIRUSTOTAL_API_KEY}"
-    scan_on_upload: true
-    quarantine_infected: true
-```
-
-Get API key from [VirusTotal Developer Portal](https://www.virustotal.com/).
-
-### Scanning Behavior
-
-When malware scanning is enabled:
-
-1. **Upload receives file** -> File stored temporarily
-2. **Scanner processes file** -> Asynchronous scan
-3. **Scan results:**
-   - **Clean**: File moved to permanent storage
-   - **Infected**: File moved to quarantine bucket, upload rejected
-   - **Error**: Configurable fail-open or fail-closed
-
-### Quarantine Management
-
-```bash
-# List quarantined files
-fluxbase-cli storage list --bucket quarantine
-
-# Download quarantined file for analysis
-fluxbase-cli storage download --bucket quarantine --path suspicious.exe
-
-# Delete quarantined files (after review)
-fluxbase-cli storage delete --bucket quarantine --path suspicious.exe
-```
-
-### Best Practices
-
-- **Enable in production**: Always scan files from untrusted sources
-- **Quarantine first**: Review quarantined files before permanent deletion
-- **Rate limiting**: Malware scanning can be slow, implement rate limiting
-- **Async scanning**: Consider async scanning for better UX
-- **False positives**: Whitelist known-safe files as needed
-- **Regular updates**: Keep ClamAV definitions updated
+Fluxbase does not include built-in malware scanning. For untrusted uploads, scan files in an edge function or job (e.g. calling ClamAV or a scanning API) before serving them.
 
 ## Error Handling
 
@@ -706,7 +583,38 @@ try {
 
 ## REST API
 
-For direct HTTP access without the SDK, see the [Storage SDK Documentation](/api/sdk/classes/fluxbasestorage/).
+All storage endpoints are under `/api/v1/storage`. Bucket and object operations require authentication and the `storage:read` / `storage:write` scopes.
+
+### Uploads
+
+| Mode | Method & Path | When to use |
+|------|---------------|-------------|
+| Simple | `POST /storage/{bucket}/{key}` | Typical uploads (request body is the file) |
+| Multipart | `POST /storage/{bucket}/multipart` | S3-style multipart uploads |
+| Streaming | `POST /storage/{bucket}/stream/{key}` | Large streamed request bodies |
+| Resumable (chunked) | `POST /storage/{bucket}/chunked/init` → `PUT /storage/{bucket}/chunked/{uploadId}/{chunkIndex}` → `POST /storage/{bucket}/chunked/{uploadId}/complete` | Very large files; resumable across dropped connections |
+
+Resumable uploads also expose `GET /storage/{bucket}/chunked/{uploadId}/status` (progress) and `DELETE /storage/{bucket}/chunked/{uploadId}` (abort).
+
+### Downloads
+
+`GET` or `HEAD` `/storage/{bucket}/{key}` downloads an object or fetches its metadata. `GET /storage/object` downloads via a signed-URL token (public, no auth header required).
+
+### Signed URLs
+
+`POST /storage/{bucket}/sign/{key}` generates a time-limited signed URL for a private object, with optional image-transform parameters.
+
+### File Sharing
+
+Share an object with another user and manage grants:
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/storage/{bucket}/{key}/share` | Share a file with a user (read/write) |
+| `GET` | `/storage/{bucket}/{key}/shares` | List a file's shares |
+| `DELETE` | `/storage/{bucket}/{key}/share/{user_id}` | Revoke a share |
+
+For SDK usage, see the [Storage SDK reference](/api/sdk/classes/fluxbasestorage/).
 
 ## Related Documentation
 

--- a/docs/src/content/docs/guides/testing.md
+++ b/docs/src/content/docs/guides/testing.md
@@ -428,7 +428,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.25"
 
       - name: Setup test database
         run: ./test/scripts/setup_test_db.sh
@@ -488,11 +488,11 @@ open coverage.html  # macOS
 xdg-open coverage.html  # Linux
 ```
 
-**Coverage Targets**:
+**Coverage Targets** (enforced in CI via go-test-coverage):
 
-- Overall: > 70%
-- Critical paths (auth, RLS, security): > 90%
-- Utilities: > 80%
+- Overall: 25%+ (starting point, increasing over time)
+- Core business logic: 50%+ per file
+- Critical modules (auth, API): 70%+ per file
 
 ### SDK Coverage
 

--- a/docs/src/content/docs/guides/tutorials/first-api.md
+++ b/docs/src/content/docs/guides/tutorials/first-api.md
@@ -359,4 +359,4 @@ Congratulations! You've built your first Fluxbase API. Here's what to explore ne
 - [Row-Level Security](/guides/row-level-security/) - Advanced RLS patterns
 - [Edge Functions](/guides/edge-functions/) - Add serverless business logic
 - [Realtime Subscriptions](/guides/realtime/) - Get live updates via WebSocket
-- [TypeScript SDK Reference](/api/sdk/) - Complete SDK reference
+- [TypeScript SDK Reference](/api/sdk/readme/) - Complete SDK reference

--- a/docs/src/content/docs/guides/webhooks.md
+++ b/docs/src/content/docs/guides/webhooks.md
@@ -256,7 +256,9 @@ func handleWebhook(body []byte, signatureHeader, secret string) error {
 ```javascript
 const crypto = require('crypto');
 
-function verifyWebhookSignature(payload, header, secret, toleranceMs = 300000) {
+function verifyWebhookSignature(rawBody, header, secret, toleranceMs = 300000) {
+  // rawBody must be the EXACT raw request body string (bytes) — re-serializing
+  // JSON (e.g. JSON.stringify) changes whitespace/key order and breaks the HMAC.
   // Parse header: t=timestamp,v1=signature
   const parts = header.split(',').reduce((acc, part) => {
     const [key, value] = part.split('=');
@@ -271,8 +273,8 @@ function verifyWebhookSignature(payload, header, secret, toleranceMs = 300000) {
     throw new Error('Signature timestamp too old or in future');
   }
 
-  // Compute expected signature
-  const signedPayload = `${parts.timestamp}.${JSON.stringify(payload)}`;
+  // Compute expected signature over the raw body
+  const signedPayload = `${parts.timestamp}.${rawBody}`;
   const expectedSig = crypto
     .createHmac('sha256', secret)
     .update(signedPayload)

--- a/docs/src/content/docs/intro.md
+++ b/docs/src/content/docs/intro.md
@@ -122,7 +122,7 @@ WebSocket-based AI chatbot integration:
 | **Multi-Tenancy**      | ✅ Database-per-tenant        | ⚠️ RLS-based only                      | ⚠️ Namespaces       |
 | **Database**           | PostgreSQL 15+                | PostgreSQL 15+                         | Proprietary (NoSQL) |
 | **Row-Level Security** | ✅ Yes                        | ✅ Yes                                 | ⚠️ Rules-based      |
-| **Client SDK**         | TypeScript, React, Go         | JS, Flutter, Python, Swift, Kotlin, C# | TypeScript/JS       |
+| **Client SDK**         | TypeScript, React             | JS, Flutter, Python, Swift, Kotlin, C# | TypeScript/JS       |
 | **Horizontal Scaling** | ✅ Yes (distributed backends) | ✅ Yes (read replicas)                 | ✅ Yes (auto)       |
 | **Open Source**        | ✅ AGPLv3                     | ✅ Apache 2.0                          | ❌ Proprietary      |
 
@@ -221,7 +221,7 @@ graph TB
 - [Multi-Tenancy](/guides/multi-tenancy/) - Build multi-tenant SaaS applications
 - [AI Chatbots Guide](/guides/ai-chatbots/) - Build natural language interfaces to your database
 - [Configuration Reference](/reference/configuration/) - Customize Fluxbase for your needs
-- [TypeScript SDK Reference](/api/sdk/) - Learn how to use the TypeScript SDK
+- [TypeScript SDK Reference](/api/sdk/readme/) - Learn how to use the TypeScript SDK
 
 ## Community & Support
 

--- a/docs/src/content/docs/reference/configuration.md
+++ b/docs/src/content/docs/reference/configuration.md
@@ -5,9 +5,28 @@ description: Complete reference for configuring Fluxbase via YAML config file or
 
 Complete reference for configuring Fluxbase via configuration file or environment variables.
 
+## Configuration Layers
+
+Fluxbase loads configuration in order; later layers override earlier ones:
+
+1. **Built-in defaults** — `internal/config/config_defaults.go`
+2. **Config file** — the first match found (see search paths below)
+3. **Environment** — a `.env` file is auto-loaded first (`.env`, then `.env.local`, then `../.env`; it does **not** overwrite variables already present in the environment), then `FLUXBASE_*` environment variables (highest precedence)
+
+Environment variables use the `FLUXBASE_` prefix with `_` separating nested keys — for example `server.body_limits.default_limit` maps to `FLUXBASE_SERVER_BODY_LIMITS_DEFAULT_LIMIT`. Lists are comma-separated in env (e.g. `FLUXBASE_CORS_ALLOWED_ORIGINS="a,b"`).
+
 ## Configuration File
 
-Create `fluxbase.yaml` in your working directory:
+Fluxbase searches these locations in order and uses the first match:
+
+- `./fluxbase.yaml`
+- `./fluxbase.yml`
+- `./config/fluxbase.yaml`
+- `./config/fluxbase.yml`
+- `/etc/fluxbase/fluxbase.yaml`
+- `/etc/fluxbase/fluxbase.yml`
+
+A minimal config:
 
 ```yaml
 # General Configuration
@@ -133,24 +152,17 @@ realtime:
   max_connections: 1000
   max_connections_per_user: 10
   max_connections_per_ip: 20
-  ping_interval: 30s
-  pong_timeout: 60s
-  read_buffer_size: 1024
-  write_buffer_size: 1024
-  message_size_limit: 524288 # 512KB
-  channel_buffer_size: 100
   rls_cache_size: 100000
   rls_cache_ttl: 30s
   listener_pool_size: 2 # LISTEN connections for redundancy
   notification_workers: 4
-  notification_queue_size: 1000
   client_message_queue_size: 256
   slow_client_threshold: 100
   slow_client_timeout: 30s
 
 # Admin UI
 admin:
-  enabled: false # Enable React admin dashboard
+  enabled: true # Admin UI on by default; API routes are still gated by security.setup_token
 
 # Multi-Tenancy
 tenants:
@@ -446,12 +458,6 @@ auth:
 | `FLUXBASE_REALTIME_MAX_CONNECTIONS`          | Max WebSocket connections    | `1000`           | `5000`          |
 | `FLUXBASE_REALTIME_MAX_CONNECTIONS_PER_USER` | Max connections per user     | `10`             | `20`            |
 | `FLUXBASE_REALTIME_MAX_CONNECTIONS_PER_IP`   | Max connections per IP       | `20`             | `50`            |
-| `FLUXBASE_REALTIME_PING_INTERVAL`            | Ping interval                | `30s`            | `30s`           |
-| `FLUXBASE_REALTIME_PONG_TIMEOUT`             | Pong timeout                 | `60s`            | `60s`           |
-| `FLUXBASE_REALTIME_READ_BUFFER_SIZE`         | WebSocket read buffer        | `1024`           | `2048`          |
-| `FLUXBASE_REALTIME_WRITE_BUFFER_SIZE`        | WebSocket write buffer       | `1024`           | `2048`          |
-| `FLUXBASE_REALTIME_MESSAGE_SIZE_LIMIT`       | Max message size (bytes)     | `524288` (512KB) | `1048576`       |
-| `FLUXBASE_REALTIME_CHANNEL_BUFFER_SIZE`      | Channel buffer size          | `100`            | `200`           |
 | `FLUXBASE_REALTIME_RLS_CACHE_SIZE`           | RLS permission cache entries | `100000`         | `200000`        |
 | `FLUXBASE_REALTIME_RLS_CACHE_TTL`            | RLS cache TTL                | `30s`            | `60s`           |
 
@@ -461,7 +467,6 @@ auth:
 | --------------------------------------------- | ------------------------------------------------ | ------- | ------- |
 | `FLUXBASE_REALTIME_LISTENER_POOL_SIZE`        | LISTEN connections for redundancy                | `2`     | `4`     |
 | `FLUXBASE_REALTIME_NOTIFICATION_WORKERS`      | Workers for parallel notification processing     | `4`     | `8`     |
-| `FLUXBASE_REALTIME_NOTIFICATION_QUEUE_SIZE`   | Queue size per notification worker               | `1000`  | `2000`  |
 | `FLUXBASE_REALTIME_CLIENT_MESSAGE_QUEUE_SIZE` | Per-client message queue for async sending       | `256`   | `512`   |
 | `FLUXBASE_REALTIME_SLOW_CLIENT_THRESHOLD`     | Queue length threshold for slow client detection | `100`   | `200`   |
 | `FLUXBASE_REALTIME_SLOW_CLIENT_TIMEOUT`       | Duration before disconnecting slow clients       | `30s`   | `60s`   |
@@ -481,7 +486,7 @@ The migrations API requires both IP allowlist and service key authentication. Th
 
 | Variable                 | Description     | Default | Example         |
 | ------------------------ | --------------- | ------- | --------------- |
-| `FLUXBASE_ADMIN_ENABLED` | Enable Admin UI | `false` | `true`, `false` |
+| `FLUXBASE_ADMIN_ENABLED` | Enable Admin UI (on by default; routes still gated by `security.setup_token`) | `true` | `true`, `false` |
 
 ### Multi-Tenancy
 
@@ -860,13 +865,9 @@ Global settings for the Deno runtime used by edge functions and background jobs.
 | `FLUXBASE_JOBS_WORKER_TIMEOUT`               | Worker considered dead after                  | `30s`      | `60s`                                |
 | `FLUXBASE_JOBS_GRACEFUL_SHUTDOWN_TIMEOUT`    | Time to wait for running jobs during shutdown | `5m`       | `10m`                                |
 
-**Execution Log Retention:**
-
-| Variable                                      | Description                                  | Default | Example |
-| --------------------------------------------- | -------------------------------------------- | ------- | ------- |
-| `FLUXBASE_JOBS_FUNCTIONS_LOGS_RETENTION_DAYS` | Retention for function execution logs (days) | `30`    | `60`    |
-| `FLUXBASE_JOBS_RPC_LOGS_RETENTION_DAYS`       | Retention for RPC execution logs (days)      | `30`    | `60`    |
-| `FLUXBASE_JOBS_JOBS_LOGS_RETENTION_DAYS`      | Retention for job execution logs (days)      | `30`    | `60`    |
+:::note[Execution Log Retention]
+Function, RPC, and job execution-log retention is controlled by `FLUXBASE_LOGGING_EXECUTION_RETENTION_DAYS` (see [Logging](#logging)) — there are no per-resource `jobs.*_logs_retention_days` settings.
+:::
 
 **Sync Security:**
 

--- a/docs/src/content/docs/sdk-react/getting-started.md
+++ b/docs/src/content/docs/sdk-react/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started
+title: React SDK Getting Started
 description: React hooks for Fluxbase — provider setup, queries, mutations, and auth.
 ---
 

--- a/docs/src/content/docs/sdk/admin.md
+++ b/docs/src/content/docs/sdk/admin.md
@@ -983,6 +983,6 @@ import type {
 ## Next Steps
 
 - [Authentication Guide](/guides/authentication) - User authentication methods
-- [SDK Reference](/api/sdk/) - Query and manipulate data
+- [SDK Reference](/api/sdk/readme/) - Query and manipulate data
 - [Storage Guide](/guides/storage) - File upload and management
 - [Realtime Guide](/guides/realtime) - WebSocket subscriptions

--- a/docs/src/content/docs/sdk/advanced-features.md
+++ b/docs/src/content/docs/sdk/advanced-features.md
@@ -638,5 +638,5 @@ await client.admin.settings.app.update({
 - [DDL SDK](/sdk/ddl) - Database schema operations
 - [OAuth SDK](/sdk/oauth) - Authentication provider configuration
 - [Impersonation SDK](/sdk/impersonation) - User impersonation and debugging
-- [TypeScript SDK Reference](/api/sdk/) - General SDK usage
+- [TypeScript SDK Reference](/api/sdk/readme/) - General SDK usage
 - [API Cookbook](/api-cookbook) - Common API patterns

--- a/docs/src/content/docs/sdk/ddl.md
+++ b/docs/src/content/docs/sdk/ddl.md
@@ -910,5 +910,5 @@ These features may be added in future releases based on user feedback.
 
 - Learn about [Admin SDK](/sdk/admin) for user management
 - Explore [Settings SDK](/sdk/settings) for configuration management
-- Read [SDK Reference](/api/sdk/) for data operations
+- Read [SDK Reference](/api/sdk/readme/) for data operations
 - Check out [Advanced Features](/sdk/advanced-features) for schema design patterns

--- a/docs/src/content/docs/sdk/getting-started.md
+++ b/docs/src/content/docs/sdk/getting-started.md
@@ -20,10 +20,10 @@ yarn add @nimbleflux/fluxbase-sdk
 ```typescript
 import { createClient } from "@nimbleflux/fluxbase-sdk";
 
-const client = createClient({
-  url: "https://your-fluxbase-instance.com",
-  apiKey: "your-api-key", // client key (publishable) or service key (secret)
-});
+const client = createClient(
+  "https://your-fluxbase-instance.com",
+  "your-api-key", // client key (publishable) or service key (secret)
+);
 
 // Query a table
 const { data, error } = await client
@@ -106,6 +106,7 @@ const { error } = await client
 
 ```typescript
 const channel = client
+  .realtime
   .channel("products-changes")
   .on("postgres_changes", { table: "products" }, (payload) => {
     console.log("Change:", payload);

--- a/docs/src/content/docs/sdk/settings.md
+++ b/docs/src/content/docs/sdk/settings.md
@@ -1017,5 +1017,5 @@ console.log(secretMetadata.updated_at) // timestamp
 
 - Learn about [Admin SDK](/sdk/admin) for user management and authentication
 - Explore [Management SDK](/sdk/management) for client keys and webhooks
-- Read about [SDK Reference](/api/sdk/) operations
+- Read about [SDK Reference](/api/sdk/readme/) operations
 - Check out [Authentication](/guides/authentication) for user-facing auth flows

--- a/docs/src/content/docs/supabase-comparison.md
+++ b/docs/src/content/docs/supabase-comparison.md
@@ -22,7 +22,7 @@ Fluxbase provides API-compatible alternatives to Supabase's core features in a s
 | **Background Jobs**    | ✅ Built-in                   | ✅ pg_cron (ext)                       | ❌ No               |
 | **Database**           | PostgreSQL 15+                | PostgreSQL 15+                         | Proprietary (NoSQL) |
 | **Row-Level Security** | ✅ Yes                        | ✅ Yes                                 | ⚠️ Rules-based      |
-| **Client SDK**         | TypeScript, React, Go         | JS, Flutter, Python, Swift, Kotlin, C# | TypeScript/JS       |
+| **Client SDK**         | TypeScript, React             | JS, Flutter, Python, Swift, Kotlin, C# | TypeScript/JS       |
 | **Horizontal Scaling** | ✅ Yes (distributed backends) | ✅ Yes (read replicas)                 | ✅ Yes (auto)       |
 | **Open Source**        | ✅ AGPLv3                     | ✅ Apache 2.0                          | ❌ Proprietary      |
 | **CLI**                | ✅ Fluxbase CLI               | ⚠️ Only cloud version                  | ⚠️ Only cloud       |

--- a/internal/settings/custom_settings.go
+++ b/internal/settings/custom_settings.go
@@ -342,7 +342,7 @@ func (s *CustomSettingsService) ListSettings(ctx context.Context, userRole strin
 	var settings []CustomSetting
 	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT id, key, value, value_type, description, editable_by, metadata, created_by, updated_by, created_at, updated_at
+			SELECT id, key, value, value_type, COALESCE(description, ''), editable_by, metadata, created_by, updated_by, created_at, updated_at
 			FROM app.settings
 			WHERE category = 'custom'
 			ORDER BY key


### PR DESCRIPTION
## Summary

Full audit of all hand-written docs (~85 pages) + auto-generated TypeDoc references against the Go backend, TypeScript SDKs, and CLI. This PR fixes the **P0 accuracy bugs** (fabricated features, wrong endpoints/defaults/table names, broken SDK examples), most **P1 structural issues**, and documents several previously-**undocumented features** (email templates API, AI reasoning, MCP tools, OAuth endpoints, per-tenant overrides).

The auto-generated SDK references were verified **fully in sync** (0 missing, 0 stale exports) — the real defects were all in hand-written pages.

**Build: green** (`astro build`, 604 pages, 0 broken links).

> Note: this branch also includes a concurrent fix `bccaa780` (fix: ListSettings crashes on NULL description).

## P0 accuracy fixes
- **knowledge-bases**: OCR is shipped (was "not supported")
- **api-cookbook**: password-reset + `createSignedUrl` + `getPublicUrl` + `getCurrentUser` signatures
- **api/http**: REST requires `{schema}`; removed fabricated `/bulk`/`/export`/`/realtime/broadcast`; rewrote AI section to real `/api/v1/ai/*`; full KB routes; `/api-docs`; `GET /graphql`
- **graphql**: `GET` introspection; `AND`/`OR`/`NOT`
- **configuration**: `admin.enabled` default; removed 10 phantom keys; documented config layers
- **mcp/tools**: full rewrite 19→**46 tools** with correct scopes
- **mcp/integration-guide**: 5 wrong tool names + all resource URIs (`fluxbase://`)
- **authentication**: providers list; removed `captcha-v2`/`impersonation_enabled`/`signInAnonymously`; role gate
- **database-migrations + row-level-security**: `migrations.app`→`platform.migrations`
- **edge-functions**: `FLUXBASE_URL`; bundle 50MB; exec 30s/300s; response 10MB
- **jobs**: removed phantom env vars; `max-retries` default 0
- **rate-limiting**: `local`/`postgres`/`redis` backends; `/client-keys` path
- **storage**: removed fabricated malware/Vault sections; 2GB upload default
- **rpc**: phantom env vars + cron scheduling
- **realtime**: removed fabricated `presence.*` config
- **monitoring**: `/monitoring/health` requires auth+scope; Docker healthcheck→`/health`
- **branching/mcp/index**: correct `enabled` + `session_timeout` defaults
- **intro/supabase-comparison**: dropped fictional Go SDK
- **sdk/getting-started**: `createClient` signature; `client.realtime.channel`
- **captcha**: source file ref; `captcha-v2`; adaptive-trust env vars
- **oauth-providers**: `issuer_url` requirement note
- **logging**: `flush_interval` default 1s
- **user-impersonation**: service role string + role gate
- **testing**: Go 1.25 + real coverage thresholds
- **webhooks**: HMAC verify must use raw body

## P1 structural + completeness
- Retargeted **14 broken `/api/sdk` links**; fixed `#horizontal-scaling` anchor
- CLI sidebar: added `providers` + `internal-schema`; de-orphaned React SDK
- **email-services**: documented the templates API (list/get/update/test/reset) + per-tenant overrides (was entirely undocumented)
- **ai-chatbots**: reasoning modes (react/strict/none), intent rules, model/max-iterations/show-reasoning annotations + examples
- **edge-functions + jobs**: missing `@fluxbase:` annotations (timeout/memory/allow-*/disable-logs/allowed-domains/progress-timeout/schedule-params)
- **multi-tenancy**: tenant members/admins + single-key settings endpoints
- **oauth-providers**: token/logout/logout-callback endpoints
- **rpc**: admin cancel-execution endpoint; logging test endpoint

## Remaining backlog (follow-up PRs)
- **New guides needed:** `/dashboard/auth/*` (3rd auth surface), Service Keys lifecycle, internal AI endpoint (`/api/v1/internal/ai/*`), Idempotency-Key/ETag headers.
- **Per-page polish:** saml `redirectUrl` key, supabase realtime example shape, deployment Deno version + Redis guidance, oauth `exchangeCodeForSession` return shape, monitoring metric-name verification.
- **Source-export gap:** 15 React hooks implemented but not exported from `index.ts`.
- **Phantom keys** in `fluxbase.yaml.example` + Helm `values.yaml`.

## Verification
- [x] `cd docs && bun run build` — 604 pages, 0 errors, 0 broken-link warnings
- [x] Grep recheck: 0 bare `/api/sdk)` links, 0 `{#…}` anchors
- [x] Each P0 page spot-checked against source after editing

Detailed per-page audit in `docs/plans/docs-audit.md` (local; `docs/plans/` is gitignored).