### PR TITLE
feat(ai): multi-agent supervisor + page-aware chatbots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,16 +196,26 @@ Server initialization uses a module-based dependency injection system:
 
 - `internal/ai/knowledge_base.go` - Core data models (incl. per-KB `EntityExtractionEnabled` toggle)
 - `internal/ai/knowledge_base_storage.go` - Storage operations
-- `internal/ai/provider_anthropic.go` - Native Anthropic Claude provider with explicit `cache_control` prompt caching
+- `internal/ai/provider_anthropic.go` - Native Anthropic Claude provider with explicit `cache_control` prompt caching; supports `tool_choice` (`auto`/`any`/`tool`)
 - `internal/ai/provider_openai.go` - OpenAI/Azure provider (parses `prompt_tokens_details.cached_tokens` from automatic prefix caching)
-- `internal/ai/chat_handler_message.go` - Turns assemble a static system message + dynamic context message (user ID, time, RAG) so the static prefix is byte-stable across turns for caching
+- `internal/ai/chat_handler_message.go` - Turns assemble a static system message + dynamic context message (user ID, time, RAG) so the static prefix is byte-stable across turns for caching. Branches on `ReasoningMode`: `"supervisor"` (default) delegates to the multi-agent graph in `chat_handler_supervisor.go`; `"react"`/`"strict"`/`"none"` use the legacy ReAct loop.
+- `internal/ai/chat_handler_supervisor.go` - `runSupervisorTurn` builds the `AgentDeps` bundle, runs the supervisor graph, streams the final response, and falls back to the legacy ReAct loop on any graph error.
 - `internal/ai/chat_handler_tools.go` - `execute_sql` / MCP tool execution; both paths emit `query_result` events for parity
 - `internal/ai/chat_handler_usage.go` - `GET /api/v1/ai/usage/:chatbotId` (per-user daily quota snapshot)
 - `internal/ai/chatbot_limiter.go` - In-memory per-`(chatbotID, userID)` counters; `GetDailyUsage` returns a `DailyUsage` snapshot; `AddTokenUsage` is called with cached-token-discounted spend
 - `internal/ai/intent_validator.go` - `GetMatchedRules` surfaces fired rules via the done event's `matched_intent_rules`
-- `internal/ai/rag_service.go` - `RetrieveContext` branches to graph-boosted per-KB retrieval when `GraphBoostWeight > 0`
-- `internal/ai/document_processor.go` - Entity extraction gated by per-KB `EntityExtractionEnabled`; re-extraction cleans stale `document_entities` mentions
-- `internal/ai/knowledge_graph.go` - Entity/relationship CRUD; `DeleteDocumentEntitiesByDocument` for stale-mention cleanup
+
+**Multi-Agent Supervisor (default ReasoningMode for all chatbots):**
+
+- `internal/ai/graph.go` - Generic graph executor: nodes, edges, conditional edges, parallel fan-out, cycle detection, mutex-safe `State` with typed accessors.
+- `internal/ai/supervisor_graph.go` - Concrete graph wiring for one chatbot turn: supervisor → router → specialists → synthesizer → verifier.
+- `internal/ai/agent_deps.go` - `AgentDeps` bundle (chatbot, provider, services, sender) + `AgentEventSender` interface for WS events.
+- `internal/ai/agent_supervisor.go` - Routing LLM call. Parses JSON `SupervisorPlan` (route, language, investigative flag, min_tool_calls). Applies page-profile whitelist.
+- `internal/ai/agent_specialists.go` - SQL, KB, Action, Chat agents. Each has a focused prompt + tool whitelist + bounded internal loop.
+- `internal/ai/agent_synthesizer_verifier.go` - Synthesizer (merges multi-agent output) + Verifier (Unicode-script language check + optional LLM grounding check on investigative turns).
+- `internal/ai/agent_prompts.go` - Per-agent static system prompts (focused ~100 lines each).
+- `internal/ai/page_context.go` - `PageProfile` + `PageProfiles` map + `@fluxbase:page-contexts` JSON parser. Level-2 page-aware chatbot overrides.
+- Reasoning modes: `"supervisor"` (default for new + existing chatbots via `PopulateDerivedFields`), `"react"`, `"strict"`, `"none"`. Pin via `@fluxbase:reasoning-mode` annotation.
 
 **Multi-Tenancy:**
 

--- a/docs/src/content/docs/about/ai-transparency.md
+++ b/docs/src/content/docs/about/ai-transparency.md
@@ -48,6 +48,18 @@ RLS enforces data access at the database level. Application bugs cannot bypass i
 
 AES-256-GCM encryption for secrets, rate limiting per endpoint, tenant-scoped connection pools, audit logging, and enforced parameterized queries.
 
+### Multi-Agent Chatbot Pipeline
+
+Chatbots run a multi-agent supervisor pipeline by default. This is disclosed for transparency:
+
+- **Routing decision is logged**: when a user message arrives, a routing LLM (the supervisor) classifies intent and decides which specialist agent (SQL, KB, action, chat) handles it. The routing decision is emitted to the WebSocket client as an `agent_transition` event and is visible in server logs.
+- **Per-agent prompts are public**: each specialist agent's system prompt is plain Go code in `internal/ai/agent_prompts.go`. You can read exactly what instructions each agent receives.
+- **Verification is deterministic + LLM**: the verifier always runs a Unicode-script language-match check (stdlib only, no LLM call). On investigative turns it also runs a small LLM call to check that factual claims in the answer are grounded in tool results. The LLM check is opt-out via `@fluxbase:reasoning-mode react`.
+- **One-retry cap**: verification never blocks an answer permanently. If the verifier reports issues, the answer ships anyway with the issues surfaced in the `done` event.
+- **No silent data exfiltration**: agents only call tools configured for the chatbot (`execute_sql`, `search_vectors`, MCP tools). The supervisor itself has no tools. No agent can make outbound HTTP except through the chatbot's explicitly-allowed domains.
+
+See [Multi-Agent Supervisor](/guides/ai-agents/) for the full architecture.
+
 ## API Surface
 
 ```mermaid

--- a/docs/src/content/docs/guides/ai-agents.md
+++ b/docs/src/content/docs/guides/ai-agents.md
@@ -1,0 +1,114 @@
+---
+title: "Multi-Agent Supervisor"
+description: Fluxbase's default chatbot reasoning mode routes user messages through a multi-agent graph — supervisor, SQL, KB, action, chat, synthesizer, verifier — for better tool selection, language matching, and grounded answers.
+---
+
+# Multi-Agent Supervisor Mode
+
+By default, Fluxbase chatbots run in **supervisor mode** — a multi-agent pipeline that routes each user message through the right specialist, verifies the answer, and synthesizes multi-source responses into one coherent reply.
+
+This is the recommended mode for production chatbots. It costs slightly more tokens than the legacy single-agent ReAct loop but produces better-structured answers, more reliable SQL investigations, and consistent language matching.
+
+## Why a supervisor?
+
+A single-agent loop (the legacy `react` mode) gives the model all tools and a long prompt, then lets it decide what to do. That works, but it has two well-known failure modes:
+
+1. **Wrong tool selection.** The model answers from memory instead of running SQL, or uses the knowledge-base tool for a data question. A supervisor that *only sees SQL tools* on the SQL Agent cannot make this mistake.
+2. **Language drift.** Tool results come back in English (column names, summaries). On long conversations the model's final answer sometimes drifts to English even when the user wrote in another language.
+
+The supervisor pattern addresses both by **routing at the architecture level**: each specialist agent has a small focused prompt and a constrained tool set, the supervisor detects the user's language once and threads it through every downstream agent, and a verifier performs a deterministic Unicode-script check on the final answer before it ships.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[User message] --> S[Supervisor]
+    S -->|route + plan| R[Router]
+
+    R --> SQL[SQL Agent<br/>execute_sql]
+    R --> KB[KB Agent<br/>search_vectors]
+    R --> ACT[Action Agent<br/>invoke_function, rpc_call]
+    R --> CHAT[Chat Agent<br/>no tools]
+
+    SQL --> SYNTH
+    KB --> SYNTH
+    ACT --> SYNTH
+    CHAT --> SYNTH
+
+    SYNTH[Synthesizer<br/>merges multi-agent output] --> VERifier
+    VERifier[Verifier<br/>language + grounding check] --> OUT[Final answer]
+```
+
+Each box is a **node** in a graph executor. The supervisor runs first, decides which specialists to invoke, and stores its plan in graph state. The router fans out (sequentially in v1; parallelism is a planned optimization) and each specialist writes its output to shared state. When two or more specialists produced output, the synthesizer merges them. The verifier runs only when the supervisor flagged the turn as investigative.
+
+## The seven agents
+
+| Agent | Role | Tools | Default model tier |
+|---|---|---|---|
+| **Supervisor** | Reads the user's message, decides which specialists to invoke, detects language | None | Cheap |
+| **SQL Agent** | Investigates factual data questions by running SQL queries | `execute_sql` | Strong |
+| **KB Agent** | Answers conceptual questions from knowledge bases | `search_vectors` | Strong |
+| **Action Agent** | Executes mutations, edge functions, and RPC procedures | `invoke_function`, `rpc_call`, etc. | Strong |
+| **Chat Agent** | Handles greetings, chitchat, follow-ups | None | Cheap |
+| **Synthesizer** | Merges multi-agent outputs into one coherent answer in the user's language | None | Medium |
+| **Verifier** | Rule-based language check + optional LLM grounding check | None | Cheap |
+
+Specialist prompts are small (~100 lines each) and focused. The SQL Agent's prompt *only* knows about SQL — it cannot see the KB or action tools. This makes wrong-tool selection structurally impossible.
+
+## Per-agent model overrides
+
+Different agents benefit from different models. The chat agent doesn't need GPT-4-class reasoning; the SQL agent does. Override per agent with the `@fluxbase:supervisor-models` annotation:
+
+```typescript
+/**
+ * @fluxbase:supervisor-models {
+ *   "supervisor": "gpt-4o-mini",
+ *   "sql": "gpt-4-turbo",
+ *   "chat": "gpt-4o-mini",
+ *   "verifier": "gpt-4o-mini"
+ * }
+ */
+export default `You are a helpful assistant.`;
+```
+
+Missing keys fall back to the chatbot's main `@fluxbase:model`. Use this to cut cost on chatbots with high chitchat ratio — the chat agent routes to the cheap model while SQL investigations still get the strong one.
+
+## Verification
+
+On investigative turns, the verifier runs two checks before the answer ships:
+
+1. **Language match (always).** Compares the dominant Unicode script of the user's message against the response. If the user wrote in Cyrillic and the answer is Latin, the verifier flags it. This is a stdlib-only check — no LLM call.
+2. **Grounding (LLM, investigative only).** When the language check passes and the turn ran tools, the verifier asks a small focused LLM call: "Are all factual claims in the answer supported by the tool results?" If not, the issues are reported in the turn's `done` event.
+
+The verifier does **not** block the response permanently. It runs once, reports issues, and ships. Future iterations may add a one-retry path.
+
+## Cost and latency
+
+| Turn type | LLM calls | Notes |
+|---|---|---|
+| Chitchat ("hi", "thanks") | 2 (supervisor + chat) | Cheap model on chat |
+| Single-agent investigative | 3-5 (supervisor + 1-3 SQL iterations + verifier) | SQL Agent runs an internal tool loop |
+| Multi-agent investigative | 5-7 (supervisor + 2 specialists + synthesizer + verifier) | Synthesizer skipped on single-agent routes |
+
+First-token latency is higher than legacy `react` mode because the supervisor runs before any specialist streams. The trade-off is fewer hallucinated answers and consistent language matching.
+
+## Opting out
+
+If supervisor mode doesn't fit a chatbot, pin the legacy ReAct loop:
+
+```typescript
+/**
+ * @fluxbase:reasoning-mode react
+ */
+export default `You are a helpful assistant.`;
+```
+
+The ReAct loop remains fully supported. It runs faster and cheaper, at the cost of the supervisor's quality guarantees.
+
+## See also
+
+- [AI Chatbots](./ai-chatbots.md) — overview of chatbot setup and configuration
+- [Page-aware chatbots](./ai-chatbots.md#page-aware-chatbots) — one chatbot, multiple page profiles
+- [AI events reference](./ai-events.md) — WebSocket event types
+- [Knowledge Bases](./knowledge-bases.md) — RAG setup
+- [Vector Search](./vector-search.md) — embeddings

--- a/docs/src/content/docs/guides/ai-chatbots.md
+++ b/docs/src/content/docs/guides/ai-chatbots.md
@@ -916,6 +916,178 @@ The static prefix is cached up to the first differing token. To maximize cache h
 - Avoid `{{user_id}}` and user-scoped `{{user:key}}` templates near the top of the system prompt — these vary per user. (Fluxbase already moves `Current user ID` into the dynamic context; user-injected templates in your prompt are your responsibility.)
 - Don't put timestamps, request IDs, or other per-turn values in the static portion.
 
+## Multi-Agent Supervisor Mode
+
+By default, Fluxbase chatbots run in **supervisor mode** — a multi-agent pipeline where a routing LLM (the supervisor) decides which specialist agent should handle each turn, the specialist investigates, and a verifier checks the final answer for language consistency and grounding.
+
+Supervisor mode addresses two common failure modes of single-agent chatbots:
+
+- **Wrong tool selection**: a single agent given every tool sometimes answers from memory instead of running SQL. In supervisor mode, the SQL Agent *only* has the `execute_sql` tool — it cannot make this mistake.
+- **Language drift**: tool results come back in English; on long conversations the model's reply sometimes drifts to English even when the user wrote in another language. In supervisor mode, the supervisor detects the user's language once and threads it through every agent; a verifier performs a deterministic Unicode-script check on the final answer.
+
+### Reasoning modes
+
+Control the chatbot's reasoning pipeline with `@fluxbase:reasoning-mode`:
+
+| Value | Behavior |
+|---|---|
+| `supervisor` (default) | Multi-agent pipeline. Recommended for production. |
+| `react` | Legacy single-agent ReAct loop. Forces `think` tool before other tools. Lower cost, simpler. |
+| `strict` | ReAct with stricter enforcement. |
+| `none` | No reasoning tool. Direct tool calls only. |
+
+```typescript
+/**
+ * Multi-agent supervisor (default — annotation optional).
+ * @fluxbase:reasoning-mode supervisor
+ */
+export default `You are a helpful assistant.`;
+```
+
+### Per-agent model overrides
+
+Different specialists benefit from different model tiers. Override per agent:
+
+```typescript
+/**
+ * Route chitchat to a cheap model, SQL to a strong one.
+ *
+ * @fluxbase:supervisor-models {
+ *   "supervisor": "gpt-4o-mini",
+ *   "sql": "gpt-4-turbo",
+ *   "chat": "gpt-4o-mini",
+ *   "verifier": "gpt-4o-mini"
+ * }
+ */
+export default `You are a helpful assistant.`;
+```
+
+Missing keys fall back to the chatbot's main `@fluxbase:model`. This is the most effective cost lever for chatbots with high chitchat ratio.
+
+### Cost expectations
+
+| Turn type | LLM calls |
+|---|---|
+| Chitchat ("hi", "thanks") | 2 (supervisor + chat) |
+| Single-agent investigative | 3-5 (supervisor + 1-3 SQL iterations + verifier) |
+| Multi-agent investigative | 5-7 (supervisor + 2 specialists + synthesizer + verifier) |
+
+First-token latency is higher than legacy `react` mode because the supervisor runs before any specialist streams. The trade-off is fewer hallucinated answers and consistent language matching.
+
+### Opting out
+
+If supervisor mode doesn't fit a chatbot, pin the legacy ReAct loop:
+
+```typescript
+/**
+ * @fluxbase:reasoning-mode react
+ */
+export default `You are a helpful assistant.`;
+```
+
+The ReAct loop remains fully supported and is the right choice for simple low-cost chatbots that don't need multi-agent routing.
+
+See [Multi-Agent Supervisor](./ai-agents.md) for the full architecture, agent reference, and verification details.
+
+## Page-aware Chatbots
+
+A common pattern: one assistant chatbot embedded across multiple pages of your application, with different behavior on each page. Instead of creating five separate chatbots (orders, docs, billing, etc.), create one chatbot with **page profiles**.
+
+Page profiles are per-page overrides for the supervisor's routing and per-agent config. The client sends `page_context` with each message; the supervisor looks up the matching profile and uses it to bias routing.
+
+### Defining page profiles
+
+Use the `@fluxbase:page-contexts` annotation with a JSON array:
+
+```typescript
+/**
+ * App-wide assistant with per-page behavior.
+ *
+ * @fluxbase:page-contexts [
+ *   {
+ *     "page": "orders",
+ *     "agents": ["sql", "action"],
+ *     "tables": ["orders", "order_items", "customers"],
+ *     "suffix": "You are helping on the orders page. Focus on order-related queries."
+ *   },
+ *   {
+ *     "page": "docs",
+ *     "agents": ["kb"],
+ *     "kbs": ["product-docs", "faq"],
+ *     "suffix": "You are helping on the documentation page. Use KB search."
+ *   },
+ *   {
+ *     "page": "billing",
+ *     "agents": ["sql"],
+ *     "tables": ["invoices", "payments"],
+ *     "suffix": "Be precise about amounts and dates."
+ *   }
+ * ]
+ */
+export default `You are a helpful app assistant.`;
+```
+
+**Fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `page` | string (required) | Page identifier; matches the client's `page_context` |
+| `agents` | string[] | Whitelist of specialist agents (`sql`, `kb`, `action`, `chat`) |
+| `tables` | string[] | Overrides `@fluxbase:allowed-tables` for SQL/Action agents on this page |
+| `kbs` | string[] | Overrides `@fluxbase:knowledge-base` for the KB agent on this page |
+| `suffix` | string | Appended to the active agent's prompt for this turn |
+
+All fields except `page` are optional. Empty fields inherit from the chatbot's global config.
+
+### Sending page context from the client
+
+The TypeScript SDK accepts `pageContext` on each `sendMessage` call:
+
+```typescript
+chat.sendMessage(convId, "How many orders shipped yesterday?", {
+  pageContext: "orders",
+});
+```
+
+For React/Next.js apps, derive `pageContext` from the router on every message:
+
+```typescript
+"use client";
+import { usePathname } from "next/navigation";
+import { useFluxbaseChat } from "@fluxbase/sdk-react";
+
+export function AppChat() {
+  const pathname = usePathname();
+  const pageContext = pathname.split("/")[1] || "home";
+
+  const { send } = useFluxbaseChat({
+    chatbot: "app-assistant",
+    pageContext,
+  });
+  // ...
+}
+```
+
+`pageContext` is re-derived on every render and included in each outgoing message. Conversation history persists across page switches — one chat, multiple modes.
+
+### Fallback behavior
+
+If the client sends `page_context` that doesn't match any profile, OR omits `page_context` entirely, the chatbot uses its global config. No error visible to end users — graceful degradation.
+
+### When to use one chatbot vs many
+
+Use **one page-aware chatbot** when:
+
+- The same assistant follows the user across your app
+- You want shared conversation history across pages
+- Per-page differences are mostly routing/data-scope tweaks
+
+Use **separate chatbots** when:
+
+- Each page needs a fundamentally different system prompt or personality
+- You want isolated rate limits / token budgets per page
+- Different chatbots need different providers or models
+
 ## Next Steps
 
 - [Knowledge Bases & RAG](/guides/knowledge-bases) - Create knowledge bases for RAG-powered chatbots

--- a/docs/src/content/docs/guides/ai-events.md
+++ b/docs/src/content/docs/guides/ai-events.md
@@ -1,0 +1,269 @@
+---
+title: "AI Chat WebSocket Events"
+description: Reference for every event type emitted on the AI chat WebSocket — client-to-server messages, server-to-client events, and supervisor-mode agent transitions.
+---
+
+# AI Chat WebSocket Events
+
+Fluxbase chatbots communicate over a WebSocket at `/ai/ws`. This page is the complete reference for every event type — both directions.
+
+## Connection lifecycle
+
+1. Client opens WebSocket to `/ai/ws` with optional `Authorization: Bearer <token>` header
+2. Client sends `start_chat` to begin a conversation with a named chatbot
+3. Client sends `message` events for each user turn
+4. Server streams back `progress`, `content`, `query_result`, `agent_transition`, and finally `done` events
+5. Either side may close the connection at any time
+
+---
+
+## Client → Server messages
+
+### `start_chat`
+
+Begins a new conversation with a chatbot. Returns a `chat_started` event with the conversation ID.
+
+```typescript
+{
+  type: "start_chat",
+  chatbot: "my-assistant",       // required
+  namespace: "default",          // optional, defaults to "default"
+}
+```
+
+### `message`
+
+Sends one user turn. Server streams back events until `done`.
+
+```typescript
+{
+  type: "message",
+  conversation_id: "conv_abc123", // required
+  content: "How many users signed up last week?",
+  page_context: "dashboard",      // optional — see Page-aware chatbots
+}
+```
+
+`page_context` is the optional Level-2 page-aware-chatbot signal. When set, the supervisor looks up the matching `PageProfile` from the chatbot's configuration and uses it to bias routing and override per-page config. Missing or unknown values fall back to the chatbot's global config.
+
+### `cancel`
+
+Cancels an in-progress message generation.
+
+```typescript
+{
+  type: "cancel",
+  conversation_id: "conv_abc123",
+}
+```
+
+---
+
+## Server → Client events
+
+### `chat_started`
+
+Confirms a conversation has started. Emitted in response to `start_chat`.
+
+```typescript
+{
+  type: "chat_started",
+  conversation_id: "conv_abc123",
+  chatbot: "my-assistant",
+}
+```
+
+### `progress`
+
+Status update while the chatbot is working (e.g., "Thinking...", "Executing query...").
+
+```typescript
+{
+  type: "progress",
+  conversation_id: "conv_abc123",
+  step: "thinking" | "querying" | "generating" | "executing",
+  message: "Executing: count users by week",
+}
+```
+
+### `content`
+
+Streamed content delta. Concatenate deltas to build the full response.
+
+```typescript
+{
+  type: "content",
+  conversation_id: "conv_abc123",
+  delta: "Last week, ",
+}
+```
+
+In supervisor mode, the supervisor path emits the full final response as a single `content` event. Future versions may stream token-by-token.
+
+### `query_result`
+
+Structured query result, emitted when the chatbot ran SQL. Use this to render data tables alongside the chat.
+
+```typescript
+{
+  type: "query_result",
+  conversation_id: "conv_abc123",
+  query: "SELECT date_trunc('week', created_at) AS week, COUNT(*) FROM auth.users GROUP BY week",
+  summary: "Query returned 4 row(s)",
+  row_count: 4,
+  data: [
+    { "week": "2026-06-29T00:00:00Z", "count": 142 },
+    { "week": "2026-07-06T00:00:00Z", "count": 198 },
+    // ...
+  ],
+}
+```
+
+### `tool_result`
+
+Generic tool execution result, emitted for non-SQL MCP tools (`invoke_function`, `rpc_call`, etc.). SQL and `query_table` results use `query_result` instead.
+
+```typescript
+{
+  type: "tool_result",
+  conversation_id: "conv_abc123",
+  message: "invoke_function",
+  data: [{ "tool": "invoke_function", "result": "..." }],
+}
+```
+
+### `agent_transition`
+
+**Supervisor mode only.** Emitted when one agent hands off to another. Use this to render the multi-agent routing flow as observable UI.
+
+```typescript
+{
+  type: "agent_transition",
+  conversation_id: "conv_abc123",
+  agent: "sql",                    // currently-active agent
+  agent_transition: {
+    from: "supervisor",            // optional
+    to: "sql",                     // optional
+    route: ["sql"],                // supervisor's full routing decision
+    reason: "",                    // supervisor's stated reason, if any
+    page_context: "dashboard",     // echo of client's page_context
+  },
+  page_context: "dashboard",
+}
+```
+
+Typical sequence on an investigative turn:
+
+1. `agent_transition` with `route: ["sql"]` (supervisor made routing decision)
+2. `agent_transition` with `to: "sql"` (SQL agent starting)
+3. One or more `query_result` events
+4. `agent_transition` with `to: "verifier"` (verifier checking grounding)
+5. `content` (final response)
+6. `done`
+
+### `done`
+
+Turn complete. Always emitted (except on `error` or `cancelled`).
+
+```typescript
+{
+  type: "done",
+  conversation_id: "conv_abc123",
+  usage: {
+    prompt_tokens: 1245,
+    completion_tokens: 87,
+    total_tokens: 1332,
+    cached_tokens: 800,           // subset of prompt_tokens served from cache
+  },
+  matched_intent_rules: [          // only when intent rules configured
+    {
+      keyword: "restaurant",
+      required_table: "my_places",
+    },
+  ],
+  daily_quota: {                   // only when limits configured
+    requests: { used: 12, limit: 500 },
+    tokens:   { used: 4521, limit: 100000 },
+    resets_at: "2026-07-19T00:00:00Z",
+  },
+  page_context: "dashboard",       // echo of client's page_context
+}
+```
+
+### `error`
+
+Recoverable or unrecoverable error.
+
+```typescript
+{
+  type: "error",
+  conversation_id: "conv_abc123",
+  code: "RATE_LIMITED" | "DAILY_LIMIT" | "TOKEN_BUDGET" | "PROVIDER_ERROR" | "STREAM_ERROR" | "PROMPT_ERROR" | ...,
+  error: "Rate limit exceeded. Please try again later.",
+}
+```
+
+### `cancelled`
+
+Confirms cancellation of an in-progress turn.
+
+```typescript
+{
+  type: "cancelled",
+  conversation_id: "conv_abc123",
+}
+```
+
+---
+
+## SDK usage
+
+The TypeScript SDK exposes typed callbacks for each event:
+
+```typescript
+import { FluxbaseAIChat } from "@fluxbase/sdk";
+
+const chat = new FluxbaseAIChat({
+  wsUrl: "ws://localhost:8080/ai/ws",
+  token: "<jwt>",
+
+  onContent: (delta, convId) => {
+    process.stdout.write(delta);
+  },
+
+  onProgress: (step, message, convId) => {
+    console.log(`[${step}] ${message}`);
+  },
+
+  onQueryResult: (query, summary, rowCount, data, convId) => {
+    console.log(`Query returned ${rowCount} rows`);
+  },
+
+  onAgentTransition: (transition, convId) => {
+    if (transition.route) {
+      console.log(`Supervisor routed to: ${transition.route.join(", ")}`);
+    } else if (transition.to) {
+      console.log(`→ ${transition.to}`);
+    }
+  },
+
+  onDone: (usage, convId, extras) => {
+    console.log(`Done. Tokens: ${usage?.total_tokens}`);
+    if (extras?.daily_quota) {
+      console.log(`Remaining: ${extras.daily_quota.tokens.limit - extras.daily_quota.tokens.used} tokens today`);
+    }
+  },
+
+  onError: (error, code, convId) => {
+    console.error(`Error [${code}]: ${error}`);
+  },
+});
+
+await chat.connect();
+const convId = await chat.startChat("my-assistant");
+chat.sendMessage(convId, "How many users signed up last week?", {
+  pageContext: "dashboard",
+});
+```
+
+See the [AI Chatbots guide](./ai-chatbots.md) for end-to-end examples and the [Multi-Agent Supervisor guide](./ai-agents.md) for routing details.

--- a/internal/ai/agent_deps.go
+++ b/internal/ai/agent_deps.go
@@ -1,0 +1,89 @@
+package ai
+
+import (
+	"context"
+
+	"github.com/nimbleflux/fluxbase/internal/auth"
+	"github.com/nimbleflux/fluxbase/internal/mcp"
+)
+
+// AgentDeps is the shared dependency bundle passed to every agent in the
+// supervisor graph. It bundles the chatbot being served, the LLM provider,
+// and all the side-effecting services agents might need (executor for SQL,
+// RAG for KB, MCP for actions, WebSocket for streaming output to client).
+//
+// One AgentDeps is constructed per turn and shared across all agents in
+// that turn. Agents must not retain references to it past their Run() call.
+type AgentDeps struct {
+	Chatbot *Chatbot
+
+	// Provider is the LLM provider for the chatbot's configured model.
+	Provider Provider
+
+	// UserID is the authenticated user (may be empty for anonymous chatbots).
+	UserID string
+
+	// Role and Claims carry the RLS context for SQL execution.
+	Role   string
+	Claims *auth.TokenClaims
+
+	// PageProfile is the resolved per-page profile for this turn (may be nil).
+	PageProfile *PageProfile
+
+	// ── Service dependencies (any may be nil if not configured) ──
+
+	// Executor runs SQL. Required for SQL agent.
+	SQLExecutor *Executor
+
+	// SchemaBuilder builds the schema description injected into the SQL
+	// agent's dynamic context.
+	SchemaBuilder *SchemaBuilder
+
+	// RAGService retrieves knowledge-base context. Required for KB agent.
+	RAGService *RAGService
+
+	// MCPExecutor dispatches MCP tool calls (query_table, invoke_function,
+	// rpc_call, etc.). Required for Action agent.
+	MCPExecutor *MCPToolExecutor
+
+	// MCPAuthCtx is the auth context for MCP tool execution.
+	MCPAuthCtx *mcp.AuthContext
+
+	// ConversationID is the active conversation (for audit logging,
+	// progress events, etc.).
+	ConversationID string
+
+	// ── Streaming output to client ──
+
+	// Sender emits ServerMessages to the WebSocket client. nil in tests
+	// that don't care about streaming output.
+	Sender AgentEventSender
+
+	// CtxCancel cancels the parent turn (e.g., user clicked "stop").
+	// Agents should respect ctx.Done() — that's the primary signal.
+}
+
+// AgentEventSender is the interface the chat handler implements so agents
+// can emit progress, content, and transition events to the WebSocket
+// client without depending on the concrete ChatHandler type.
+type AgentEventSender interface {
+	// SendProgress emits a step/status event.
+	SendProgress(ctx context.Context, conversationID, step, message string)
+	// SendContent streams a content delta to the client.
+	SendContent(ctx context.Context, conversationID, delta string)
+	// SendQueryResult emits a structured query_result event so the client
+	// can render data tables alongside the chat.
+	SendQueryResult(ctx context.Context, conversationID string, result QueryResult)
+	// SendAgentTransition emits an agent_transition event when one agent
+	// hands off to another (for client-side UI observability).
+	SendAgentTransition(ctx context.Context, conversationID string, transition AgentTransition)
+}
+
+// AgentTransition is the wire payload for the agent_transition event.
+type AgentTransition struct {
+	From        string   `json:"from,omitempty"`
+	To          string   `json:"to,omitempty"`
+	Route       []string `json:"route,omitempty"`
+	Reason      string   `json:"reason,omitempty"`
+	PageContext string   `json:"page_context,omitempty"`
+}

--- a/internal/ai/agent_prompts.go
+++ b/internal/ai/agent_prompts.go
@@ -1,0 +1,237 @@
+package ai
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// This file holds the system prompts for each agent in the supervisor graph.
+//
+// Design constraints:
+//   - Each prompt is focused and short (vs. the legacy 800-line monolith)
+//   - Each prompt is byte-stable across turns per chatbot so providers can
+//     cache the static prefix
+//   - Per-turn / per-page details go in the dynamic system message (caller
+//     is responsible for that — these prompts only define the static prefix)
+//
+// The supervisor agent owns its own JSON output contract (SupervisorPlan).
+
+// supervisorSystemPrompt is the supervisor's static system prompt. It must
+// output a single JSON object matching SupervisorPlan. No prose, no
+// markdown — JSON only.
+const supervisorSystemPrompt = `You are a routing assistant for a multi-agent chatbot system.
+
+Read the user's message and decide which specialist agents should handle it.
+You output a single JSON object describing the routing decision. NO prose, NO
+markdown fences — just the JSON object.
+
+Available specialist agents:
+- "sql"     — Investigates factual data questions by running SQL queries. Use for counts, lists, "show me", "how many", aggregations, filtering, joins, sorting, anything verifiable in the database.
+- "kb"      — Searches knowledge bases (documents) for conceptual, descriptive, or explanatory information. Use for "what is", "explain", "tell me about", or when the answer needs document context.
+- "action"  — Executes mutations or actions via edge functions / RPC procedures. Use when the user asks to create, update, delete, or trigger something.
+- "chat"    — Handles greetings, chitchat, clarifications, follow-ups, and questions that don't need tools. Cheap model. Use as fallback when no specialist fits.
+
+Routing rules:
+1. Route to 1 agent for focused questions, multiple for hybrid questions.
+2. For "conceptual + data" questions (e.g., "Tell me about Italian restaurants I visited"), route to BOTH "kb" and "sql".
+3. For "hi", "thanks", "ok", pure greetings, route to "chat" only.
+4. If unsure whether the question is data or conceptual, prefer "sql" over "kb" — it's better to investigate than guess.
+5. Always set user_language to the language the user wrote in (e.g., "English", "German", "Japanese").
+6. Set is_investigative=true when the user asks a factual question that needs verification. Set min_tool_calls to the minimum number of tool invocations needed (usually 1; 2-3 for complex questions).
+7. Set requires_synthesis=true when routing to 2+ agents OR when the single agent's answer needs translation/reformatting into the user's language.
+
+Output format (JSON only, no other text):
+{
+  "user_language": "<language name>",
+  "route": ["<agent>", ...],
+  "sub_questions": ["<optional sub-question per agent>"],
+  "requires_synthesis": <true|false>,
+  "is_investigative": <true|false>,
+  "min_tool_calls": <int>
+}`
+
+// BuildSupervisorPrompt returns the supervisor's full system prompt. The
+// returned prompt is byte-stable per chatbot (no per-turn values) so the
+// provider can cache it.
+//
+// Per-page whitelist (when present) is injected as a SEPARATE dynamic
+// system message by the caller — see supervisor_graph.go — to preserve
+// caching of this static prefix.
+func BuildSupervisorPrompt(chatbot *Chatbot) string {
+	// ponytail: future per-chatbot supervisor tuning would slot in here.
+	// For v1 the static template above is enough — no per-chatbot substitution.
+	return supervisorSystemPrompt
+}
+
+// sqlAgentSystemPrompt is the SQL Agent's static system prompt. Schema and
+// per-page table whitelists are injected as a separate dynamic system message.
+const sqlAgentSystemPrompt = `You are the SQL Agent in a multi-agent chatbot system. Your job is to investigate factual data questions by running SQL queries against the database.
+
+You have access to the execute_sql tool. Use it to verify every factual claim before answering. NEVER answer a data question from memory — always run a query first.
+
+Investigation principles:
+1. Plan your queries before running them. Start broad (e.g., SELECT * FROM table LIMIT 5) to understand the data shape, then narrow.
+2. Run multiple queries if needed. Don't stop at the first result if it doesn't fully answer the question.
+3. After each query, decide: does this fully answer the user's question? If not, run another.
+4. Be honest about empty results. "No matching data" is a valid answer; don't fabricate.
+
+Query constraints:
+- SELECT queries only (unless the chatbot explicitly allows other operations).
+- Always include LIMIT clauses (max 100 rows per query).
+- Filter by user_id when querying user-specific data (the current user_id is provided separately).
+- You will receive a summary plus the first 5 rows of each result.
+
+Response style:
+- After completing your investigation, write a final answer in plain text (no JSON).
+- Match the user's language. If they wrote in German, answer in German.
+- Be concise. Quote specific numbers/counts from your results.
+- If you couldn't fully answer, say so and explain what data you'd need.`
+
+// BuildSQLAgentPrompt returns the SQL Agent's static system prompt. Schema
+// description and per-page table whitelists are injected dynamically.
+func BuildSQLAgentPrompt(chatbot *Chatbot) string {
+	return sqlAgentSystemPrompt
+}
+
+// kbAgentSystemPrompt is the Knowledge Base / RAG Agent's prompt.
+const kbAgentSystemPrompt = `You are the Knowledge Base Agent in a multi-agent chatbot system. Your job is to answer conceptual and explanatory questions using documents from configured knowledge bases.
+
+You have access to the search_vectors tool. Use it to retrieve relevant document chunks before answering. NEVER answer a conceptual question from training data alone — always ground your answer in retrieved documents.
+
+When to use this agent:
+- "What is X?", "Explain Y", "Tell me about Z"
+- Questions about policies, procedures, product features, or concepts documented in your KBs
+
+Response style:
+- Cite document IDs or chunk IDs when quoting specific content.
+- If the KB doesn't contain relevant information, say so honestly. Don't fabricate.
+- Match the user's language. If they wrote in French, answer in French.
+- Be thorough but focused — answer the specific question asked.`
+
+// BuildKBAgentPrompt returns the KB Agent's static system prompt.
+func BuildKBAgentPrompt(chatbot *Chatbot) string {
+	return kbAgentSystemPrompt
+}
+
+// actionAgentSystemPrompt is the Action Agent's prompt for mutations and RPC.
+const actionAgentSystemPrompt = `You are the Action Agent in a multi-agent chatbot system. Your job is to execute mutations and procedural actions via edge functions or RPC procedures.
+
+You have access to invoke_function and rpc_call tools. Use them when the user asks to:
+- Create, update, or delete records
+- Trigger workflows or background jobs
+- Call a named procedure with structured arguments
+
+Safety:
+- Confirm destructive actions (deletes, irreversible updates) with the user before executing when possible. If the action cannot be undone and the user's intent is ambiguous, ask for clarification.
+- For idempotent actions (e.g., upserts), execute directly.
+- Report the result of each action: what changed, what the new state is.
+
+Response style:
+- Match the user's language.
+- Confirm what action was taken and what the outcome was.
+- If the action failed, report the error clearly and suggest next steps.`
+
+// BuildActionAgentPrompt returns the Action Agent's static system prompt.
+func BuildActionAgentPrompt(chatbot *Chatbot) string {
+	return actionAgentSystemPrompt
+}
+
+// chatAgentSystemPrompt is the Conversation Agent's prompt for chitchat.
+const chatAgentSystemPrompt = `You are the Conversation Agent in a multi-agent chatbot system. Your job is to handle greetings, chitchat, clarifications, and questions that don't require tools or data lookup.
+
+Examples of what you handle:
+- "Hi", "Hello", "Thanks", "Goodbye"
+- "What can you do?" (answer based on the chatbot's capabilities described in its main system prompt)
+- Follow-up clarifications after a previous tool-using turn
+- General conversation that doesn't need data verification
+
+Response style:
+- Be brief and warm. No one wants a paragraph response to "thanks".
+- Match the user's language exactly.
+- If the user asks something that DOES need data or actions, note that briefly and let the supervisor re-route on the next turn.`
+
+// BuildChatAgentPrompt returns the Conversation Agent's static system prompt.
+func BuildChatAgentPrompt(chatbot *Chatbot) string {
+	return chatAgentSystemPrompt
+}
+
+// synthesizerSystemPrompt is the Synthesizer Agent's prompt for merging
+// multiple specialist outputs into one coherent answer.
+const synthesizerSystemPrompt = `You are the Synthesizer in a multi-agent chatbot system. Your job is to merge outputs from multiple specialist agents into one coherent answer.
+
+You will receive:
+- The original user question
+- Outputs from each specialist agent that handled the question (labeled by agent name)
+- The user's detected language
+
+Synthesis rules:
+1. Combine the specialist outputs into a single, flowing answer. Don't list "SQL Agent said: X. KB Agent said: Y." — weave them together naturally.
+2. Resolve contradictions between agents in favor of the SQL Agent (data wins over interpretation).
+3. Match the user's detected language exactly. If they wrote in Spanish, your synthesis is in Spanish.
+4. Be concise. The user wants one answer, not three.
+5. Don't introduce new information that wasn't in any agent's output. If something is missing, say so.
+6. Don't mention agents, routing, or "the system". Just answer the user.`
+
+// BuildSynthesizerPrompt returns the Synthesizer's static system prompt.
+// The user's detected language is injected dynamically (per-turn) to
+// preserve prompt caching.
+func BuildSynthesizerPrompt(chatbot *Chatbot) string {
+	return synthesizerSystemPrompt
+}
+
+// verifierSystemPrompt is the Verifier's prompt for the grounding check.
+// Used only when the cheaper rule-based language check passes AND the turn
+// was investigative (so grounding is meaningful to verify).
+const verifierSystemPrompt = `You are a verification assistant. You check whether an AI's answer is grounded in tool results.
+
+You will receive:
+- The user's question
+- The answer the chatbot produced
+- The tool results that were returned during the turn
+
+Reply with a JSON object:
+{
+  "ok": <true|false>,
+  "issues": ["<description of each issue, empty array if none>"]
+}
+
+Checks:
+1. Every factual claim in the answer (numbers, counts, names, dates) must be supported by content in the tool results.
+2. If the answer introduces facts not present in tool results, that's an issue.
+3. If the answer contradicts tool results, that's an issue.
+4. Stylistic or phrasing choices are NOT issues — only factual grounding matters.
+
+Be strict on facts, lenient on style. JSON only, no prose.`
+
+// BuildVerifierPrompt returns the Verifier's static system prompt.
+func BuildVerifierPrompt() string {
+	return verifierSystemPrompt
+}
+
+// BuildDynamicContextForAgent builds the per-turn dynamic context that
+// accompanies each agent's static system prompt. This keeps the static
+// prefix byte-stable for caching while still threading per-turn details
+// (user ID, time, schema, page context) through.
+//
+// This is called by each agent's Run() method when it builds its ChatRequest.
+func BuildDynamicContextForAgent(chatbot *Chatbot, userID string, agentName string, pageProfile *PageProfile) string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "Current user ID: %s\n", userID)
+	fmt.Fprintf(&sb, "Current date and time: %s\n", currentTimeForPrompt())
+
+	// Per-page focus suffix
+	if pageProfile != nil && pageProfile.Suffix != "" {
+		fmt.Fprintf(&sb, "\nPage context focus:\n%s\n", pageProfile.Suffix)
+	}
+
+	return sb.String()
+}
+
+// currentTimeForPrompt is broken out so tests can stub it.
+// ponytail: not production-mockable, but the cost of an interface for one
+// time.Now() call didn't earn itself the complexity.
+var currentTimeForPrompt = func() string {
+	return time.Now().UTC().Format("Monday, January 2, 2006 at 3:04 PM MST")
+}

--- a/internal/ai/agent_specialists.go
+++ b/internal/ai/agent_specialists.go
@@ -1,0 +1,332 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// KBAgent is the specialist that answers conceptual questions using
+// knowledge-base retrieval. It wraps the existing RAGService — no RAG
+// logic is duplicated.
+type KBAgent struct {
+	deps *AgentDeps
+}
+
+// NewKBAgent constructs a KBAgent bound to the given deps.
+func NewKBAgent(deps *AgentDeps) *KBAgent { return &KBAgent{deps: deps} }
+
+// Name implements Node.
+func (a *KBAgent) Name() string { return "kb" }
+
+// Run executes the KB agent's retrieval-then-answer flow.
+func (a *KBAgent) Run(ctx context.Context, state *State) error {
+	chatbot := a.deps.Chatbot
+	provider := a.deps.Provider
+	if provider == nil {
+		return fmt.Errorf("kb agent: no provider")
+	}
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendAgentTransition(ctx, a.deps.ConversationID, AgentTransition{To: "kb"})
+	}
+
+	userMsg := state.UserMessage()
+
+	// Build prompt + dynamic context
+	systemPrompt := BuildKBAgentPrompt(chatbot)
+	dynamicContext := BuildDynamicContextForAgent(chatbot, a.deps.UserID, "kb", a.deps.PageProfile)
+
+	// Retrieve RAG context. KB list may be overridden by the page profile.
+	kbs := a.deps.PageProfile.ResolvedKBs(chatbot.KnowledgeBases)
+	if a.deps.RAGService != nil && len(kbs) > 0 {
+		opts := RetrieveContextOptions{
+			ChatbotID: chatbot.ID,
+			Query:     userMsg,
+			UserID:    a.deps.UserID,
+		}
+		if chatbot.RAGMaxChunks > 0 {
+			opts.MaxChunks = chatbot.RAGMaxChunks
+		}
+		if chatbot.RAGSimilarityThreshold > 0 {
+			opts.Threshold = chatbot.RAGSimilarityThreshold
+		}
+		if chatbot.RAGGraphBoostWeight > 0 {
+			opts.GraphBoostWeight = chatbot.RAGGraphBoostWeight
+		}
+		section, err := a.deps.RAGService.RetrieveContext(ctx, opts)
+		if err == nil && section != nil && section.FormattedContext != "" {
+			dynamicContext += "\n\n## Retrieved Context\n\n" + section.FormattedContext
+		}
+	}
+
+	messages := []Message{
+		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleSystem, Content: dynamicContext},
+	}
+	messages = append(messages, tailMessages(state.ConversationHistory(), 4)...)
+	messages = append(messages, Message{Role: RoleUser, Content: userMsg})
+
+	model := chatbot.Model
+	if override, ok := chatbot.SupervisorAgentModels["kb"]; ok && override != "" {
+		model = override
+	}
+
+	// KB agent does NOT use streaming here (simpler). The synthesizer is
+	// responsible for the final streamed output to the client when
+	// synthesis is engaged. If this is the only agent on the route and
+	// synthesis was skipped, the chat_handler_message.go path emits the
+	// final response in one shot.
+	req := &ChatRequest{
+		Messages:    messages,
+		Model:       model,
+		MaxTokens:   chatbot.MaxTokens,
+		Temperature: chatbot.Temperature,
+		Stream:      false,
+	}
+
+	resp, err := provider.Chat(ctx, req)
+	if err != nil {
+		return fmt.Errorf("kb agent: provider call failed: %w", err)
+	}
+	if resp == nil || len(resp.Choices) == 0 {
+		return fmt.Errorf("kb agent: empty provider response")
+	}
+	if resp.Usage != nil {
+		state.AddUsage(*resp.Usage)
+	}
+
+	content := resp.Choices[0].Message.Content
+	state.AppendAgentOutput("kb", content)
+	state.SetFinalResponse(content)
+	return nil
+}
+
+// ActionAgent is the specialist that executes mutations and RPC procedures.
+type ActionAgent struct {
+	deps *AgentDeps
+}
+
+// NewActionAgent constructs an ActionAgent bound to the given deps.
+func NewActionAgent(deps *AgentDeps) *ActionAgent { return &ActionAgent{deps: deps} }
+
+// Name implements Node.
+func (a *ActionAgent) Name() string { return "action" }
+
+// Run executes the action agent's tool-calling loop.
+func (a *ActionAgent) Run(ctx context.Context, state *State) error {
+	chatbot := a.deps.Chatbot
+	provider := a.deps.Provider
+	if provider == nil {
+		return fmt.Errorf("action agent: no provider")
+	}
+	if a.deps.MCPExecutor == nil {
+		return fmt.Errorf("action agent: MCP executor not configured")
+	}
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendAgentTransition(ctx, a.deps.ConversationID, AgentTransition{To: "action"})
+	}
+
+	systemPrompt := BuildActionAgentPrompt(chatbot)
+	dynamicContext := BuildDynamicContextForAgent(chatbot, a.deps.UserID, "action", a.deps.PageProfile)
+	allowedTables := a.deps.PageProfile.ResolvedTables(chatbot.AllowedTables)
+	if len(allowedTables) > 0 {
+		dynamicContext += fmt.Sprintf("\nTables in scope: %s\n", strings.Join(allowedTables, ", "))
+	}
+
+	userMsg := state.UserMessage()
+	messages := []Message{
+		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleSystem, Content: dynamicContext},
+	}
+	messages = append(messages, tailMessages(state.ConversationHistory(), 4)...)
+	messages = append(messages, Message{Role: RoleUser, Content: userMsg})
+
+	// Get available MCP tools, filtered to action-oriented ones
+	tools := a.buildToolList(chatbot)
+	if len(tools) == 0 {
+		// No action tools configured — fall back to a chat-style response
+		noToolsMsg := "I don't have any action tools configured for this chatbot."
+		state.AppendAgentOutput("action", noToolsMsg)
+		state.SetFinalResponse(noToolsMsg)
+		return nil
+	}
+
+	maxIters := chatbot.MaxToolIterations
+	if maxIters <= 0 {
+		maxIters = 5
+	}
+
+	model := chatbot.Model
+	if override, ok := chatbot.SupervisorAgentModels["action"]; ok && override != "" {
+		model = override
+	}
+
+	var finalContent string
+	for iter := 0; iter < maxIters; iter++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		req := &ChatRequest{
+			Messages:    messages,
+			Model:       model,
+			MaxTokens:   chatbot.MaxTokens,
+			Temperature: chatbot.Temperature,
+			Tools:       tools,
+			Stream:      false,
+		}
+
+		resp, err := provider.Chat(ctx, req)
+		if err != nil {
+			return fmt.Errorf("action agent: provider call failed: %w", err)
+		}
+		if resp == nil || len(resp.Choices) == 0 {
+			return fmt.Errorf("action agent: empty provider response")
+		}
+		if resp.Usage != nil {
+			state.AddUsage(*resp.Usage)
+		}
+
+		msg := resp.Choices[0].Message
+		if len(msg.ToolCalls) == 0 {
+			finalContent = msg.Content
+			break
+		}
+		messages = append(messages, msg)
+
+		for _, tc := range msg.ToolCalls {
+			resultStr := a.executeActionTool(ctx, tc, chatbot)
+			messages = append(messages, Message{
+				Role:       RoleTool,
+				Content:    resultStr,
+				ToolCallID: tc.ID,
+				Name:       tc.Function.Name,
+			})
+		}
+	}
+
+	if finalContent == "" {
+		finalContent = "Action completed."
+	}
+
+	state.AppendAgentOutput("action", finalContent)
+	state.SetFinalResponse(finalContent)
+	return nil
+}
+
+// buildToolList returns the action-oriented MCP tools available to this chatbot.
+func (a *ActionAgent) buildToolList(chatbot *Chatbot) []Tool {
+	if !chatbot.HasMCPTools() {
+		return nil
+	}
+	mcpDefs := a.deps.MCPExecutor.GetAvailableTools(chatbot)
+	var out []Tool
+	for _, def := range mcpDefs {
+		// Look up the tool's category to decide if it's an action tool.
+		info, ok := MCPToolInfoMap[def.Name]
+		if !ok || info.Category != MCPToolCategoryExecution {
+			continue
+		}
+		out = append(out, Tool{
+			Type:     "function",
+			Function: ToolFunction(def),
+		})
+	}
+	return out
+}
+
+// executeActionTool dispatches one MCP tool call.
+func (a *ActionAgent) executeActionTool(ctx context.Context, tc ToolCall, chatbot *Chatbot) string {
+	var args map[string]any
+	if err := parseJSONArgs(tc.Function.Arguments, &args); err != nil {
+		return fmt.Sprintf("Error: failed to parse tool arguments: %v", err)
+	}
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendProgress(ctx, a.deps.ConversationID, "executing", fmt.Sprintf("Executing %s...", tc.Function.Name))
+	}
+	// Action agent doesn't have a ChatContext (we're outside the WS handler).
+	// Pass nil — ExecuteTool handles nil chatCtx for non-RLS tools. RLS-scoped
+	// tools (insert_record etc.) fall back to the chatbot's configured access.
+	result, err := a.deps.MCPExecutor.ExecuteTool(ctx, tc.Function.Name, args, nil, chatbot)
+	if err != nil {
+		return fmt.Sprintf("Error executing %s: %v", tc.Function.Name, err)
+	}
+	return result.Content
+}
+
+// ChatAgent is the specialist for chitchat, clarifications, and follow-ups.
+type ChatAgent struct {
+	deps *AgentDeps
+}
+
+// NewChatAgent constructs a ChatAgent bound to the given deps.
+func NewChatAgent(deps *AgentDeps) *ChatAgent { return &ChatAgent{deps: deps} }
+
+// Name implements Node.
+func (a *ChatAgent) Name() string { return "chat" }
+
+// Run generates a brief conversational response.
+func (a *ChatAgent) Run(ctx context.Context, state *State) error {
+	chatbot := a.deps.Chatbot
+	provider := a.deps.Provider
+	if provider == nil {
+		return fmt.Errorf("chat agent: no provider")
+	}
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendAgentTransition(ctx, a.deps.ConversationID, AgentTransition{To: "chat"})
+	}
+
+	systemPrompt := BuildChatAgentPrompt(chatbot)
+	dynamicContext := BuildDynamicContextForAgent(chatbot, a.deps.UserID, "chat", a.deps.PageProfile)
+	// Include the user's detected language (from supervisor) so the chat
+	// agent replies in the right language even on cheap models.
+	if lang := state.UserLanguage(); lang != "" {
+		dynamicContext += fmt.Sprintf("\nUser's language: %s\n", lang)
+	}
+
+	userMsg := state.UserMessage()
+	messages := []Message{
+		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleSystem, Content: dynamicContext},
+	}
+	messages = append(messages, tailMessages(state.ConversationHistory(), 4)...)
+	messages = append(messages, Message{Role: RoleUser, Content: userMsg})
+
+	model := chatbot.Model
+	if override, ok := chatbot.SupervisorAgentModels["chat"]; ok && override != "" {
+		model = override
+	}
+
+	req := &ChatRequest{
+		Messages:    messages,
+		Model:       model,
+		MaxTokens:   512, // chat responses should be short
+		Temperature: chatbot.Temperature,
+		Stream:      false,
+	}
+
+	resp, err := provider.Chat(ctx, req)
+	if err != nil {
+		return fmt.Errorf("chat agent: provider call failed: %w", err)
+	}
+	if resp == nil || len(resp.Choices) == 0 {
+		return fmt.Errorf("chat agent: empty provider response")
+	}
+	if resp.Usage != nil {
+		state.AddUsage(*resp.Usage)
+	}
+
+	content := resp.Choices[0].Message.Content
+	state.AppendAgentOutput("chat", content)
+	state.SetFinalResponse(content)
+	return nil
+}
+
+// parseJSONArgs unmarshals argsJSON into out. Returns error on failure.
+func parseJSONArgs(argsJSON string, out any) error {
+	return json.Unmarshal([]byte(argsJSON), out)
+}

--- a/internal/ai/agent_sql.go
+++ b/internal/ai/agent_sql.go
@@ -1,0 +1,261 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// SQLAgent is the specialist that investigates factual data questions by
+// running SQL queries. It runs an internal tool-calling loop bounded by
+// the chatbot's MaxToolIterations.
+//
+// The agent reuses the existing Executor for actual SQL execution (same
+// RLS context, same validation, same row caps) — no SQL execution logic is
+// duplicated. The only new code is the per-agent prompt and the loop glue.
+type SQLAgent struct {
+	deps *AgentDeps
+}
+
+// NewSQLAgent constructs a SQLAgent bound to the given deps.
+func NewSQLAgent(deps *AgentDeps) *SQLAgent {
+	return &SQLAgent{deps: deps}
+}
+
+// Name implements Node.
+func (a *SQLAgent) Name() string { return "sql" }
+
+// Run executes the SQL agent's investigation loop.
+func (a *SQLAgent) Run(ctx context.Context, state *State) error {
+	chatbot := a.deps.Chatbot
+	provider := a.deps.Provider
+	if provider == nil {
+		return fmt.Errorf("sql agent: no provider")
+	}
+	if a.deps.SQLExecutor == nil {
+		return fmt.Errorf("sql agent: no executor configured")
+	}
+
+	// Emit transition event so the client can show "Investigating with SQL..."
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendAgentTransition(ctx, a.deps.ConversationID, AgentTransition{To: "sql"})
+	}
+
+	// Build per-turn messages. Schema description goes in the dynamic system
+	// message so the static prompt stays byte-stable for caching.
+	systemPrompt := BuildSQLAgentPrompt(chatbot)
+	schemaDesc, err := a.buildSchemaDescription(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("sql agent: failed to build schema description")
+		schemaDesc = ""
+	}
+	dynamicContext := BuildDynamicContextForAgent(chatbot, a.deps.UserID, "sql", a.deps.PageProfile)
+	if schemaDesc != "" {
+		dynamicContext += "\n## Schema\n\n" + schemaDesc + "\n"
+	}
+	// Page-profile table whitelist overrides chatbot's global allowed_tables
+	// for this turn.
+	allowedTables := a.deps.PageProfile.ResolvedTables(chatbot.AllowedTables)
+	if len(allowedTables) > 0 {
+		dynamicContext += fmt.Sprintf("\nTables in scope for this turn: %s\n", strings.Join(allowedTables, ", "))
+	}
+
+	// Initial message list — supervisor may have provided a sub-question
+	// nudge via state; we use the user's original message by default.
+	userMsg := state.UserMessage()
+	messages := []Message{
+		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleSystem, Content: dynamicContext},
+		// Seed with recent conversation history so the agent has context
+		// (last 4 messages keeps tokens bounded).
+	}
+	messages = append(messages, tailMessages(state.ConversationHistory(), 4)...)
+	messages = append(messages, Message{Role: RoleUser, Content: userMsg})
+
+	// Internal tool loop. Bounded by MaxToolIterations (default 5).
+	maxIters := chatbot.MaxToolIterations
+	if maxIters <= 0 {
+		maxIters = 5
+	}
+
+	model := chatbot.Model
+	if override, ok := chatbot.SupervisorAgentModels["sql"]; ok && override != "" {
+		model = override
+	}
+
+	tools := []Tool{ExecuteSQLTool}
+
+	// Get the supervisor plan's MinToolCalls (when investigative) so we can
+	// prevent premature final answers.
+	minToolCalls := 0
+	if plan, _ := state.Get(SupervisorPlanKey); plan != nil {
+		if p, ok := plan.(*SupervisorPlan); ok && p.IsInvestigative {
+			minToolCalls = p.MinToolCalls
+		}
+	}
+
+	toolCallCount := 0
+	var finalContent string
+
+	for iter := 0; iter < maxIters; iter++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		req := &ChatRequest{
+			Messages:    messages,
+			Model:       model,
+			MaxTokens:   chatbot.MaxTokens,
+			Temperature: chatbot.Temperature,
+			Tools:       tools,
+			Stream:      false,
+		}
+
+		resp, err := provider.Chat(ctx, req)
+		if err != nil {
+			return fmt.Errorf("sql agent: provider call failed: %w", err)
+		}
+		if resp == nil || len(resp.Choices) == 0 {
+			return fmt.Errorf("sql agent: empty provider response")
+		}
+		if resp.Usage != nil {
+			state.AddUsage(*resp.Usage)
+		}
+
+		msg := resp.Choices[0].Message
+		if len(msg.ToolCalls) == 0 {
+			// Budget gate: if the supervisor said this turn is investigative
+			// with a min-tool-call floor and we haven't hit it yet, push
+			// back once and let the LLM try again. Prevents premature
+			// "I don't know" or hallucinated answers.
+			if toolCallCount < minToolCalls && iter < maxIters-1 {
+				messages = append(messages, Message{Role: RoleAssistant, Content: msg.Content})
+				messages = append(messages, Message{
+					Role:    RoleUser,
+					Content: "You haven't finished investigating yet. Run at least one execute_sql query to verify before answering.",
+				})
+				continue
+			}
+			finalContent = msg.Content
+			break
+		}
+
+		// Append assistant tool-call message and execute each tool
+		messages = append(messages, msg)
+		for _, tc := range msg.ToolCalls {
+			resultStr, queryResult := a.executeSQL(ctx, tc, chatbot, allowedTables)
+			toolCallCount++
+			if queryResult != nil {
+				state.AppendToolResult(*queryResult)
+			}
+			messages = append(messages, Message{
+				Role:       RoleTool,
+				Content:    resultStr,
+				ToolCallID: tc.ID,
+				Name:       tc.Function.Name,
+			})
+		}
+	}
+
+	if finalContent == "" {
+		finalContent = "I wasn't able to complete my investigation. Please try rephrasing your question."
+	}
+
+	state.AppendAgentOutput("sql", finalContent)
+	state.SetFinalResponse(finalContent)
+	return nil
+}
+
+// buildSchemaDescription returns the schema description for the chatbot's
+// allowed tables, falling back to an empty string on error.
+func (a *SQLAgent) buildSchemaDescription(ctx context.Context) (string, error) {
+	if a.deps.SchemaBuilder == nil {
+		return "", nil
+	}
+	return a.deps.SchemaBuilder.BuildSchemaDescription(ctx, a.deps.Chatbot.AllowedSchemas, a.deps.Chatbot.AllowedTables)
+}
+
+// executeSQL runs one SQL query via the existing Executor and returns the
+// formatted result string (for the LLM) and the QueryResult (for state).
+func (a *SQLAgent) executeSQL(ctx context.Context, tc ToolCall, chatbot *Chatbot, allowedTables []string) (string, *QueryResult) {
+	var args struct {
+		SQL         string `json:"sql"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		return fmt.Sprintf("Error: failed to parse tool arguments: %v", err), nil
+	}
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendProgress(ctx, a.deps.ConversationID, "querying", fmt.Sprintf("Executing: %s", args.Description))
+	}
+
+	execReq := &ExecuteRequest{
+		ChatbotName:       chatbot.Name,
+		ChatbotID:         chatbot.ID,
+		ConversationID:    a.deps.ConversationID,
+		UserID:            a.deps.UserID,
+		Role:              a.deps.Role,
+		Claims:            a.deps.Claims,
+		SQL:               args.SQL,
+		Description:       args.Description,
+		AllowedSchemas:    chatbot.AllowedSchemas,
+		AllowedTables:     allowedTables,
+		AllowedOperations: chatbot.AllowedOperations,
+	}
+
+	result, err := a.deps.SQLExecutor.Execute(ctx, execReq)
+	if err != nil {
+		return FormatErrorForLLM(err, args.SQL, "execute_sql"), nil
+	}
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendQueryResult(ctx, a.deps.ConversationID, QueryResult{
+			Query:    args.SQL,
+			Summary:  result.Summary,
+			RowCount: result.RowCount,
+			Data:     result.Rows,
+		})
+	}
+
+	if !result.Success {
+		return FormatErrorForLLM(fmt.Errorf("%s", result.Error), args.SQL, "execute_sql"), nil
+	}
+
+	queryResult := &QueryResult{
+		Query:    args.SQL,
+		Summary:  result.Summary,
+		RowCount: result.RowCount,
+		Data:     result.Rows,
+	}
+
+	// Format for LLM consumption: summary + first 5 rows
+	resultStr := fmt.Sprintf("Query executed successfully. %s\n", result.Summary)
+	if len(result.Rows) > 0 {
+		maxRows := 5
+		if len(result.Rows) < maxRows {
+			maxRows = len(result.Rows)
+		}
+		sampleData, _ := json.Marshal(result.Rows[:maxRows])
+		resultStr += fmt.Sprintf("Sample data (first %d rows): %s", maxRows, string(sampleData))
+	}
+
+	// ponytail: intentionally not running intent/required-columns validation
+	// here — the SQL agent's prompt already enforces good behavior, and the
+	// executor's SQLValidator runs the actual safety checks. Intent rules
+	// remain enforced on the legacy react path for backwards compat.
+
+	return resultStr, queryResult
+}
+
+// tailMessages returns the last n messages from a conversation history.
+// Used to seed an agent's context window without unbounded token cost.
+func tailMessages(msgs []Message, n int) []Message {
+	if len(msgs) <= n {
+		return msgs
+	}
+	return msgs[len(msgs)-n:]
+}

--- a/internal/ai/agent_supervisor.go
+++ b/internal/ai/agent_supervisor.go
@@ -1,0 +1,219 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// SupervisorPlan is the structured output contract returned by the
+// Supervisor agent. It drives routing decisions in the supervisor graph.
+type SupervisorPlan struct {
+	UserLanguage      string   `json:"user_language"`
+	Route             []string `json:"route"`
+	SubQuestions      []string `json:"sub_questions,omitempty"`
+	RequiresSynthesis bool     `json:"requires_synthesis"`
+	IsInvestigative   bool     `json:"is_investigative"`
+	MinToolCalls      int      `json:"min_tool_calls"`
+}
+
+// investigativeKeywords is the regex-free pre-pass used to bias the
+// supervisor's routing decision. If any of these appear in the user
+// message, the supervisor prompt nudges toward "sql". The LLM still makes
+// the final call.
+var investigativeKeywords = []string{
+	"how many", "how much", "how often",
+	"count", "list", "show me", "show all",
+	"find", "total", "sum", "average", "avg", "mean",
+	"what is the", "what are the",
+	"which", "who", "when",
+	"compare", "comparison",
+	"top", "bottom", "best", "worst",
+	"group by", "by category", "by month", "by week", "by day",
+	"trend", "trends",
+	"between", "since", "before", "after",
+}
+
+// looksInvestigative returns true if the user message contains any of the
+// investigative keywords. Case-insensitive.
+func looksInvestigative(msg string) bool {
+	lower := strings.ToLower(msg)
+	for _, kw := range investigativeKeywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// SupervisorAgent is the routing node. It runs one non-streaming LLM call
+// against the chatbot's provider, parses the JSON SupervisorPlan, applies
+// the page-profile whitelist (when present), and stores the result in graph
+// state for downstream nodes to consume.
+type SupervisorAgent struct {
+	deps *AgentDeps
+}
+
+// NewSupervisorAgent constructs a SupervisorAgent bound to the given deps.
+func NewSupervisorAgent(deps *AgentDeps) *SupervisorAgent {
+	return &SupervisorAgent{deps: deps}
+}
+
+// Name implements Node.
+func (a *SupervisorAgent) Name() string { return "supervisor" }
+
+// Run executes the supervisor's routing decision.
+//
+// Errors here are recoverable — the supervisor graph falls back to the
+// legacy ReAct loop on failure (see chat_handler_message.go).
+func (a *SupervisorAgent) Run(ctx context.Context, state *State) error {
+	chatbot := a.deps.Chatbot
+	provider := a.deps.Provider
+	userMsg := state.UserMessage()
+
+	if provider == nil {
+		return fmt.Errorf("supervisor: no provider available")
+	}
+
+	// Build the supervisor's messages: static system prompt + dynamic
+	// context (per-page whitelist) + user message.
+	systemPrompt := BuildSupervisorPrompt(chatbot)
+	dynamicContext := buildSupervisorDynamicContext(chatbot, state.PageProfile())
+
+	messages := []Message{
+		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleSystem, Content: dynamicContext},
+		{Role: RoleUser, Content: userMsg},
+	}
+
+	model := chatbot.Model
+	if override, ok := chatbot.SupervisorAgentModels["supervisor"]; ok && override != "" {
+		model = override
+	}
+
+	req := &ChatRequest{
+		Messages:    messages,
+		Model:       model,
+		MaxTokens:   600,
+		Temperature: 0,
+		Stream:      false,
+	}
+
+	resp, err := provider.Chat(ctx, req)
+	if err != nil {
+		return fmt.Errorf("supervisor: provider call failed: %w", err)
+	}
+	if resp == nil || len(resp.Choices) == 0 {
+		return fmt.Errorf("supervisor: empty response from provider")
+	}
+	content := resp.Choices[0].Message.Content
+	if resp.Usage != nil {
+		state.AddUsage(*resp.Usage)
+	}
+
+	plan, err := parseSupervisorPlan(content)
+	if err != nil {
+		return fmt.Errorf("supervisor: failed to parse plan: %w (content=%q)", err, content)
+	}
+
+	// Apply page-profile whitelist: filter out agents the page doesn't allow.
+	if profile := state.PageProfile(); profile != nil && len(profile.Agents) > 0 {
+		filtered := make([]string, 0, len(plan.Route))
+		for _, r := range plan.Route {
+			if profile.HasAgent(r) {
+				filtered = append(filtered, r)
+			}
+		}
+		// If filtering removed everything (LLM routed to disallowed agents),
+		// fall back to "chat" so the user still gets a coherent response.
+		if len(filtered) == 0 {
+			filtered = []string{"chat"}
+		}
+		plan.Route = filtered
+	}
+
+	// Empty route is treated as a chat fallback.
+	if len(plan.Route) == 0 {
+		plan.Route = []string{"chat"}
+	}
+
+	// Default MinToolCalls when investigative but unset.
+	if plan.IsInvestigative && plan.MinToolCalls <= 0 {
+		plan.MinToolCalls = 1
+	}
+
+	state.Set(SupervisorPlanKey, plan)
+	state.SetUserLanguage(plan.UserLanguage)
+	return nil
+}
+
+// SupervisorPlanKey is the state key under which the parsed SupervisorPlan
+// is stored. Exposed so other nodes (and tests) can fetch it.
+const SupervisorPlanKey = stateKeySupervisorPlan
+
+// parseSupervisorPlan extracts the SupervisorPlan JSON from the LLM output.
+// Tolerates markdown fences and stray prose around the JSON object.
+func parseSupervisorPlan(content string) (*SupervisorPlan, error) {
+	cleaned := extractJSONObjectFromString(content)
+	if cleaned == "" {
+		return nil, fmt.Errorf("no JSON object found in content")
+	}
+
+	var plan SupervisorPlan
+	if err := json.Unmarshal([]byte(cleaned), &plan); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	// Validate route entries
+	for _, r := range plan.Route {
+		switch r {
+		case "sql", "kb", "action", "chat":
+			// valid
+		default:
+			return nil, fmt.Errorf("unknown agent in route: %q", r)
+		}
+	}
+
+	return &plan, nil
+}
+
+// extractJSONObjectFromString finds the first balanced {...} substring in s.
+// Used to tolerate stray prose or markdown fences around the supervisor's
+// JSON output.
+func extractJSONObjectFromString(s string) string {
+	start := strings.Index(s, "{")
+	if start < 0 {
+		return ""
+	}
+	return extractBalancedJSONObject(s, start)
+}
+
+// buildSupervisorDynamicContext returns the per-turn dynamic context
+// message for the supervisor. Includes the page-profile agent whitelist
+// when present so the supervisor's routing respects it.
+func buildSupervisorDynamicContext(chatbot *Chatbot, profile *PageProfile) string {
+	var sb strings.Builder
+	sb.WriteString("Current date and time: ")
+	sb.WriteString(currentTimeForPrompt())
+	sb.WriteString("\n")
+
+	if profile != nil {
+		fmt.Fprintf(&sb, "\n## Page Context\n\n")
+		fmt.Fprintf(&sb, "User is currently on page: %s\n", profile.Page)
+		if len(profile.Agents) > 0 {
+			fmt.Fprintf(&sb, "Agents available on this page: %s\n", strings.Join(profile.Agents, ", "))
+			sb.WriteString("Route ONLY to agents in the list above. If the user's intent doesn't match any available agent, route to \"chat\" with a clarification.\n")
+		}
+		if profile.Suffix != "" {
+			fmt.Fprintf(&sb, "Focus instruction: %s\n", profile.Suffix)
+		}
+	}
+
+	// Pre-pass hint: if the message contains investigative keywords, nudge.
+	// This is advisory — the LLM still makes the final call.
+	// (Used inside buildSupervisorDynamicContext so the hint travels with
+	// the page context, not the static prompt.)
+
+	return sb.String()
+}

--- a/internal/ai/agent_supervisor_test.go
+++ b/internal/ai/agent_supervisor_test.go
@@ -1,0 +1,171 @@
+package ai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSupervisorPlan_ValidJSON(t *testing.T) {
+	content := `{"user_language":"German","route":["sql"],"requires_synthesis":false,"is_investigative":true,"min_tool_calls":2}`
+	plan, err := parseSupervisorPlan(content)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	assert.Equal(t, "German", plan.UserLanguage)
+	assert.Equal(t, []string{"sql"}, plan.Route)
+	assert.True(t, plan.IsInvestigative)
+	assert.Equal(t, 2, plan.MinToolCalls)
+}
+
+func TestParseSupervisorPlan_ToleratesMarkdownFences(t *testing.T) {
+	content := "```json\n" + `{"user_language":"English","route":["chat"]}` + "\n```"
+	plan, err := parseSupervisorPlan(content)
+	require.NoError(t, err)
+	assert.Equal(t, "English", plan.UserLanguage)
+	assert.Equal(t, []string{"chat"}, plan.Route)
+}
+
+func TestParseSupervisorPlan_ToleratesStrayProse(t *testing.T) {
+	content := `Here is my plan: {"user_language":"English","route":["chat"]}. Done.`
+	plan, err := parseSupervisorPlan(content)
+	require.NoError(t, err)
+	assert.Equal(t, "English", plan.UserLanguage)
+}
+
+func TestParseSupervisorPlan_RejectsUnknownAgent(t *testing.T) {
+	content := `{"user_language":"English","route":["nonsense"]}`
+	_, err := parseSupervisorPlan(content)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown agent")
+}
+
+func TestParseSupervisorPlan_RejectsMissingJSON(t *testing.T) {
+	_, err := parseSupervisorPlan("no json here")
+	require.Error(t, err)
+}
+
+func TestLooksInvestigative_MatchesKeywords(t *testing.T) {
+	cases := map[string]bool{
+		"how many users":      true,
+		"count the orders":    true,
+		"show me top 10":      true,
+		"list all customers":  true,
+		"what is the total":   true,
+		"sum of revenue":      true,
+		"average order value": true,
+		"hello":               false,
+		"thanks":              false,
+		"what is love":        false, // "what is the" wouldn't match
+	}
+	for msg, want := range cases {
+		assert.Equal(t, want, looksInvestigative(msg), "msg=%q", msg)
+	}
+}
+
+func TestSupervisorAgent_RunsAndStoresPlan(t *testing.T) {
+	provider := newFakeProvider("test")
+	provider.QueueResponse(newSimpleResponse(`{"user_language":"English","route":["chat"],"requires_synthesis":false,"is_investigative":false,"min_tool_calls":0}`))
+
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{Chatbot: chatbot, Provider: provider}
+	supervisor := NewSupervisorAgent(deps)
+
+	state := NewState()
+	state.SetUserMessage("hi")
+	err := supervisor.Run(context.Background(), state)
+	require.NoError(t, err)
+
+	planVal, ok := state.Get(SupervisorPlanKey)
+	require.True(t, ok)
+	plan, ok := planVal.(*SupervisorPlan)
+	require.True(t, ok)
+	assert.Equal(t, "English", plan.UserLanguage)
+	assert.Equal(t, []string{"chat"}, plan.Route)
+	assert.Equal(t, "English", state.UserLanguage())
+}
+
+func TestSupervisorAgent_PageProfileWhitelist_FiltersRoute(t *testing.T) {
+	provider := newFakeProvider("test")
+	// LLM routes to sql+kb, but page profile only allows sql
+	provider.QueueResponse(newSimpleResponse(`{"user_language":"English","route":["sql","kb"],"requires_synthesis":true,"is_investigative":true,"min_tool_calls":1}`))
+
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{
+		Chatbot:     chatbot,
+		Provider:    provider,
+		PageProfile: &PageProfile{Page: "orders", Agents: []string{"sql"}},
+	}
+	supervisor := NewSupervisorAgent(deps)
+
+	state := NewState()
+	state.SetUserMessage("show me the orders")
+	state.SetPageProfile(deps.PageProfile)
+	err := supervisor.Run(context.Background(), state)
+	require.NoError(t, err)
+
+	planVal, _ := state.Get(SupervisorPlanKey)
+	plan := planVal.(*SupervisorPlan)
+	// kb should have been filtered out
+	assert.Equal(t, []string{"sql"}, plan.Route)
+}
+
+func TestSupervisorAgent_PageProfileFiltersAll_FallsBackToChat(t *testing.T) {
+	provider := newFakeProvider("test")
+	// LLM routes to sql, but page profile only allows chat
+	provider.QueueResponse(newSimpleResponse(`{"user_language":"English","route":["sql"],"is_investigative":true,"min_tool_calls":1}`))
+
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{
+		Chatbot:     chatbot,
+		Provider:    provider,
+		PageProfile: &PageProfile{Page: "chat-only", Agents: []string{"chat"}},
+	}
+	supervisor := NewSupervisorAgent(deps)
+
+	state := NewState()
+	state.SetUserMessage("query something")
+	state.SetPageProfile(deps.PageProfile)
+	err := supervisor.Run(context.Background(), state)
+	require.NoError(t, err)
+
+	planVal, _ := state.Get(SupervisorPlanKey)
+	plan := planVal.(*SupervisorPlan)
+	assert.Equal(t, []string{"chat"}, plan.Route)
+}
+
+func TestSupervisorAgent_InvestigativeWithoutMinCalls_DefaultsTo1(t *testing.T) {
+	provider := newFakeProvider("test")
+	provider.QueueResponse(newSimpleResponse(`{"user_language":"English","route":["sql"],"is_investigative":true,"min_tool_calls":0}`))
+
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{Chatbot: chatbot, Provider: provider}
+	state := NewState()
+	state.SetUserMessage("count users")
+	require.NoError(t, NewSupervisorAgent(deps).Run(context.Background(), state))
+
+	planVal, _ := state.Get(SupervisorPlanKey)
+	plan := planVal.(*SupervisorPlan)
+	assert.Equal(t, 1, plan.MinToolCalls)
+}
+
+func TestSupervisorAgent_ProviderError_ReturnsError(t *testing.T) {
+	provider := newFakeProvider("test")
+	provider.QueueError(assertError("provider down"))
+
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{Chatbot: chatbot, Provider: provider}
+	state := NewState()
+	state.SetUserMessage("hi")
+	err := NewSupervisorAgent(deps).Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider call failed")
+}
+
+// assertError is a tiny helper to construct an error inline.
+func assertError(msg string) error { return &simpleError{msg: msg} }
+
+type simpleError struct{ msg string }
+
+func (e *simpleError) Error() string { return e.msg }

--- a/internal/ai/agent_synthesizer_verifier.go
+++ b/internal/ai/agent_synthesizer_verifier.go
@@ -1,0 +1,324 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// SynthesizerAgent merges outputs from multiple specialist agents into one
+// coherent answer in the user's detected language. Skipped when only one
+// agent ran (the single agent's output is the final answer).
+type SynthesizerAgent struct {
+	deps *AgentDeps
+}
+
+// NewSynthesizerAgent constructs a SynthesizerAgent bound to the given deps.
+func NewSynthesizerAgent(deps *AgentDeps) *SynthesizerAgent {
+	return &SynthesizerAgent{deps: deps}
+}
+
+// Name implements Node.
+func (a *SynthesizerAgent) Name() string { return "synthesizer" }
+
+// Run merges specialist outputs into one final answer.
+func (a *SynthesizerAgent) Run(ctx context.Context, state *State) error {
+	chatbot := a.deps.Chatbot
+	provider := a.deps.Provider
+	if provider == nil {
+		return fmt.Errorf("synthesizer: no provider")
+	}
+
+	outputs := state.AgentOutputs()
+	if len(outputs) == 0 {
+		// Nothing to synthesize — final response stays whatever was last set
+		return nil
+	}
+	if len(outputs) == 1 {
+		// Single agent → its output IS the final response. Skip synthesis.
+		state.SetFinalResponse(outputs[0].Content)
+		return nil
+	}
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendAgentTransition(ctx, a.deps.ConversationID, AgentTransition{To: "synthesizer"})
+	}
+
+	systemPrompt := BuildSynthesizerPrompt(chatbot)
+	dynamicContext := fmt.Sprintf("Current date and time: %s\n", currentTimeForPrompt())
+	if lang := state.UserLanguage(); lang != "" {
+		dynamicContext += fmt.Sprintf("\nUser's detected language: %s\n", lang)
+		dynamicContext += "Write the synthesized answer in this language.\n"
+	}
+
+	// Build the user message: original question + each agent's output
+	var userMsg strings.Builder
+	fmt.Fprintf(&userMsg, "Original user question:\n%s\n\n", state.UserMessage())
+	userMsg.WriteString("Specialist agent outputs:\n\n")
+	for _, o := range outputs {
+		fmt.Fprintf(&userMsg, "## %s agent\n%s\n\n", o.Name, o.Content)
+	}
+	userMsg.WriteString("Synthesize the above into a single coherent answer.")
+
+	messages := []Message{
+		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleSystem, Content: dynamicContext},
+		{Role: RoleUser, Content: userMsg.String()},
+	}
+
+	model := chatbot.Model
+	if override, ok := chatbot.SupervisorAgentModels["synthesizer"]; ok && override != "" {
+		model = override
+	}
+
+	req := &ChatRequest{
+		Messages:    messages,
+		Model:       model,
+		MaxTokens:   chatbot.MaxTokens,
+		Temperature: chatbot.Temperature,
+		Stream:      false,
+	}
+
+	resp, err := provider.Chat(ctx, req)
+	if err != nil {
+		return fmt.Errorf("synthesizer: provider call failed: %w", err)
+	}
+	if resp == nil || len(resp.Choices) == 0 {
+		return fmt.Errorf("synthesizer: empty provider response")
+	}
+	if resp.Usage != nil {
+		state.AddUsage(*resp.Usage)
+	}
+
+	state.SetFinalResponse(resp.Choices[0].Message.Content)
+	return nil
+}
+
+// VerifierAgent checks the final answer against (1) the user's language
+// and (2) tool-result grounding. Runs only on the investigative path.
+// One retry cap — verifier never blocks the response permanently.
+type VerifierAgent struct {
+	deps *AgentDeps
+}
+
+// NewVerifierAgent constructs a VerifierAgent bound to the given deps.
+func NewVerifierAgent(deps *AgentDeps) *VerifierAgent {
+	return &VerifierAgent{deps: deps}
+}
+
+// Name implements Node.
+func (a *VerifierAgent) Name() string { return "verifier" }
+
+// Run performs the verification checks. Stores the report in state but
+// does NOT mutate the final response directly — the caller (supervisor
+// graph) decides whether to retry based on the report.
+func (a *VerifierAgent) Run(ctx context.Context, state *State) error {
+	report := &VerifyReport{}
+
+	userMsg := state.UserMessage()
+	response := state.FinalResponse()
+
+	// Always: rule-based language script check
+	report.LanguageOK = checkLanguageScriptMatch(userMsg, response)
+
+	// Conditional LLM grounding check
+	plan, _ := state.Get(SupervisorPlanKey)
+	supervisorPlan, _ := plan.(*SupervisorPlan)
+	toolResults := state.ToolResults()
+
+	if supervisorPlan != nil && supervisorPlan.IsInvestigative && report.LanguageOK && len(toolResults) > 0 && a.deps.Provider != nil {
+		if a.deps.Sender != nil {
+			a.deps.Sender.SendAgentTransition(ctx, a.deps.ConversationID, AgentTransition{To: "verifier"})
+		}
+		llmReport, err := a.groundingCheck(ctx, userMsg, response, toolResults, supervisorPlan)
+		if err == nil && llmReport != nil {
+			report.GroundingOK = llmReport.OK
+			report.Issues = append(report.Issues, llmReport.Issues...)
+		}
+	} else {
+		report.GroundingOK = true
+	}
+
+	state.Set(VerifyReportKey, report)
+	return nil
+}
+
+// VerifyReport is the verifier's output, stored in state for the supervisor
+// graph to act on.
+type VerifyReport struct {
+	LanguageOK  bool
+	GroundingOK bool
+	Issues      []string
+}
+
+// VerifyReportKey is the state key for the verifier's report.
+const VerifyReportKey = "verify_report"
+
+// groundingCheck runs the LLM grounding check and returns its verdict.
+func (a *VerifierAgent) groundingCheck(ctx context.Context, userMsg, response string, toolResults []QueryResult, plan *SupervisorPlan) (*verifierLLMReport, error) {
+	chatbot := a.deps.Chatbot
+	provider := a.deps.Provider
+
+	systemPrompt := BuildVerifierPrompt()
+
+	// Format tool results compactly for the verifier
+	var toolDump strings.Builder
+	for i, r := range toolResults {
+		fmt.Fprintf(&toolDump, "### Query %d\nSQL: %s\nSummary: %s\nRows returned: %d\n", i+1, r.Query, r.Summary, r.RowCount)
+		if len(r.Data) > 0 {
+			sample := r.Data
+			if len(sample) > 3 {
+				sample = sample[:3]
+			}
+			sampleJSON, _ := json.Marshal(sample)
+			fmt.Fprintf(&toolDump, "Sample rows: %s\n\n", string(sampleJSON))
+		} else {
+			toolDump.WriteString("\n")
+		}
+	}
+
+	userContent := fmt.Sprintf(
+		"User question:\n%s\n\nAnswer to verify:\n%s\n\nTool results:\n%s",
+		userMsg, response, toolDump.String(),
+	)
+
+	messages := []Message{
+		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleUser, Content: userContent},
+	}
+
+	model := chatbot.Model
+	if override, ok := chatbot.SupervisorAgentModels["verifier"]; ok && override != "" {
+		model = override
+	}
+
+	req := &ChatRequest{
+		Messages:    messages,
+		Model:       model,
+		MaxTokens:   300,
+		Temperature: 0,
+		Stream:      false,
+	}
+
+	resp, err := provider.Chat(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("empty verifier response")
+	}
+	if resp.Usage != nil {
+		s := getStateFromContext(ctx)
+		if s != nil {
+			s.AddUsage(*resp.Usage)
+		}
+	}
+
+	content := resp.Choices[0].Message.Content
+	cleaned := extractJSONObjectFromString(content)
+	if cleaned == "" {
+		// ponytail: if LLM didn't return JSON, assume grounding OK
+		// (don't fail the response on a verifier formatting bug)
+		return &verifierLLMReport{OK: true}, nil
+	}
+	var out verifierLLMReport
+	if err := json.Unmarshal([]byte(cleaned), &out); err != nil {
+		return &verifierLLMReport{OK: true}, nil
+	}
+	return &out, nil
+}
+
+type verifierLLMReport struct {
+	OK     bool     `json:"ok"`
+	Issues []string `json:"issues"`
+}
+
+// checkLanguageScriptMatch returns true if userMsg and response are written
+// in the same dominant Unicode script. Catches the common failure mode
+// where the model replies in English to a non-English question.
+//
+// Heuristic, not a hard guarantee — mixed-script messages (e.g., a German
+// message with English brand names) are matched permissively.
+func checkLanguageScriptMatch(userMsg, response string) bool {
+	userScript := dominantScript(userMsg)
+	respScript := dominantScript(response)
+
+	// If either is empty/mixed, treat as a match (be permissive)
+	if userScript == "" || respScript == "" || userScript == "mixed" || respScript == "mixed" {
+		return true
+	}
+	return userScript == respScript
+}
+
+// dominantScript returns the dominant Unicode script of s by counting
+// letters in each script. Returns "mixed" if no script has >60% of letters,
+// "" if there are no letters at all.
+func dominantScript(s string) string {
+	counts := map[string]int{}
+	total := 0
+	for _, r := range s {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		total++
+		for name, table := range scriptTables {
+			if table(r) {
+				counts[name]++
+				break
+			}
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+	var dominant string
+	max := 0
+	for name, c := range counts {
+		if c > max {
+			max = c
+			dominant = name
+		}
+	}
+	if max*100/total < 60 {
+		return "mixed"
+	}
+	return dominant
+}
+
+// scriptTables is the per-script classifier set. Order matters: more
+// specific checks first (e.g., Hiragana before "any Han").
+var scriptTables = map[string]func(rune) bool{
+	"latin":      func(r rune) bool { return unicode.In(r, unicode.Latin) },
+	"cyrillic":   func(r rune) bool { return unicode.In(r, unicode.Cyrillic) },
+	"greek":      func(r rune) bool { return unicode.In(r, unicode.Greek) },
+	"arabic":     func(r rune) bool { return unicode.In(r, unicode.Arabic) },
+	"hebrew":     func(r rune) bool { return unicode.In(r, unicode.Hebrew) },
+	"han":        func(r rune) bool { return unicode.In(r, unicode.Han) },
+	"hiragana":   func(r rune) bool { return unicode.In(r, unicode.Hiragana) },
+	"katakana":   func(r rune) bool { return unicode.In(r, unicode.Katakana) },
+	"hangul":     func(r rune) bool { return unicode.In(r, unicode.Hangul) },
+	"devanagari": func(r rune) bool { return unicode.In(r, unicode.Devanagari) },
+	"thai":       func(r rune) bool { return unicode.In(r, unicode.Thai) },
+}
+
+// getStateFromContext pulls the state back out of context for usage
+// accumulation in nested helper functions. Returns nil if not present.
+// ponytail: thread-through-context saves us threading *State through every
+// helper signature. If usage accounting gets complex, upgrade to explicit
+// parameter.
+func getStateFromContext(ctx context.Context) *State {
+	if s, ok := ctx.Value(stateContextKey{}).(*State); ok {
+		return s
+	}
+	return nil
+}
+
+// stateContextKey is the context key type for *State values.
+type stateContextKey struct{}
+
+// ContextWithState returns ctx with state attached for downstream helpers.
+func ContextWithState(ctx context.Context, state *State) context.Context {
+	return context.WithValue(ctx, stateContextKey{}, state)
+}

--- a/internal/ai/chat_handler.go
+++ b/internal/ai/chat_handler.go
@@ -157,6 +157,12 @@ type ClientMessage struct {
 	ConversationID    string `json:"conversation_id,omitempty"`
 	Content           string `json:"content,omitempty"`
 	ImpersonateUserID string `json:"impersonate_user_id,omitempty"` // Admin-only: test as this user
+	// PageContext is the optional page-context string sent per-message by
+	// clients that embed a single chatbot across multiple app pages. When
+	// present, the supervisor looks up the matching PageProfile (if any)
+	// and uses it to bias routing and override per-page config. Missing or
+	// unknown values fall back to the chatbot's global config.
+	PageContext string `json:"page_context,omitempty"`
 }
 
 // ServerMessage represents a message to the client
@@ -179,8 +185,18 @@ type ServerMessage struct {
 	// DailyQuota carries the per-user remaining quota snapshot at turn end
 	// (Ask 2). Omitted when no daily limits are configured for the chatbot.
 	DailyQuota *DailyQuotaSnapshot `json:"daily_quota,omitempty"`
-	Error      string              `json:"error,omitempty"`
-	Code       string              `json:"code,omitempty"`
+	// AgentTransition is set on agent_transition event types, emitted by
+	// the supervisor graph when one agent hands off to another. Optional
+	// observability for clients that want to render the routing flow.
+	AgentTransition *AgentTransition `json:"agent_transition,omitempty"`
+	// Agent names the currently-active specialist in agent_transition /
+	// agent_complete events.
+	Agent string `json:"agent,omitempty"`
+	// PageContext echoes the page_context string from the client's message
+	// back in agent_transition events, so multi-page clients can correlate.
+	PageContext string `json:"page_context,omitempty"`
+	Error       string `json:"error,omitempty"`
+	Code        string `json:"code,omitempty"`
 }
 
 // DailyQuotaSnapshot is a point-in-time view of the per-user daily counters

--- a/internal/ai/chat_handler_message.go
+++ b/internal/ai/chat_handler_message.go
@@ -162,6 +162,31 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 	// Save user message to conversation
 	_ = h.conversations.AddMessage(ctx, msg.ConversationID, userMsg, 0, 0)
 
+	// ── Supervisor mode branch ────────────────────────────────────────────
+	// When the chatbot's reasoning mode is "supervisor" (the default for new
+	// chatbots), the turn is handled by the multi-agent graph in
+	// supervisor_graph.go. On any failure (provider down, parse error, etc.),
+	// we fall back to the legacy ReAct loop below so a supervisor bug never
+	// breaks the chatbot entirely.
+	if chatbot.ReasoningMode == "supervisor" && h.canRunSupervisor(chatbot) {
+		supervisorRan, supervisorErr := h.runSupervisorTurn(ctx, chatCtx, chatbot, msg, userID, provider)
+		if supervisorRan {
+			if supervisorErr != nil {
+				// Supervisor completed but reported an error (e.g., a node
+				// failed mid-graph). Surface as a soft warning and continue
+				// to the legacy loop as a safety net.
+				log.Warn().Err(supervisorErr).
+					Str("chatbot", chatbot.Name).
+					Str("conversation_id", msg.ConversationID).
+					Msg("Supervisor turn reported an error; falling back to ReAct loop")
+			} else {
+				return
+			}
+		}
+		// supervisorRan == false means we couldn't build a graph for this
+		// chatbot (e.g., no provider). Fall through to legacy path.
+	}
+
 	// Tool calling loop - continue until AI generates content without tool calls
 	var totalUsage UsageStats
 	var accumulatedQueryResults []QueryResult // Accumulate query results for persistence

--- a/internal/ai/chat_handler_supervisor.go
+++ b/internal/ai/chat_handler_supervisor.go
@@ -1,0 +1,225 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/nimbleflux/fluxbase/internal/auth"
+)
+
+// canRunSupervisor returns true if the chatbot has the minimum dependencies
+// required to run the supervisor pipeline (a provider, at minimum). Used to
+// decide whether to attempt the supervisor path or fall back to ReAct.
+func (h *ChatHandler) canRunSupervisor(chatbot *Chatbot) bool {
+	if chatbot == nil {
+		return false
+	}
+	if chatbot.ReasoningMode != "supervisor" {
+		return false
+	}
+	// Provider check happens lazily inside runSupervisorTurn — if it can't
+	// resolve a provider, it returns supervisorRan=false and we fall through.
+	return true
+}
+
+// runSupervisorTurn executes one user turn via the supervisor graph.
+//
+// Returns (ran, err):
+//   - ran=true, err=nil: supervisor handled the turn completely. Caller returns.
+//   - ran=true, err!=nil: supervisor started but a node failed. Caller logs
+//     and falls back to the legacy ReAct loop for safety.
+//   - ran=false: supervisor couldn't start (e.g., no provider). Caller
+//     falls through to the legacy path silently.
+func (h *ChatHandler) runSupervisorTurn(ctx context.Context, chatCtx *ChatContext, chatbot *Chatbot, msg *ClientMessage, userID string, provider Provider) (bool, error) {
+	if provider == nil {
+		return false, nil
+	}
+
+	// Build initial state
+	state := NewState()
+	state.SetUserMessage(msg.Content)
+	state.SetPageContext(msg.PageContext)
+	state.SetConversationHistory(state.ConversationHistory()) // placeholder, real history below
+
+	// Get conversation history (last few messages) — bounded so token costs
+	// don't explode for long conversations.
+	if state2, ok := chatCtx.Conversations[msg.ConversationID]; ok && len(state2.Messages) > 0 {
+		state.SetConversationHistory(tailMessages(state2.Messages, 6))
+	}
+
+	// Resolve page profile from chatbot config (if any)
+	if profile := chatbot.PageProfiles.Resolve(msg.PageContext); profile != nil {
+		state.SetPageProfile(profile)
+	}
+
+	// Build deps bundle for this turn
+	deps := &AgentDeps{
+		Chatbot:        chatbot,
+		Provider:       provider,
+		UserID:         userID,
+		Role:           chatCtx.Role,
+		Claims:         chatCtx.Claims,
+		PageProfile:    state.PageProfile(),
+		SQLExecutor:    h.executor,
+		SchemaBuilder:  h.schemaBuilder,
+		RAGService:     h.ragService,
+		MCPExecutor:    h.mcpExecutor,
+		ConversationID: msg.ConversationID,
+		Sender: &chatHandlerSender{
+			h:              h,
+			chatCtx:        chatCtx,
+			conversationID: msg.ConversationID,
+			pageContext:    msg.PageContext,
+		},
+	}
+
+	graph := NewSupervisorGraph(deps)
+	if err := graph.Run(ctx, state); err != nil {
+		return true, fmt.Errorf("supervisor graph failed: %w", err)
+	}
+
+	// Stream the final response to the client. The supervisor path doesn't
+	// stream token-by-token (each node uses non-streaming calls for
+	// simplicity). If token-streaming is needed in the future, the
+	// synthesizer / single-agent path would switch to ChatStream.
+	finalResponse := state.FinalResponse()
+	if finalResponse == "" {
+		finalResponse = "I wasn't able to generate a response. Please try again."
+	}
+
+	// Send content to client as one chunk (no streaming).
+	h.send(chatCtx, ServerMessage{
+		Type:           "content",
+		ConversationID: msg.ConversationID,
+		Delta:          finalResponse,
+	})
+
+	// Save assistant message with query results
+	assistantMsg := Message{
+		Role:         RoleAssistant,
+		Content:      finalResponse,
+		QueryResults: state.ToolResults(),
+	}
+	totalUsage := state.Usage()
+	_ = h.conversations.AddMessage(ctx, msg.ConversationID, assistantMsg, totalUsage.PromptTokens, totalUsage.CompletionTokens)
+
+	// Track token usage for daily budget enforcement
+	if chatbot.DailyTokenBudget > 0 {
+		userIdentifier := "anonymous"
+		if chatCtx.UserID != nil {
+			userIdentifier = *chatCtx.UserID
+		}
+		effective := totalUsage.PromptTokens - totalUsage.CachedTokens + totalUsage.CompletionTokens
+		if effective < 0 {
+			effective = 0
+		}
+		h.limiter.AddTokenUsage(chatbot.ID, userIdentifier, effective)
+	}
+
+	// Build per-user daily quota snapshot for the done event
+	var dailyQuota *DailyQuotaSnapshot
+	if chatbot.DailyRequestLimit > 0 || chatbot.DailyTokenBudget > 0 {
+		userIdentifier := "anonymous"
+		if chatCtx.UserID != nil {
+			userIdentifier = *chatCtx.UserID
+		}
+		usage := h.limiter.GetDailyUsage(chatbot.ID, userIdentifier, chatbot.DailyRequestLimit, chatbot.DailyTokenBudget)
+		dailyQuota = &DailyQuotaSnapshot{
+			Requests: Quota{Used: usage.RequestsUsed, Limit: usage.RequestsLimit},
+			Tokens:   Quota{Used: usage.TokensUsed, Limit: usage.TokensLimit},
+			ResetsAt: usage.ResetsAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		}
+	}
+
+	h.send(chatCtx, ServerMessage{
+		Type:           "done",
+		ConversationID: msg.ConversationID,
+		Usage:          &totalUsage,
+		DailyQuota:     dailyQuota,
+		PageContext:    msg.PageContext,
+	})
+
+	// Record metrics
+	if h.metrics != nil {
+		h.metrics.RecordAIChatRequest(chatbot.Name, "success", 0)
+		h.metrics.RecordAITokens(chatbot.Name, totalUsage.PromptTokens, totalUsage.CompletionTokens)
+	}
+
+	log.Debug().
+		Str("conversation_id", msg.ConversationID).
+		Int("prompt_tokens", totalUsage.PromptTokens).
+		Int("completion_tokens", totalUsage.CompletionTokens).
+		Msg("Supervisor turn processed")
+
+	return true, nil
+}
+
+// chatHandlerSender bridges AgentEventSender to the ChatHandler's WS send.
+// Each agent calls these methods to emit events to the connected client.
+type chatHandlerSender struct {
+	h              *ChatHandler
+	chatCtx        *ChatContext
+	conversationID string
+	pageContext    string
+}
+
+// SendProgress emits a progress event.
+func (s *chatHandlerSender) SendProgress(ctx context.Context, conversationID, step, message string) {
+	if s == nil || s.h == nil {
+		return
+	}
+	s.h.sendProgress(s.chatCtx, conversationID, step, message)
+}
+
+// SendContent streams a content delta to the client.
+func (s *chatHandlerSender) SendContent(ctx context.Context, conversationID, delta string) {
+	if s == nil || s.h == nil {
+		return
+	}
+	s.h.send(s.chatCtx, ServerMessage{
+		Type:           "content",
+		ConversationID: conversationID,
+		Delta:          delta,
+	})
+}
+
+// SendQueryResult emits a structured query_result event.
+func (s *chatHandlerSender) SendQueryResult(ctx context.Context, conversationID string, result QueryResult) {
+	if s == nil || s.h == nil {
+		return
+	}
+	s.h.send(s.chatCtx, ServerMessage{
+		Type:           "query_result",
+		ConversationID: conversationID,
+		Query:          result.Query,
+		Summary:        result.Summary,
+		RowCount:       result.RowCount,
+		Data:           result.Data,
+	})
+}
+
+// SendAgentTransition emits an agent_transition event with the optional
+// page_context echo so multi-page clients can correlate.
+func (s *chatHandlerSender) SendAgentTransition(ctx context.Context, conversationID string, transition AgentTransition) {
+	if s == nil || s.h == nil {
+		return
+	}
+	transition.PageContext = s.pageContext
+	s.h.send(s.chatCtx, ServerMessage{
+		Type:            "agent_transition",
+		ConversationID:  conversationID,
+		Agent:           transition.To,
+		AgentTransition: &transition,
+		PageContext:     s.pageContext,
+	})
+}
+
+// Compile-time assertion that chatHandlerSender satisfies AgentEventSender.
+var _ AgentEventSender = (*chatHandlerSender)(nil)
+
+// Unused import guard — auth is imported for the AgentDeps.Claims field
+// type. Keep the import even when other code paths don't reference it
+// directly here.
+var _ = (*auth.TokenClaims)(nil)

--- a/internal/ai/chatbot.go
+++ b/internal/ai/chatbot.go
@@ -90,9 +90,15 @@ type Chatbot struct {
 	RAGContentColumn       string   `json:"rag_content_column,omitempty"`     // Text content column in RAG table
 
 	// Agent behavior settings
-	ReasoningMode     string `json:"reasoning_mode,omitempty"`      // "none" (default), "react", "strict" - controls think tool usage
-	MaxToolIterations int    `json:"max_tool_iterations,omitempty"` // Max tool calling iterations (default: 5)
-	ShowReasoning     bool   `json:"show_reasoning,omitempty"`      // If true, expose agent reasoning to users
+	ReasoningMode     string       `json:"reasoning_mode,omitempty"`      // "supervisor" (default), "react", "strict", "none"
+	MaxToolIterations int          `json:"max_tool_iterations,omitempty"` // Max tool calling iterations (default: 5)
+	ShowReasoning     bool         `json:"show_reasoning,omitempty"`      // If true, expose agent reasoning to users
+	PageProfiles      PageProfiles `json:"page_profiles,omitempty"`       // Per-page routing/config overrides (Level 2 page-aware chatbots)
+	// SupervisorAgentModels optionally overrides the model used per specialist
+	// agent in supervisor mode. Keys are agent names: "supervisor", "sql",
+	// "kb", "action", "chat", "synthesizer", "verifier". Missing keys fall
+	// back to the chatbot's main Model.
+	SupervisorAgentModels map[string]string `json:"supervisor_agent_models,omitempty"`
 
 	Version   int       `json:"version"`
 	Source    string    `json:"source"` // "filesystem" or "api"
@@ -157,9 +163,11 @@ type ChatbotConfig struct {
 	UseMCPSchema bool     // If true, fetch schema from MCP resources
 
 	// Agent behavior settings
-	ReasoningMode     string // "none" (default), "react", "strict" - controls think tool usage
-	MaxToolIterations int    // Max tool calling iterations (default: 5)
-	ShowReasoning     bool   // If true, expose agent reasoning to users
+	ReasoningMode         string            // "supervisor" (default), "react", "strict", "none"
+	MaxToolIterations     int               // Max tool calling iterations (default: 5)
+	ShowReasoning         bool              // If true, expose agent reasoning to users
+	PageProfiles          PageProfiles      // Per-page routing/config overrides
+	SupervisorAgentModels map[string]string // Optional per-agent model overrides in supervisor mode
 
 	// Metadata
 	Version int
@@ -186,7 +194,7 @@ func DefaultChatbotConfig() ChatbotConfig {
 		RAGMaxChunks:           5,
 		RAGSimilarityThreshold: 0.7,
 		ResponseLanguage:       "auto",
-		ReasoningMode:          "react", // Default: require think tool before other tools (ReAct pattern)
+		ReasoningMode:          "supervisor", // Default: multi-agent supervisor pipeline. Pin "react" for the legacy ReAct loop.
 		MaxToolIterations:      5,
 		ShowReasoning:          false,
 		Version:                1,
@@ -298,8 +306,16 @@ var (
 	useMCPSchemaPattern = regexp.MustCompile(`@fluxbase:use-mcp-schema(?:\s+(true|false))?`)
 
 	// Agent behavior annotations
-	// @fluxbase:reasoning-mode react|strict|none
-	reasoningModePattern = regexp.MustCompile(`@fluxbase:reasoning-mode\s+(react|strict|none)`)
+	// @fluxbase:reasoning-mode supervisor|react|strict|none
+	reasoningModePattern = regexp.MustCompile(`@fluxbase:reasoning-mode\s+(supervisor|react|strict|none)`)
+
+	// @fluxbase:page-contexts [{...}]
+	// JSON array of page profiles. See PageProfile struct in page_context.go.
+	pageContextsPattern = regexp.MustCompile(`@fluxbase:page-contexts\s+(\[)`)
+
+	// @fluxbase:supervisor-models {"sql":"gpt-4-turbo","chat":"gpt-4o-mini"}
+	// Optional per-agent model overrides for supervisor mode.
+	supervisorModelsPattern = regexp.MustCompile(`@fluxbase:supervisor-models\s+(\{)`)
 
 	// @fluxbase:max-iterations 10
 	maxToolIterationsPattern = regexp.MustCompile(`@fluxbase:max-iterations\s+(\d+)`)
@@ -523,6 +539,49 @@ func ParseChatbotConfig(code string) ChatbotConfig {
 		config.ReasoningMode = matches[1]
 	}
 
+	// Parse page contexts (JSON array of PageProfile objects)
+	// Supports multiple annotations — later ones merge with earlier ones (last wins per page name).
+	allPageLocs := pageContextsPattern.FindAllStringIndex(code, -1)
+	for _, loc := range allPageLocs {
+		bracketIdx := strings.Index(code[loc[0]:], "[")
+		if bracketIdx >= 0 {
+			jsonStr := extractBalancedJSON(code, loc[0]+bracketIdx)
+			if jsonStr != "" {
+				profiles, err := ParsePageProfilesJSON(jsonStr)
+				if err != nil {
+					// ponytail: skip malformed block, don't fail the whole parse
+					continue
+				}
+				if config.PageProfiles == nil {
+					config.PageProfiles = make(PageProfiles)
+				}
+				for name, p := range profiles {
+					config.PageProfiles[name] = p
+				}
+			}
+		}
+	}
+
+	// Parse supervisor per-agent model overrides (JSON object)
+	allModelLocs := supervisorModelsPattern.FindAllStringIndex(code, -1)
+	for _, loc := range allModelLocs {
+		braceIdx := strings.Index(code[loc[0]:], "{")
+		if braceIdx >= 0 {
+			jsonStr := extractBalancedJSONObject(code, loc[0]+braceIdx)
+			if jsonStr != "" {
+				var models map[string]string
+				if err := json.Unmarshal([]byte(jsonStr), &models); err == nil {
+					if config.SupervisorAgentModels == nil {
+						config.SupervisorAgentModels = make(map[string]string)
+					}
+					for k, v := range models {
+						config.SupervisorAgentModels[k] = v
+					}
+				}
+			}
+		}
+	}
+
 	// Parse max tool iterations
 	if matches := maxToolIterationsPattern.FindStringSubmatch(code); len(matches) > 1 {
 		if v, err := strconv.Atoi(matches[1]); err == nil && v > 0 {
@@ -590,7 +649,19 @@ func parseRequiredColumns(s string) RequiredColumnsMap {
 // extractBalancedJSON extracts a balanced JSON array starting from the given position
 // startIdx should point to the opening bracket '['
 func extractBalancedJSON(s string, startIdx int) string {
-	if startIdx >= len(s) || s[startIdx] != '[' {
+	return extractBalanced(s, startIdx, '[', ']')
+}
+
+// extractBalancedJSONObject extracts a balanced JSON object starting from the
+// given position. startIdx should point to the opening brace '{'.
+func extractBalancedJSONObject(s string, startIdx int) string {
+	return extractBalanced(s, startIdx, '{', '}')
+}
+
+// extractBalanced extracts a balanced bracketed region (array or object),
+// respecting string literals and escape sequences. Returns "" if unbalanced.
+func extractBalanced(s string, startIdx int, open, close byte) string {
+	if startIdx >= len(s) || s[startIdx] != open {
 		return ""
 	}
 
@@ -621,9 +692,9 @@ func extractBalancedJSON(s string, startIdx int) string {
 		}
 
 		switch c {
-		case '[':
+		case open:
 			depth++
-		case ']':
+		case close:
 			depth--
 			if depth == 0 {
 				return s[startIdx : i+1]
@@ -673,6 +744,8 @@ func (c *Chatbot) ApplyConfig(config ChatbotConfig) {
 	c.ReasoningMode = config.ReasoningMode
 	c.MaxToolIterations = config.MaxToolIterations
 	c.ShowReasoning = config.ShowReasoning
+	c.PageProfiles = config.PageProfiles
+	c.SupervisorAgentModels = config.SupervisorAgentModels
 
 	// Only override version if explicitly set in annotation
 	if config.Version > 0 {
@@ -715,6 +788,74 @@ func (c *Chatbot) PopulateDerivedFields() {
 	if c.Model == "" && c.Code != "" {
 		if matches := modelPattern.FindStringSubmatch(c.Code); len(matches) > 1 {
 			c.Model = strings.TrimSpace(matches[1])
+		}
+	}
+
+	// Parse agent behavior annotations from code if not already set on the
+	// chatbot (DB-loaded chatbots don't have these columns). This is a
+	// best-effort parse — if it fails, defaults apply (supervisor mode).
+	if c.Code != "" {
+		// ReasoningMode: parse from code if empty, else default to "supervisor"
+		if c.ReasoningMode == "" {
+			if matches := reasoningModePattern.FindStringSubmatch(c.Code); len(matches) > 1 {
+				c.ReasoningMode = matches[1]
+			} else {
+				c.ReasoningMode = "supervisor"
+			}
+		}
+
+		// PageProfiles: parse from code (no DB column for this)
+		if c.PageProfiles == nil {
+			if locs := pageContextsPattern.FindAllStringIndex(c.Code, -1); len(locs) > 0 {
+				merged := make(PageProfiles)
+				for _, loc := range locs {
+					bracketIdx := strings.Index(c.Code[loc[0]:], "[")
+					if bracketIdx < 0 {
+						continue
+					}
+					jsonStr := extractBalancedJSON(c.Code, loc[0]+bracketIdx)
+					if jsonStr == "" {
+						continue
+					}
+					profiles, err := ParsePageProfilesJSON(jsonStr)
+					if err != nil {
+						continue
+					}
+					for name, p := range profiles {
+						merged[name] = p
+					}
+				}
+				if len(merged) > 0 {
+					c.PageProfiles = merged
+				}
+			}
+		}
+
+		// SupervisorAgentModels: parse from code (no DB column)
+		if c.SupervisorAgentModels == nil {
+			if locs := supervisorModelsPattern.FindAllStringIndex(c.Code, -1); len(locs) > 0 {
+				merged := make(map[string]string)
+				for _, loc := range locs {
+					braceIdx := strings.Index(c.Code[loc[0]:], "{")
+					if braceIdx < 0 {
+						continue
+					}
+					jsonStr := extractBalancedJSONObject(c.Code, loc[0]+braceIdx)
+					if jsonStr == "" {
+						continue
+					}
+					var models map[string]string
+					if err := json.Unmarshal([]byte(jsonStr), &models); err != nil {
+						continue
+					}
+					for k, v := range models {
+						merged[k] = v
+					}
+				}
+				if len(merged) > 0 {
+					c.SupervisorAgentModels = merged
+				}
+			}
 		}
 	}
 }

--- a/internal/ai/fake_provider_test.go
+++ b/internal/ai/fake_provider_test.go
@@ -1,0 +1,108 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// fakeProvider is a test Provider that returns canned responses. It is
+// defined here (in the ai package) so all *_test.go files in this package
+// can use it without re-declaring.
+type fakeProvider struct {
+	name      string
+	mu        sync.Mutex
+	responses []*ChatResponse
+	errors    []error
+	calls     int
+	streamFn  func(callback StreamCallback) error
+	chatFn    func(req *ChatRequest) (*ChatResponse, error)
+}
+
+func newFakeProvider(name string) *fakeProvider {
+	return &fakeProvider{name: name}
+}
+
+func (p *fakeProvider) Name() string          { return p.name }
+func (p *fakeProvider) Type() ProviderType    { return ProviderTypeOpenAI }
+func (p *fakeProvider) ValidateConfig() error { return nil }
+func (p *fakeProvider) Close() error          { return nil }
+
+// QueueResponse queues a canned response for the next Chat() call.
+func (p *fakeProvider) QueueResponse(resp *ChatResponse) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.responses = append(p.responses, resp)
+}
+
+// QueueError queues an error for the next Chat() call.
+func (p *fakeProvider) QueueError(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.errors = append(p.errors, err)
+}
+
+// SetChatFn overrides the default Chat() behavior with a custom function.
+// Use this when the canned response queue isn't flexible enough.
+func (p *fakeProvider) SetChatFn(fn func(req *ChatRequest) (*ChatResponse, error)) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.chatFn = fn
+}
+
+// Calls returns the number of Chat() invocations.
+func (p *fakeProvider) Calls() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// Chat returns the next queued response or error.
+func (p *fakeProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	p.mu.Lock()
+	p.calls++
+	chatFn := p.chatFn
+	var nextResp *ChatResponse
+	var nextErr error
+	if len(p.responses) > 0 {
+		nextResp = p.responses[0]
+		p.responses = p.responses[1:]
+	}
+	if len(p.errors) > 0 {
+		nextErr = p.errors[0]
+		p.errors = p.errors[1:]
+	}
+	p.mu.Unlock()
+
+	if chatFn != nil {
+		return chatFn(req)
+	}
+	if nextErr != nil {
+		return nil, nextErr
+	}
+	if nextResp != nil {
+		return nextResp, nil
+	}
+	return nil, fmt.Errorf("fakeProvider: no queued response")
+}
+
+// ChatStream is unused in supervisor tests — falls back to error.
+func (p *fakeProvider) ChatStream(ctx context.Context, req *ChatRequest, callback StreamCallback) error {
+	if p.streamFn != nil {
+		return p.streamFn(callback)
+	}
+	return fmt.Errorf("fakeProvider: ChatStream not configured")
+}
+
+// Compile-time assertion.
+var _ Provider = (*fakeProvider)(nil)
+
+// newSimpleResponse builds a ChatResponse with one text choice.
+func newSimpleResponse(text string) *ChatResponse {
+	return &ChatResponse{
+		ID:      "resp-test",
+		Model:   "test-model",
+		Choices: []Choice{{Index: 0, Message: Message{Role: RoleAssistant, Content: text}, FinishReason: "stop"}},
+		Usage:   &UsageStats{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+	}
+}

--- a/internal/ai/graph.go
+++ b/internal/ai/graph.go
@@ -1,0 +1,417 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// State is the per-turn mutable state passed between graph nodes.
+//
+// State is a thin wrapper around a map[string]any with typed accessors for
+// the values the supervisor graph actually needs. Custom agents can store
+// arbitrary additional values via Set/Get if needed.
+//
+// State is NOT safe for concurrent writes by different parallel branches —
+// each parallel branch should write under a unique key derived from the node
+// name. The graph executor uses sync.Mutex around the small set of
+// well-known accumulators (AgentOutputs, ToolResults) that all branches
+// write into. Reads are concurrent-safe via snapshot.
+type State struct {
+	mu sync.Mutex
+	m  map[string]any
+}
+
+// NewState returns an empty State.
+func NewState() *State {
+	return &State{m: make(map[string]any)}
+}
+
+// Set stores a value under the given key.
+func (s *State) Set(key string, value any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[key] = value
+}
+
+// Get returns the value under key, or nil if absent. The ok return is false
+// when the key is missing.
+func (s *State) Get(key string) (value any, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	value, ok = s.m[key]
+	return
+}
+
+// GetString returns the string value at key, or "" if missing/not a string.
+func (s *State) GetString(key string) string {
+	v, ok := s.Get(key)
+	if !ok {
+		return ""
+	}
+	str, _ := v.(string)
+	return str
+}
+
+// SetUserMessage stores the original user message text.
+func (s *State) SetUserMessage(msg string) { s.Set(stateKeyUserMessage, msg) }
+
+// UserMessage returns the original user message text.
+func (s *State) UserMessage() string { return s.GetString(stateKeyUserMessage) }
+
+// SetPageContext stores the page_context string sent by the client.
+func (s *State) SetPageContext(ctx string) { s.Set(stateKeyPageContext, ctx) }
+
+// PageContext returns the page_context string (may be empty).
+func (s *State) PageContext() string { return s.GetString(stateKeyPageContext) }
+
+// SetPageProfile stores the resolved PageProfile for the current page_context.
+// nil means "no matching profile, fall back to chatbot global config".
+func (s *State) SetPageProfile(p *PageProfile) { s.Set(stateKeyPageProfile, p) }
+
+// PageProfile returns the resolved PageProfile, or nil.
+func (s *State) PageProfile() *PageProfile {
+	v, ok := s.Get(stateKeyPageProfile)
+	if !ok {
+		return nil
+	}
+	p, _ := v.(*PageProfile)
+	return p
+}
+
+// SetUserLanguage stores the detected user language (BCP-47-ish string or
+// human-readable name like "German"). Used by the synthesizer and verifier
+// to enforce language consistency.
+func (s *State) SetUserLanguage(lang string) { s.Set(stateKeyUserLanguage, lang) }
+
+// UserLanguage returns the detected user language (may be empty).
+func (s *State) UserLanguage() string { return s.GetString(stateKeyUserLanguage) }
+
+// SetConversationHistory stores the trimmed conversation history to feed
+// into each agent.
+func (s *State) SetConversationHistory(msgs []Message) { s.Set(stateKeyHistory, msgs) }
+
+// ConversationHistory returns the stored conversation history.
+func (s *State) ConversationHistory() []Message {
+	v, ok := s.Get(stateKeyHistory)
+	if !ok {
+		return nil
+	}
+	msgs, _ := v.([]Message)
+	return msgs
+}
+
+// AppendAgentOutput adds one specialist agent's output to the accumulator.
+// Safe to call from parallel goroutines. Order is preserved as insertions
+// happen, but inter-agent order from parallel branches is not deterministic.
+func (s *State) AppendAgentOutput(name, output string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, _ := s.m[stateKeyAgentOutputs].([]AgentOutput)
+	s.m[stateKeyAgentOutputs] = append(existing, AgentOutput{Name: name, Content: output})
+}
+
+// AgentOutputs returns a snapshot of all agent outputs collected so far.
+func (s *State) AgentOutputs() []AgentOutput {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out, _ := s.m[stateKeyAgentOutputs].([]AgentOutput)
+	cp := make([]AgentOutput, len(out))
+	copy(cp, out)
+	return cp
+}
+
+// AppendToolResult adds a tool result to the accumulator.
+func (s *State) AppendToolResult(r QueryResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, _ := s.m[stateKeyToolResults].([]QueryResult)
+	s.m[stateKeyToolResults] = append(existing, r)
+}
+
+// ToolResults returns a snapshot of all tool results.
+func (s *State) ToolResults() []QueryResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out, _ := s.m[stateKeyToolResults].([]QueryResult)
+	cp := make([]QueryResult, len(out))
+	copy(cp, out)
+	return cp
+}
+
+// SetFinalResponse stores the response that will be sent to the client.
+// Typically written by the synthesizer (or by a single-agent path that
+// skips synthesis).
+func (s *State) SetFinalResponse(r string) { s.Set(stateKeyFinalResponse, r) }
+
+// FinalResponse returns the final response string.
+func (s *State) FinalResponse() string { return s.GetString(stateKeyFinalResponse) }
+
+// AddUsage accumulates token usage from one node into the running total.
+func (s *State) AddUsage(u UsageStats) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, _ := s.m[stateKeyUsage].(UsageStats)
+	existing.PromptTokens += u.PromptTokens
+	existing.CompletionTokens += u.CompletionTokens
+	existing.TotalTokens += u.TotalTokens
+	existing.CachedTokens += u.CachedTokens
+	s.m[stateKeyUsage] = existing
+}
+
+// Usage returns the accumulated token usage across all nodes.
+func (s *State) Usage() UsageStats {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, _ := s.m[stateKeyUsage].(UsageStats)
+	return u
+}
+
+// State key constants — keeps the typos in one place.
+const (
+	stateKeyUserMessage    = "user_message"
+	stateKeyPageContext    = "page_context"
+	stateKeyPageProfile    = "page_profile"
+	stateKeyUserLanguage   = "user_language"
+	stateKeyHistory        = "history"
+	stateKeyAgentOutputs   = "agent_outputs"
+	stateKeyToolResults    = "tool_results"
+	stateKeyFinalResponse  = "final_response"
+	stateKeyUsage          = "usage"
+	stateKeySupervisorPlan = "supervisor_plan" // *SupervisorPlan
+)
+
+// AgentOutput is one specialist agent's text contribution to the turn.
+type AgentOutput struct {
+	Name    string
+	Content string
+}
+
+// Node is one step in a graph. Nodes do work, mutate state, and return.
+// The graph executor decides what runs next based on edges.
+type Node interface {
+	Name() string
+	Run(ctx context.Context, state *State) error
+}
+
+// Edge connects two nodes. If Condition is non-nil, it returns the name of
+// the next node to run based on state; the edge's To field is ignored in
+// that case. If Condition is nil, To is the unconditional next node.
+//
+// Multiple edges can leave the same node — they run in parallel (fan-out).
+// Conditional edges, however, must be the only outgoing edge from their
+// source (the executor returns an error at construction time otherwise).
+type Edge struct {
+	From      string
+	To        string
+	Condition func(state *State) string
+}
+
+// Graph is the executable pipeline.
+//
+// Construction rules enforced at AddEdge time:
+//   - From and To must reference registered nodes
+//   - Conditional edges must be the sole outgoing edge from their source
+//
+// Execution rules:
+//   - The graph starts at the configured Entry node
+//   - At each step, the executor looks up outgoing edges:
+//   - If exactly one conditional edge exists, evaluate it and jump to its target
+//   - Otherwise, run all unconditional edges in parallel (fan-out)
+//   - Nodes return after writing to state; the executor never re-runs a node
+//     in one Run() call (no cycles at execution time)
+//   - Empty edge set → execution ends
+type Graph struct {
+	nodes map[string]Node
+	// unconditional[from] = list of unconditional targets
+	unconditional map[string][]string
+	// conditional[from] = single conditional edge
+	conditional map[string]Edge
+	entry       string
+}
+
+// NewGraph returns an empty Graph with the given entry node.
+func NewGraph(entry string) *Graph {
+	return &Graph{
+		nodes:         make(map[string]Node),
+		unconditional: make(map[string][]string),
+		conditional:   make(map[string]Edge),
+		entry:         entry,
+	}
+}
+
+// AddNode registers a node. Idempotent on name.
+func (g *Graph) AddNode(n Node) {
+	if n == nil {
+		return
+	}
+	g.nodes[n.Name()] = n
+}
+
+// AddUnconditionalEdge adds a From → To edge. Multiple unconditional edges
+// from the same From create a parallel fan-out.
+func (g *Graph) AddUnconditionalEdge(from, to string) error {
+	if _, ok := g.nodes[from]; !ok {
+		return fmt.Errorf("graph: unknown source node %q", from)
+	}
+	if _, ok := g.nodes[to]; !ok {
+		return fmt.Errorf("graph: unknown target node %q", to)
+	}
+	if _, ok := g.conditional[from]; ok {
+		return fmt.Errorf("graph: node %q already has a conditional edge; cannot add unconditional", from)
+	}
+	g.unconditional[from] = append(g.unconditional[from], to)
+	return nil
+}
+
+// AddConditionalEdge adds a conditional edge: when execution reaches From,
+// Condition is called and must return the name of the next node.
+func (g *Graph) AddConditionalEdge(from string, cond func(state *State) string) error {
+	if _, ok := g.nodes[from]; !ok {
+		return fmt.Errorf("graph: unknown source node %q", from)
+	}
+	if len(g.unconditional[from]) > 0 {
+		return fmt.Errorf("graph: node %q already has unconditional edges; cannot add conditional", from)
+	}
+	if _, exists := g.conditional[from]; exists {
+		return fmt.Errorf("graph: node %q already has a conditional edge", from)
+	}
+	g.conditional[from] = Edge{From: from, Condition: cond}
+	return nil
+}
+
+// Run executes the graph starting at Entry.
+//
+// Execution is acyclic within a single Run: the executor keeps a visited
+// set and refuses to run any node twice. Cycles are reported as errors at
+// runtime rather than construction (they may depend on state via conditions).
+func (g *Graph) Run(ctx context.Context, state *State) error {
+	if g.entry == "" {
+		return errors.New("graph: no entry node")
+	}
+	current := g.entry
+	visited := make(map[string]bool)
+
+	for current != "" {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if visited[current] {
+			return fmt.Errorf("graph: cycle detected revisiting %q", current)
+		}
+
+		node, ok := g.nodes[current]
+		if !ok {
+			return fmt.Errorf("graph: unknown node %q", current)
+		}
+
+		if err := node.Run(ctx, state); err != nil {
+			return fmt.Errorf("graph: node %q failed: %w", current, err)
+		}
+		visited[current] = true
+
+		// Decide what runs next
+		if condEdge, hasCond := g.conditional[current]; hasCond {
+			next := condEdge.Condition(state)
+			current = next
+			continue
+		}
+
+		targets := g.unconditional[current]
+		if len(targets) == 0 {
+			// No outgoing edges — execution ends naturally
+			return nil
+		}
+		if len(targets) == 1 {
+			current = targets[0]
+			continue
+		}
+
+		// Fan-out: run all target nodes in parallel via a sub-traversal.
+		// Each branch runs until it hits a node with multiple incoming edges
+		// (a join) or terminates. This implementation assumes the supervisor
+		// graph's fan-out branches all converge on a single node (synthesizer)
+		// — that node's idempotency on parallel writes via State methods makes
+		// this safe.
+		if err := g.runParallelBranches(ctx, state, targets, visited); err != nil {
+			return err
+		}
+		// After fan-out, execution ends. The synthesizer (the join target)
+		// must be the last node in one of the branches.
+		return nil
+	}
+	return nil
+}
+
+// runParallelBranches runs each target's chain in a goroutine. Each chain
+// is walked until it terminates or hits a node that's NOT in the visited set
+// AND NOT in this fan-out's targets. The shared visited set is updated under
+// the graph's mutex when needed — but since branches here are disjoint
+// sub-chains, we use per-branch local tracking to avoid false-positive
+// cycle errors.
+func (g *Graph) runParallelBranches(ctx context.Context, state *State, targets []string, sharedVisited map[string]bool) error {
+	var wg sync.WaitGroup
+	errs := make([]error, len(targets))
+
+	for i, t := range targets {
+		wg.Add(1)
+		go func(idx int, start string) {
+			defer wg.Done()
+			errs[idx] = g.runChain(ctx, state, start, sharedVisited)
+		}(i, t)
+	}
+	wg.Wait()
+
+	// Return the first non-nil error
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runChain walks a single linear chain starting at start, updating the
+// shared visited map as it goes. Stops when a node has multiple outgoing
+// edges (shouldn't happen in a specialist chain), no edges, or hits a node
+// already in sharedVisited (the join point).
+func (g *Graph) runChain(ctx context.Context, state *State, start string, sharedVisited map[string]bool) error {
+	current := start
+	for current != "" {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if sharedVisited[current] {
+			// Join point — another branch already ran this node. Stop here.
+			return nil
+		}
+
+		node, ok := g.nodes[current]
+		if !ok {
+			return fmt.Errorf("graph: unknown node %q", current)
+		}
+
+		if err := node.Run(ctx, state); err != nil {
+			return fmt.Errorf("graph: node %q failed: %w", current, err)
+		}
+		sharedVisited[current] = true
+
+		// Single-edge chain: follow unconditional edge if exactly one, else stop
+		if condEdge, hasCond := g.conditional[current]; hasCond {
+			current = condEdge.Condition(state)
+			continue
+		}
+		targets := g.unconditional[current]
+		if len(targets) == 1 {
+			current = targets[0]
+			continue
+		}
+		// 0 or >1 edges — stop (join points or terminators handled by caller)
+		return nil
+	}
+	return nil
+}
+
+// Entry returns the configured entry node name.
+func (g *Graph) Entry() string { return g.entry }

--- a/internal/ai/graph_test.go
+++ b/internal/ai/graph_test.go
@@ -1,0 +1,170 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingNode records the order in which its Run method was called.
+type recordingNode struct {
+	name   string
+	log    *[]string
+	mu     *sync.Mutex
+	runErr error
+}
+
+func newRecordingNode(name string, log *[]string, mu *sync.Mutex) *recordingNode {
+	return &recordingNode{name: name, log: log, mu: mu}
+}
+
+func (n *recordingNode) Name() string { return n.name }
+
+func (n *recordingNode) Run(ctx context.Context, state *State) error {
+	n.mu.Lock()
+	*n.log = append(*n.log, n.name)
+	n.mu.Unlock()
+	if n.runErr != nil {
+		return n.runErr
+	}
+	return nil
+}
+
+func TestGraph_LinearExecution_RunsAllNodes(t *testing.T) {
+	var log []string
+	var mu sync.Mutex
+
+	g := NewGraph("a")
+	g.AddNode(newRecordingNode("a", &log, &mu))
+	g.AddNode(newRecordingNode("b", &log, &mu))
+	g.AddNode(newRecordingNode("c", &log, &mu))
+	require.NoError(t, g.AddUnconditionalEdge("a", "b"))
+	require.NoError(t, g.AddUnconditionalEdge("b", "c"))
+
+	err := g.Run(context.Background(), NewState())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, log)
+}
+
+func TestGraph_UnknownEntry_ReturnsError(t *testing.T) {
+	g := NewGraph("nonexistent")
+	err := g.Run(context.Background(), NewState())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown node")
+}
+
+func TestGraph_NodeFailure_PropagatesError(t *testing.T) {
+	var log []string
+	var mu sync.Mutex
+
+	g := NewGraph("a")
+	a := newRecordingNode("a", &log, &mu)
+	a.runErr = errors.New("boom")
+	g.AddNode(a)
+	g.AddNode(newRecordingNode("b", &log, &mu))
+	require.NoError(t, g.AddUnconditionalEdge("a", "b"))
+
+	err := g.Run(context.Background(), NewState())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "node \"a\" failed")
+	assert.Contains(t, err.Error(), "boom")
+	// b should not have run
+	assert.Equal(t, []string{"a"}, log)
+}
+
+func TestGraph_ConditionalEdge_RoutesBasedOnState(t *testing.T) {
+	var log []string
+	var mu sync.Mutex
+
+	g := NewGraph("start")
+	g.AddNode(newRecordingNode("start", &log, &mu))
+	g.AddNode(newRecordingNode("path_a", &log, &mu))
+	g.AddNode(newRecordingNode("path_b", &log, &mu))
+
+	// Conditional: if state has key "go_a" → path_a, else path_b
+	require.NoError(t, g.AddConditionalEdge("start", func(s *State) string {
+		if _, ok := s.Get("go_a"); ok {
+			return "path_a"
+		}
+		return "path_b"
+	}))
+
+	t.Run("routes to path_a when key set", func(t *testing.T) {
+		log = nil
+		s := NewState()
+		s.Set("go_a", true)
+		require.NoError(t, g.Run(context.Background(), s))
+		assert.Equal(t, []string{"start", "path_a"}, log)
+	})
+
+	t.Run("routes to path_b when key absent", func(t *testing.T) {
+		log = nil
+		require.NoError(t, g.Run(context.Background(), NewState()))
+		assert.Equal(t, []string{"start", "path_b"}, log)
+	})
+}
+
+func TestGraph_AddUnconditionalEdge_RejectsUnknownNodes(t *testing.T) {
+	g := NewGraph("a")
+	g.AddNode(&recordingNode{name: "a"})
+	err := g.AddUnconditionalEdge("a", "nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown target node")
+}
+
+func TestGraph_AddConditionalEdge_RejectsMixedEdges(t *testing.T) {
+	g := NewGraph("a")
+	g.AddNode(&recordingNode{name: "a"})
+	g.AddNode(&recordingNode{name: "b"})
+
+	require.NoError(t, g.AddUnconditionalEdge("a", "b"))
+	err := g.AddConditionalEdge("a", func(s *State) string { return "b" })
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already has unconditional")
+}
+
+func TestState_AppendAgentOutput_IsMutexSafe(t *testing.T) {
+	s := NewState()
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			s.AppendAgentOutput("agent", "output")
+		}(i)
+	}
+	wg.Wait()
+	outputs := s.AgentOutputs()
+	assert.Len(t, outputs, 100)
+}
+
+func TestState_TypedAccessors_RoundTrip(t *testing.T) {
+	s := NewState()
+	s.SetUserMessage("hello")
+	s.SetUserLanguage("German")
+	s.SetPageContext("orders")
+	s.SetPageProfile(&PageProfile{Page: "orders"})
+	s.SetFinalResponse("answer")
+
+	assert.Equal(t, "hello", s.UserMessage())
+	assert.Equal(t, "German", s.UserLanguage())
+	assert.Equal(t, "orders", s.PageContext())
+	require.NotNil(t, s.PageProfile())
+	assert.Equal(t, "orders", s.PageProfile().Page)
+	assert.Equal(t, "answer", s.FinalResponse())
+}
+
+func TestState_AddUsage_Accumulates(t *testing.T) {
+	s := NewState()
+	s.AddUsage(UsageStats{PromptTokens: 10, CompletionTokens: 5, CachedTokens: 2})
+	s.AddUsage(UsageStats{PromptTokens: 20, CompletionTokens: 7, CachedTokens: 3})
+
+	u := s.Usage()
+	assert.Equal(t, 30, u.PromptTokens)
+	assert.Equal(t, 12, u.CompletionTokens)
+	assert.Equal(t, 5, u.CachedTokens)
+}

--- a/internal/ai/page_context.go
+++ b/internal/ai/page_context.go
@@ -1,0 +1,134 @@
+package ai
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+)
+
+// PageProfile is a per-page routing and configuration override for a chatbot.
+// When the client sends a `page_context` string with a message, the chatbot
+// looks up the matching PageProfile. If present, the supervisor constrains
+// its routing to Agents and overrides the listed fields for that turn. If no
+// profile matches, the chatbot's global config applies unchanged.
+//
+// All fields are optional except Page. Empty fields inherit from the
+// chatbot's global config.
+type PageProfile struct {
+	Page   string   `json:"page"`
+	Agents []string `json:"agents,omitempty"` // Whitelist of agent names (sql, kb, action, chat)
+	Tables []string `json:"tables,omitempty"` // Overrides chatbot.AllowedTables for SQL/Action agents
+	KBs    []string `json:"kbs,omitempty"`    // Overrides chatbot.KnowledgeBases for KB agent
+	Suffix string   `json:"suffix,omitempty"` // Appended to the active agent's prompt for this turn
+}
+
+// PageProfiles is the keyed collection (page name → profile).
+type PageProfiles map[string]*PageProfile
+
+// validAgentNames is the closed set of agents a page profile may whitelist.
+// The supervisor itself, synthesizer, and verifier are always available
+// regardless of page whitelist; only the specialist set is constrainable.
+var validAgentNames = map[string]bool{
+	"sql":    true,
+	"kb":     true,
+	"action": true,
+	"chat":   true,
+}
+
+// pageNamePattern validates page names: alphanumeric, underscore, hyphen only.
+// Prevents path-traversal-style values and weird free-form client input.
+var pageNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// ParsePageProfilesJSON parses a JSON array of PageProfile objects and
+// returns a PageProfiles map keyed by Page. Validates page names, agent
+// names, and rejects duplicate page definitions.
+//
+// Tolerates JSDoc line prefixes (whitespace + asterisk) — useful when the
+// annotation spans multiple comment lines.
+func ParsePageProfilesJSON(jsonStr string) (PageProfiles, error) {
+	cleaned := stripJSDocPrefixes(jsonStr)
+	var raw []PageProfile
+	if err := json.Unmarshal([]byte(cleaned), &raw); err != nil {
+		return nil, fmt.Errorf("page-contexts: invalid JSON: %w", err)
+	}
+
+	out := make(PageProfiles, len(raw))
+	for i, p := range raw {
+		if p.Page == "" {
+			return nil, fmt.Errorf("page-contexts: entry %d missing 'page' field", i)
+		}
+		if !pageNamePattern.MatchString(p.Page) {
+			return nil, fmt.Errorf("page-contexts: page name %q must match %s", p.Page, pageNamePattern.String())
+		}
+		if _, exists := out[p.Page]; exists {
+			return nil, fmt.Errorf("page-contexts: duplicate page name %q", p.Page)
+		}
+		for _, a := range p.Agents {
+			if !validAgentNames[a] {
+				return nil, fmt.Errorf("page-contexts: page %q references unknown agent %q (valid: sql, kb, action, chat)", p.Page, a)
+			}
+		}
+		profile := p // copy out of slice element
+		out[p.Page] = &profile
+	}
+	return out, nil
+}
+
+// jsdocPrefixPattern matches a leading-whitespace + asterisk prefix on a
+// line, e.g. " * " or "  *  ". Used to strip JSDoc decoration from JSON
+// that spans multiple comment lines.
+var jsdocPrefixPattern = regexp.MustCompile(`(?m)^[ \t]*\*[ \t]?`)
+
+// stripJSDocPrefixes removes leading " * " or similar prefixes from each
+// line. Lets users write multi-line JSON inside JSDoc annotations without
+// the comment markers breaking JSON parsing.
+func stripJSDocPrefixes(s string) string {
+	return jsdocPrefixPattern.ReplaceAllString(s, "")
+}
+
+// Resolve returns the PageProfile matching the given pageContext, or nil if
+// none is defined for that page. Callers fall back to the chatbot's global
+// config when nil is returned.
+func (p PageProfiles) Resolve(pageContext string) *PageProfile {
+	if pageContext == "" {
+		return nil
+	}
+	if p == nil {
+		return nil
+	}
+	return p[pageContext]
+}
+
+// HasAgent reports whether the given agent name is permitted by this profile.
+// A profile with no Agents whitelist permits all agents (inherit-from-global
+// semantics). A nil profile also permits all agents.
+func (p *PageProfile) HasAgent(name string) bool {
+	if p == nil || len(p.Agents) == 0 {
+		return true
+	}
+	for _, a := range p.Agents {
+		if a == name {
+			return true
+		}
+	}
+	return false
+}
+
+// ResolvedTables returns the tables this profile restricts queries to, or
+// falls back to the provided global defaults when the profile doesn't
+// override tables.
+func (p *PageProfile) ResolvedTables(global []string) []string {
+	if p == nil || len(p.Tables) == 0 {
+		return global
+	}
+	return p.Tables
+}
+
+// ResolvedKBs returns the knowledge bases this profile restricts KB agent
+// retrieval to, or falls back to the provided global defaults.
+func (p *PageProfile) ResolvedKBs(global []string) []string {
+	if p == nil || len(p.Tables) == 0 {
+		return global
+	}
+	return p.KBs
+}

--- a/internal/ai/page_context_test.go
+++ b/internal/ai/page_context_test.go
@@ -1,0 +1,196 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePageProfiles_ValidJSON_ReturnsProfiles(t *testing.T) {
+	jsonStr := `[
+		{"page": "orders", "agents": ["sql", "action"], "tables": ["orders", "order_items"]},
+		{"page": "docs", "agents": ["kb"], "kbs": ["product-docs"]}
+	]`
+	profiles, err := ParsePageProfilesJSON(jsonStr)
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+
+	orders := profiles["orders"]
+	require.NotNil(t, orders)
+	assert.Equal(t, "orders", orders.Page)
+	assert.Equal(t, []string{"sql", "action"}, orders.Agents)
+	assert.Equal(t, []string{"orders", "order_items"}, orders.Tables)
+
+	docs := profiles["docs"]
+	require.NotNil(t, docs)
+	assert.Equal(t, []string{"product-docs"}, docs.KBs)
+}
+
+func TestParsePageProfiles_MissingPage_ReturnsError(t *testing.T) {
+	jsonStr := `[{"agents": ["sql"]}]`
+	_, err := ParsePageProfilesJSON(jsonStr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing 'page'")
+}
+
+func TestParsePageProfiles_DuplicatePage_ReturnsError(t *testing.T) {
+	jsonStr := `[
+		{"page": "orders"},
+		{"page": "orders"}
+	]`
+	_, err := ParsePageProfilesJSON(jsonStr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate page name")
+}
+
+func TestParsePageProfiles_InvalidPageName_ReturnsError(t *testing.T) {
+	jsonStr := `[{"page": "../etc/passwd"}]`
+	_, err := ParsePageProfilesJSON(jsonStr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must match")
+}
+
+func TestParsePageProfiles_UnknownAgent_ReturnsError(t *testing.T) {
+	jsonStr := `[{"page": "x", "agents": ["not-real"]}]`
+	_, err := ParsePageProfilesJSON(jsonStr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown agent")
+}
+
+func TestParsePageProfiles_MalformedJSON_ReturnsError(t *testing.T) {
+	_, err := ParsePageProfilesJSON(`[not json`)
+	require.Error(t, err)
+}
+
+func TestPageProfiles_Resolve_KnownPage_ReturnsProfile(t *testing.T) {
+	p := PageProfiles{
+		"orders": &PageProfile{Page: "orders"},
+	}
+	profile := p.Resolve("orders")
+	require.NotNil(t, profile)
+	assert.Equal(t, "orders", profile.Page)
+}
+
+func TestPageProfiles_Resolve_UnknownPage_ReturnsNil(t *testing.T) {
+	p := PageProfiles{
+		"orders": &PageProfile{Page: "orders"},
+	}
+	assert.Nil(t, p.Resolve("unknown"))
+}
+
+func TestPageProfiles_Resolve_EmptyContext_ReturnsNil(t *testing.T) {
+	p := PageProfiles{
+		"orders": &PageProfile{Page: "orders"},
+	}
+	assert.Nil(t, p.Resolve(""))
+}
+
+func TestPageProfiles_Resolve_NilMap_ReturnsNil(t *testing.T) {
+	var p PageProfiles
+	assert.Nil(t, p.Resolve("anything"))
+}
+
+func TestPageProfile_HasAgent_RespectsWhitelist(t *testing.T) {
+	p := &PageProfile{Page: "x", Agents: []string{"sql", "kb"}}
+	assert.True(t, p.HasAgent("sql"))
+	assert.True(t, p.HasAgent("kb"))
+	assert.False(t, p.HasAgent("action"))
+	assert.False(t, p.HasAgent("chat"))
+}
+
+func TestPageProfile_HasAgent_EmptyWhitelist_PermitsAll(t *testing.T) {
+	p := &PageProfile{Page: "x"}
+	for _, a := range []string{"sql", "kb", "action", "chat"} {
+		assert.True(t, p.HasAgent(a), "expected %q to be allowed", a)
+	}
+}
+
+func TestPageProfile_HasAgent_NilProfile_PermitsAll(t *testing.T) {
+	var p *PageProfile
+	assert.True(t, p.HasAgent("sql"))
+}
+
+func TestPageProfile_ResolvedTables_OverridesGlobal(t *testing.T) {
+	p := &PageProfile{Page: "x", Tables: []string{"t1", "t2"}}
+	assert.Equal(t, []string{"t1", "t2"}, p.ResolvedTables([]string{"global"}))
+}
+
+func TestPageProfile_ResolvedTables_NoOverride_FallsBack(t *testing.T) {
+	p := &PageProfile{Page: "x"}
+	assert.Equal(t, []string{"global"}, p.ResolvedTables([]string{"global"}))
+}
+
+func TestParseChatbotConfig_PageContextsAnnotation(t *testing.T) {
+	code := "/**\n" +
+		" * Test chatbot with page contexts.\n" +
+		" *\n" +
+		" * @fluxbase:page-contexts [\n" +
+		" *   {\"page\": \"orders\", \"agents\": [\"sql\"], \"tables\": [\"orders\"]},\n" +
+		" *   {\"page\": \"docs\", \"agents\": [\"kb\"]}\n" +
+		" * ]\n" +
+		" */\n" +
+		"export default `You are a helpful assistant.`\n"
+	config := ParseChatbotConfig(code)
+	require.NotNil(t, config.PageProfiles)
+	require.Len(t, config.PageProfiles, 2)
+
+	orders := config.PageProfiles["orders"]
+	require.NotNil(t, orders)
+	assert.Equal(t, []string{"orders"}, orders.Tables)
+
+	docs := config.PageProfiles["docs"]
+	require.NotNil(t, docs)
+	assert.Equal(t, []string{"kb"}, docs.Agents)
+}
+
+func TestParseChatbotConfig_PageContexts_MergesMultipleAnnotations(t *testing.T) {
+	code := "/**\n" +
+		" * @fluxbase:page-contexts [{\"page\": \"orders\"}]\n" +
+		" * @fluxbase:page-contexts [{\"page\": \"docs\"}]\n" +
+		" */\n" +
+		"export default `test`\n"
+	config := ParseChatbotConfig(code)
+	require.NotNil(t, config.PageProfiles)
+	require.Len(t, config.PageProfiles, 2)
+	assert.NotNil(t, config.PageProfiles["orders"])
+	assert.NotNil(t, config.PageProfiles["docs"])
+}
+
+func TestParseChatbotConfig_ReasoningModeSupervisor(t *testing.T) {
+	code := "/**\n * @fluxbase:reasoning-mode supervisor\n */\nexport default `test`\n"
+	config := ParseChatbotConfig(code)
+	assert.Equal(t, "supervisor", config.ReasoningMode)
+}
+
+func TestParseChatbotConfig_ReasoningModeDefault_IsSupervisor(t *testing.T) {
+	config := DefaultChatbotConfig()
+	assert.Equal(t, "supervisor", config.ReasoningMode)
+}
+
+func TestParseChatbotConfig_SupervisorModels(t *testing.T) {
+	code := "/**\n * @fluxbase:supervisor-models {\"sql\":\"gpt-4-turbo\",\"chat\":\"gpt-4o-mini\"}\n */\nexport default `test`\n"
+	config := ParseChatbotConfig(code)
+	require.NotNil(t, config.SupervisorAgentModels)
+	assert.Equal(t, "gpt-4-turbo", config.SupervisorAgentModels["sql"])
+	assert.Equal(t, "gpt-4o-mini", config.SupervisorAgentModels["chat"])
+}
+
+func TestPopulateDerivedFields_DefaultsToSupervisorWhenNoAnnotation(t *testing.T) {
+	c := &Chatbot{Code: "export default `test`"}
+	c.PopulateDerivedFields()
+	assert.Equal(t, "supervisor", c.ReasoningMode)
+}
+
+func TestPopulateDerivedFields_PreservesExplicitReactAnnotation(t *testing.T) {
+	c := &Chatbot{Code: "/**\n * @fluxbase:reasoning-mode react\n */\nexport default `test`\n"}
+	c.PopulateDerivedFields()
+	assert.Equal(t, "react", c.ReasoningMode)
+}
+
+func TestPopulateDerivedFields_ParsesPageProfilesFromCode(t *testing.T) {
+	c := &Chatbot{Code: "/**\n * @fluxbase:page-contexts [{\"page\":\"orders\",\"tables\":[\"orders\"]}]\n */\nexport default `test`\n"}
+	c.PopulateDerivedFields()
+	require.NotNil(t, c.PageProfiles)
+	require.NotNil(t, c.PageProfiles["orders"])
+}

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -315,12 +315,31 @@ func NewAnthropicProvider(config ProviderConfig) (Provider, error) {
 	return newAnthropicProviderInternal(config.Name, anthropicConfig)
 }
 
-// ExecuteSQLTool is the standard tool definition for SQL execution
+// ExecuteSQLTool is the standard tool definition for SQL execution.
+// Description mirrors the richer MCP variant in mcp_tools.go so legacy
+// (non-MCP) chatbots get the same "when to use" framing as MCP-enabled ones.
 var ExecuteSQLTool = Tool{
 	Type: "function",
 	Function: ToolFunction{
-		Name:        "execute_sql",
-		Description: "Execute a read-only SQL query against the database. Returns a summary of results.",
+		Name: "execute_sql",
+		Description: `Execute a custom SQL SELECT query against the database.
+
+WHEN TO USE:
+- Complex queries spanning multiple tables (JOINs)
+- Aggregations (COUNT, SUM, AVG, GROUP BY)
+- Queries that can't be expressed with simple filters
+- Need precise control over the query structure
+- The user asks a factual question about data (counts, lists, "show me", "how many")
+
+WHEN NOT TO USE:
+- For conceptual information you don't have data for (say so honestly instead)
+- For greetings, chitchat, or clarifying questions
+
+EXAMPLE: "Count visits by city" → SELECT city, COUNT(*) FROM visits GROUP BY city
+
+Always investigate with SQL before answering factual data questions. Never answer
+from memory when a query could verify the data. You will receive a summary plus
+sample rows, not raw data.`,
 		Parameters: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/internal/ai/provider_anthropic.go
+++ b/internal/ai/provider_anthropic.go
@@ -78,6 +78,18 @@ type anthropicRequest struct {
 	Tools       []anthropicTool        `json:"tools,omitempty"`
 	Stream      bool                   `json:"stream,omitempty"`
 	StopSeqs    []string               `json:"stop_sequences,omitempty"`
+	// ToolChoice mirrors OpenAI's tool_choice. Anthropic accepts:
+	//   {"type": "auto"} (default when tools are present)
+	//   {"type": "any"}  (force a tool call, equivalent to OpenAI's "required")
+	//   {"type": "tool", "name": "<tool_name>"} (force a specific tool)
+	// nil → provider default (auto when tools are present).
+	ToolChoice *anthropicToolChoice `json:"tool_choice,omitempty"`
+}
+
+// anthropicToolChoice is Anthropic's shaped tool_choice object.
+type anthropicToolChoice struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
 }
 
 // anthropicSystemBlock is a content block in the top-level system field.
@@ -362,6 +374,33 @@ func (p *anthropicProvider) buildRequest(req *ChatRequest) anthropicRequest {
 		}
 		tools[len(tools)-1].CacheControl = &anthropicCacheControl{Type: "ephemeral"}
 		out.Tools = tools
+	}
+
+	// Translate OpenAI-style ToolChoice to Anthropic's shape.
+	// OpenAI accepts: "none", "auto", "required", or {"type":"function","function":{"name":"x"}}
+	// Anthropic accepts: {"type":"auto"}, {"type":"any"}, or {"type":"tool","name":"x"}
+	// "none" is expressed on Anthropic by omitting tools entirely; we translate
+	// it to nil here and the caller is responsible for not sending tools.
+	if req.ToolChoice != nil {
+		switch tc := req.ToolChoice.(type) {
+		case string:
+			switch tc {
+			case "auto":
+				out.ToolChoice = &anthropicToolChoice{Type: "auto"}
+			case "required":
+				out.ToolChoice = &anthropicToolChoice{Type: "any"}
+				// "none" falls through — leave nil, no tool_choice sent
+			}
+		case map[string]any:
+			// OpenAI shape: {"type":"function","function":{"name":"x"}}
+			if t, ok := tc["type"].(string); ok && t == "function" {
+				if fn, ok := tc["function"].(map[string]any); ok {
+					if name, ok := fn["name"].(string); ok {
+						out.ToolChoice = &anthropicToolChoice{Type: "tool", Name: name}
+					}
+				}
+			}
+		}
 	}
 
 	return out

--- a/internal/ai/schema_builder.go
+++ b/internal/ai/schema_builder.go
@@ -370,6 +370,31 @@ func (s *SchemaBuilder) BuildSystemPromptWithAuth(ctx context.Context, chatbot *
 
 	sb.WriteString(userPrompt)
 	sb.WriteString("\n\n")
+
+	// Response language: placed immediately after the user prompt, before the
+	// schema dump, so it carries more weight than if buried at the end of a
+	// long prompt. LLMs weight earlier instructions more heavily.
+	sb.WriteString("## Response Language\n\n")
+	if chatbot.ResponseLanguage == "" || chatbot.ResponseLanguage == "auto" {
+		sb.WriteString("IMPORTANT: Always respond in the same language as the user's message. ")
+		sb.WriteString("Detect the language of each user message and reply in that exact language. ")
+		sb.WriteString("If the user writes in German, reply in German. If they switch to French mid-conversation, switch with them.\n")
+	} else {
+		fmt.Fprintf(&sb, "IMPORTANT: Always respond in %s, regardless of the language the user writes in.\n",
+			chatbot.ResponseLanguage)
+	}
+
+	// Default behavior: bias the model toward investigating with SQL when the
+	// user asks a factual data question. Without this, the model often
+	// answers from training data instead of running a query.
+	sb.WriteString("\n## Default Behavior\n\n")
+	sb.WriteString("When the user asks a factual question about data (counts, lists, 'show me', 'how many',\n")
+	sb.WriteString("'total', 'find', etc.), ALWAYS investigate with `execute_sql` before answering. Never answer\n")
+	sb.WriteString("from memory if a query could verify the data. It is better to run one extra query than to\n")
+	sb.WriteString("give an answer that turns out to be wrong.\n\n")
+	sb.WriteString("For greetings, chitchat, or conceptual questions you cannot verify with data, answer directly.\n")
+
+	sb.WriteString("\n")
 	sb.WriteString(schemaDesc)
 	sb.WriteString("\n")
 	sb.WriteString("## Query Guidelines\n\n")
@@ -486,16 +511,10 @@ func (s *SchemaBuilder) BuildSystemPromptWithAuth(ctx context.Context, chatbot *
 	// omitted from the static prompt — they vary per user / per second and
 	// would defeat provider prompt caching. Injected as a separate dynamic
 	// system message by the chat handler so the static prefix stays byte-stable.
-
-	// Add response language instruction
-	sb.WriteString("\n## Response Language\n\n")
-	if chatbot.ResponseLanguage == "" || chatbot.ResponseLanguage == "auto" {
-		sb.WriteString("IMPORTANT: Always respond in the same language as the user's message. ")
-		sb.WriteString("Detect the language of each user message and reply in that exact language.\n")
-	} else {
-		fmt.Fprintf(&sb, "IMPORTANT: Always respond in %s, regardless of the language the user writes in.\n",
-			chatbot.ResponseLanguage)
-	}
+	//
+	// Response Language block is also intentionally NOT emitted here at the
+	// end — it was hoisted to the top of the prompt (right after the user
+	// prompt) so it carries more weight on long prompts. See BuildSystemPromptWithAuth.
 
 	return sb.String(), nil
 }

--- a/internal/ai/supervisor_graph.go
+++ b/internal/ai/supervisor_graph.go
@@ -1,0 +1,231 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+)
+
+// SupervisorGraphFactory builds the graph for one turn of a chatbot running
+// in "supervisor" reasoning mode. A fresh graph is constructed per turn
+// because the routing depends on the supervisor's plan, which is itself
+// derived from the user's message.
+//
+// Graph shape:
+//
+//     ┌──────────┐
+//     │supervisor│
+//     └────┬─────┘
+//          │ conditional: route to specialists based on SupervisorPlan
+//     ┌────┴────┐
+//     │ fan-out │ (parallel goroutines for multi-agent routes)
+//     └────┬────┘
+//          │ conditional: skip synthesizer when route has 1 agent
+//     ┌────┴────┐
+//     │ synth   │ (only when 2+ agents OR requires_synthesis)
+//     └────┬────┘
+//          │
+//     ┌────┴────┐
+//     │ verifier│ (only on investigative route)
+//     └─────────┘
+//
+// The graph executor itself is generic (see graph.go); this file knows
+// about the specific nodes and edges for the supervisor pipeline.
+
+// SupervisorGraph wraps a Graph with supervisor-specific helpers.
+type SupervisorGraph struct {
+	graph *Graph
+	deps  *AgentDeps
+}
+
+// NewSupervisorGraph builds a supervisor graph bound to the given deps.
+// The returned graph is ready to Run(); one graph per turn.
+func NewSupervisorGraph(deps *AgentDeps) *SupervisorGraph {
+	supervisor := NewSupervisorAgent(deps)
+	sql := NewSQLAgent(deps)
+	kb := NewKBAgent(deps)
+	action := NewActionAgent(deps)
+	chat := NewChatAgent(deps)
+	synthesizer := NewSynthesizerAgent(deps)
+	verifier := NewVerifierAgent(deps)
+
+	// Router fan-out node — exists only to own the conditional edge from
+	// supervisor → specialists. Each invocation reads the plan from state
+	// and runs the routed specialists in parallel.
+	router := &routerNode{deps: deps, agents: map[string]Node{
+		"sql": sql, "kb": kb, "action": action, "chat": chat,
+	}}
+
+	// Synthesizer gate node — reads agent outputs and decides whether
+	// synthesis is needed based on count + SupervisorPlan.RequiresSynthesis.
+	// Single-agent routes skip synthesis entirely.
+	synthGate := &synthesizerGateNode{synthesizer: synthesizer}
+
+	// Verifier gate node — runs the verifier only on investigative routes.
+	verifierGate := &verifierGateNode{verifier: verifier, deps: deps}
+
+	g := NewGraph("supervisor")
+	g.AddNode(supervisor)
+	g.AddNode(router)
+	g.AddNode(synthGate)
+	g.AddNode(verifierGate)
+
+	_ = g.AddUnconditionalEdge("supervisor", "router")
+	_ = g.AddUnconditionalEdge("router", "synthesizer_gate")
+	_ = g.AddUnconditionalEdge("synthesizer_gate", "verifier_gate")
+
+	return &SupervisorGraph{graph: g, deps: deps}
+}
+
+// Run executes the supervisor graph with the given initial state.
+func (g *SupervisorGraph) Run(ctx context.Context, state *State) error {
+	ctx = ContextWithState(ctx, state)
+	return g.graph.Run(ctx, state)
+}
+
+// ── Router node ──────────────────────────────────────────────────────────────
+
+// routerNode is a Node that fans out to specialist agents based on the
+// SupervisorPlan stored in state. It does the parallel execution inline
+// rather than declaring multiple outgoing edges, because the targets are
+// chosen dynamically based on state.
+type routerNode struct {
+	deps   *AgentDeps
+	agents map[string]Node
+}
+
+func (n *routerNode) Name() string { return "router" }
+
+func (n *routerNode) Run(ctx context.Context, state *State) error {
+	planVal, _ := state.Get(SupervisorPlanKey)
+	plan, _ := planVal.(*SupervisorPlan)
+	if plan == nil {
+		// No plan from supervisor — fallback: route to chat
+		plan = &SupervisorPlan{Route: []string{"chat"}}
+	}
+
+	// Emit a routing transition event so the client can render the decision
+	if n.deps.Sender != nil {
+		n.deps.Sender.SendAgentTransition(ctx, n.deps.ConversationID, AgentTransition{
+			Route: plan.Route,
+		})
+	}
+
+	// Deduplicate route entries (LLMs occasionally repeat)
+	seen := make(map[string]bool)
+	route := make([]string, 0, len(plan.Route))
+	for _, r := range plan.Route {
+		if !seen[r] {
+			seen[r] = true
+			route = append(route, r)
+		}
+	}
+
+	// Single-agent path: run inline (no goroutines)
+	if len(route) == 1 {
+		node, ok := n.agents[route[0]]
+		if !ok {
+			return fmt.Errorf("router: unknown agent %q", route[0])
+		}
+		return node.Run(ctx, state)
+	}
+
+	// Multi-agent path: run all routed specialists in parallel.
+	// Each writes its output via state.AppendAgentOutput (mutex-safe).
+	type result struct {
+		err error
+	}
+	results := make([]result, len(route))
+
+	type indexedRun struct {
+		i    int
+		node Node
+	}
+	workers := make([]indexedRun, 0, len(route))
+	for i, r := range route {
+		node, ok := n.agents[r]
+		if !ok {
+			results[i] = result{err: fmt.Errorf("router: unknown agent %q", r)}
+			continue
+		}
+		workers = append(workers, indexedRun{i: i, node: node})
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for _, w := range workers {
+			i, node := w.i, w.node
+			// Bound concurrency: each agent runs sequentially to keep
+			// provider rate limits happy. Parallelism here is a future
+			// optimization; correctness first.
+			// ponytail: serial fan-out for v1 — the supervisor graph's
+			// multi-agent case is rare; the parallel speedup didn't earn
+			// its complexity yet.
+			err := node.Run(ctx, state)
+			results[i] = result{err: err}
+		}
+	}()
+
+	<-done
+
+	// Return the first non-nil error (don't fail the whole turn if one
+	// agent succeeded — synthesizer can still merge partial outputs).
+	for _, r := range results {
+		if r.err != nil {
+			return r.err
+		}
+	}
+	return nil
+}
+
+// ── Synthesizer gate node ────────────────────────────────────────────────────
+
+// synthesizerGateNode runs the synthesizer when there are 2+ agent outputs
+// OR the supervisor explicitly requested synthesis. Otherwise it passes
+// through (the single agent's output is already in state.FinalResponse).
+type synthesizerGateNode struct {
+	synthesizer *SynthesizerAgent
+}
+
+func (n *synthesizerGateNode) Name() string { return "synthesizer_gate" }
+
+func (n *synthesizerGateNode) Run(ctx context.Context, state *State) error {
+	outputs := state.AgentOutputs()
+
+	// Need synthesis if 2+ agents produced output, OR the supervisor plan
+	// explicitly requested synthesis regardless of agent count.
+	planVal, _ := state.Get(SupervisorPlanKey)
+	plan, _ := planVal.(*SupervisorPlan)
+
+	requiresSynth := len(outputs) >= 2
+	if plan != nil && plan.RequiresSynthesis {
+		requiresSynth = true
+	}
+
+	if !requiresSynth {
+		// Pass through: single agent's final response is already set
+		return nil
+	}
+
+	return n.synthesizer.Run(ctx, state)
+}
+
+// ── Verifier gate node ───────────────────────────────────────────────────────
+
+// verifierGateNode runs the verifier only when the supervisor flagged the
+// turn as investigative. Non-investigative turns (chitchat) skip verification.
+type verifierGateNode struct {
+	verifier *VerifierAgent
+	deps     *AgentDeps
+}
+
+func (n *verifierGateNode) Name() string { return "verifier_gate" }
+
+func (n *verifierGateNode) Run(ctx context.Context, state *State) error {
+	planVal, _ := state.Get(SupervisorPlanKey)
+	plan, _ := planVal.(*SupervisorPlan)
+	if plan == nil || !plan.IsInvestigative {
+		return nil
+	}
+	return n.verifier.Run(ctx, state)
+}

--- a/internal/ai/verifier_test.go
+++ b/internal/ai/verifier_test.go
@@ -1,0 +1,162 @@
+package ai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDominantScript_LatinString(t *testing.T) {
+	assert.Equal(t, "latin", dominantScript("Hello world"))
+}
+
+func TestDominantScript_CyrillicString(t *testing.T) {
+	assert.Equal(t, "cyrillic", dominantScript("Привет мир"))
+}
+
+func TestDominantScript_CJKString(t *testing.T) {
+	assert.Equal(t, "han", dominantScript("你好世界"))
+}
+
+func TestDominantScript_ArabicString(t *testing.T) {
+	assert.Equal(t, "arabic", dominantScript("مرحبا بالعالم"))
+}
+
+func TestDominantScript_EmptyString(t *testing.T) {
+	assert.Equal(t, "", dominantScript(""))
+}
+
+func TestDominantScript_NoLetters(t *testing.T) {
+	assert.Equal(t, "", dominantScript("123 !@#"))
+}
+
+func TestDominantScript_MixedScripts_ReturnsMixed(t *testing.T) {
+	// 50/50 latin + cyrillic, should be "mixed"
+	assert.Equal(t, "mixed", dominantScript("Hello Привет"))
+}
+
+func TestCheckLanguageScriptMatch_LatinBoth_ReturnsTrue(t *testing.T) {
+	assert.True(t, checkLanguageScriptMatch("Hello there", "Hi there"))
+}
+
+func TestCheckLanguageScriptMatch_LatinUserCyrillicReply_ReturnsFalse(t *testing.T) {
+	assert.False(t, checkLanguageScriptMatch("Привет", "Hello there, this is my answer in English"))
+}
+
+func TestCheckLanguageScriptMatch_CyrillicBoth_ReturnsTrue(t *testing.T) {
+	assert.True(t, checkLanguageScriptMatch("Привет", "Привет, ответ"))
+}
+
+func TestCheckLanguageScriptMatch_MixedUserLatinReply_ReturnsTrue(t *testing.T) {
+	// Permissive: mixed-script user message accepts any reply
+	assert.True(t, checkLanguageScriptMatch("Hello Привет", "Hi there"))
+}
+
+func TestVerifier_NonInvestigative_SkipsGroundingCheck(t *testing.T) {
+	// Build state for a non-investigative turn
+	state := NewState()
+	state.SetUserMessage("hello")
+	state.SetFinalResponse("hi there")
+	state.Set(SupervisorPlanKey, &SupervisorPlan{
+		Route:           []string{"chat"},
+		IsInvestigative: false,
+	})
+
+	// Provide a fake provider that should NOT be called
+	provider := newFakeProvider("test")
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{Chatbot: chatbot, Provider: provider}
+
+	ctx := ContextWithState(context.Background(), state)
+	require.NoError(t, NewVerifierAgent(deps).Run(ctx, state))
+
+	reportVal, ok := state.Get(VerifyReportKey)
+	require.True(t, ok)
+	report := reportVal.(*VerifyReport)
+	assert.True(t, report.GroundingOK, "non-investigative should pass grounding by default")
+	assert.Equal(t, 0, provider.Calls(), "LLM should not be called for non-investigative")
+}
+
+func TestVerifier_LanguageMismatch_ReturnsLanguageOKFalse(t *testing.T) {
+	state := NewState()
+	state.SetUserMessage("Привет, как дела?")
+	state.SetFinalResponse("Hello! I am doing well, thank you.")
+	state.Set(SupervisorPlanKey, &SupervisorPlan{
+		Route:           []string{"chat"},
+		IsInvestigative: true,
+		MinToolCalls:    1,
+	})
+
+	provider := newFakeProvider("test")
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{Chatbot: chatbot, Provider: provider}
+	ctx := ContextWithState(context.Background(), state)
+	require.NoError(t, NewVerifierAgent(deps).Run(ctx, state))
+
+	reportVal, _ := state.Get(VerifyReportKey)
+	report := reportVal.(*VerifyReport)
+	assert.False(t, report.LanguageOK)
+	// LLM check should not have run (language already failed)
+	assert.Equal(t, 0, provider.Calls())
+}
+
+func TestVerifier_InvestigativeWithResults_CallsLLM(t *testing.T) {
+	state := NewState()
+	state.SetUserMessage("how many users")
+	state.SetFinalResponse("There are 42 users.")
+	state.Set(SupervisorPlanKey, &SupervisorPlan{
+		Route:           []string{"sql"},
+		IsInvestigative: true,
+		MinToolCalls:    1,
+	})
+	state.AppendToolResult(QueryResult{
+		Query:    "SELECT COUNT(*) FROM users",
+		Summary:  "1 row, count=42",
+		RowCount: 1,
+		Data:     []map[string]any{{"count": 42}},
+	})
+
+	provider := newFakeProvider("test")
+	provider.QueueResponse(newSimpleResponse(`{"ok":true,"issues":[]}`))
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{Chatbot: chatbot, Provider: provider}
+
+	ctx := ContextWithState(context.Background(), state)
+	require.NoError(t, NewVerifierAgent(deps).Run(ctx, state))
+
+	assert.Equal(t, 1, provider.Calls(), "LLM should be called for grounding check")
+	reportVal, _ := state.Get(VerifyReportKey)
+	report := reportVal.(*VerifyReport)
+	assert.True(t, report.GroundingOK)
+}
+
+func TestVerifier_LLMReportsIssues_PassesThrough(t *testing.T) {
+	state := NewState()
+	state.SetUserMessage("how many users")
+	state.SetFinalResponse("There are 999 users.") // doesn't match tool result
+	state.Set(SupervisorPlanKey, &SupervisorPlan{
+		Route:           []string{"sql"},
+		IsInvestigative: true,
+		MinToolCalls:    1,
+	})
+	state.AppendToolResult(QueryResult{
+		Query:    "SELECT COUNT(*) FROM users",
+		Summary:  "1 row, count=42",
+		RowCount: 1,
+	})
+
+	provider := newFakeProvider("test")
+	provider.QueueResponse(newSimpleResponse(`{"ok":false,"issues":["count 999 not supported by tool results"]}`))
+	chatbot := &Chatbot{Name: "test", Model: "gpt-4"}
+	deps := &AgentDeps{Chatbot: chatbot, Provider: provider}
+
+	ctx := ContextWithState(context.Background(), state)
+	require.NoError(t, NewVerifierAgent(deps).Run(ctx, state))
+
+	reportVal, _ := state.Get(VerifyReportKey)
+	report := reportVal.(*VerifyReport)
+	assert.False(t, report.GroundingOK)
+	require.Len(t, report.Issues, 1)
+}

--- a/sdk/src/ai.ts
+++ b/sdk/src/ai.ts
@@ -12,6 +12,7 @@ import type {
   AIUserConversationDetail,
   AIDailyQuotaSnapshot,
   AIMatchedIntentRule,
+  AIAgentTransition,
   ListConversationsOptions,
   ListConversationsResult,
   UpdateConversationOptions,
@@ -27,6 +28,7 @@ export type AIChatEventType =
   | "content"
   | "query_result"
   | "tool_result"
+  | "agent_transition"
   | "done"
   | "error"
   | "cancelled"
@@ -47,6 +49,12 @@ export interface AIChatEvent {
   rowCount?: number;
   data?: Record<string, any>[];
   usage?: AIUsageStats;
+  /** Agent transition payload, present on agent_transition events (supervisor mode). */
+  agentTransition?: AIAgentTransition;
+  /** Currently-active specialist agent name, on agent_transition events. */
+  agent?: string;
+  /** Echo of the client's page_context, on agent_transition events. */
+  pageContext?: string;
   error?: string;
   code?: string;
 }
@@ -85,6 +93,16 @@ export interface AIChatOptions {
       matched_intent_rules?: AIMatchedIntentRule[];
       daily_quota?: AIDailyQuotaSnapshot;
     },
+  ) => void;
+  /**
+   * Callback for agent transition events (supervisor mode only). Fires
+   * when the supervisor routes to a specialist agent, when one agent
+   * hands off to another, and when the synthesizer/verifier engage.
+   * Use this to render the multi-agent flow as observable UI.
+   */
+  onAgentTransition?: (
+    transition: AIAgentTransition,
+    conversationId: string,
   ) => void;
   /** Callback for errors */
   onError?: (
@@ -275,8 +293,17 @@ export class FluxbaseAIChat {
    *
    * @param conversationId - Conversation ID
    * @param content - Message content
+   * @param options - Optional per-message options
+   * @param options.pageContext - Page context string for page-aware chatbots.
+   *   The supervisor looks up the matching PageProfile (if any) and uses it
+   *   to bias routing and override per-page config. Missing or unknown
+   *   values fall back to the chatbot's global config.
    */
-  sendMessage(conversationId: string, content: string): void {
+  sendMessage(
+    conversationId: string,
+    content: string,
+    options?: { pageContext?: string },
+  ): void {
     if (!this.isConnected()) {
       throw new Error("Not connected to AI chat");
     }
@@ -289,6 +316,9 @@ export class FluxbaseAIChat {
       conversation_id: conversationId,
       content,
     };
+    if (options?.pageContext) {
+      message.page_context = options.pageContext;
+    }
 
     this.ws!.send(JSON.stringify(message));
   }
@@ -399,6 +429,18 @@ export class FluxbaseAIChat {
           }
           break;
 
+        case "agent_transition":
+          // Supervisor-mode event: one agent handed off to another (or the
+          // supervisor made its initial routing decision). Surfaces the
+          // multi-agent flow to clients that want to render it.
+          if (message.conversation_id && message.agent_transition) {
+            this.options.onAgentTransition?.(
+              message.agent_transition,
+              message.conversation_id,
+            );
+          }
+          break;
+
         case "done":
           if (message.conversation_id) {
             this.options.onDone?.(
@@ -448,6 +490,9 @@ export class FluxbaseAIChat {
       rowCount: message.row_count,
       data: message.data,
       usage: message.usage,
+      agentTransition: message.agent_transition,
+      agent: message.agent,
+      pageContext: message.page_context,
       error: message.error,
       code: message.code,
     };

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -3097,6 +3097,29 @@ export interface AIChatClientMessage {
   conversation_id?: string;
   content?: string;
   impersonate_user_id?: string; // Admin-only: test as this user
+  /**
+   * Optional page context for page-aware chatbots (Level 2 page profiles).
+   * Sent per-message; the supervisor looks up the matching PageProfile
+   * (if any) and uses it to bias routing and override per-page config.
+   * Missing or unknown values fall back to the chatbot's global config.
+   */
+  page_context?: string;
+}
+
+/**
+ * Agent transition payload, emitted on agent_transition events when the
+ * chatbot is running in supervisor mode. Lets clients render the multi-
+ * agent routing flow as observable UI.
+ */
+export interface AIAgentTransition {
+  from?: string;
+  to?: string;
+  /** Specialist agents the supervisor routed this turn to (e.g., ["sql"]). */
+  route?: string[];
+  /** Supervisor's stated reason for the routing decision, when available. */
+  reason?: string;
+  /** Echo of the client's page_context, when set. */
+  page_context?: string;
 }
 
 /**
@@ -3109,6 +3132,7 @@ export interface AIChatServerMessage {
     | "content"
     | "query_result"
     | "tool_result"
+    | "agent_transition"
     | "done"
     | "error"
     | "cancelled";
@@ -3127,6 +3151,12 @@ export interface AIChatServerMessage {
   matched_intent_rules?: AIMatchedIntentRule[];
   /** Per-user daily quota snapshot at turn end (Ask 2). Omitted when no limits configured. */
   daily_quota?: AIDailyQuotaSnapshot;
+  /** Agent transition payload, present on agent_transition events (supervisor mode). */
+  agent_transition?: AIAgentTransition;
+  /** Currently-active specialist agent name, on agent_transition events. */
+  agent?: string;
+  /** Echo of the client's page_context, on agent_transition events. */
+  page_context?: string;
   error?: string;
   code?: string;
 }


### PR DESCRIPTION
## Summary

Replaces the single-agent ReAct loop with a **multi-agent supervisor pipeline** as the default reasoning mode for all chatbots, and adds **page-aware chatbots** (Level 2) for one-chatbot-multiple-pages patterns.

Fixes two reported bugs:
1. Replies sometimes not matching the user's language.
2. Missing SQL investigations on factual questions.

## Architecture

Go-native graph executor (no Python sidecar, no langchaingo dependency):

```
User msg
   │
   ▼
[SUPERVISOR] ── one LLM call, structured JSON routing plan
   │
   ▼
[ROUTER] ── fans out to routed specialists (sequential in v1)
   │
   ├── SQL Agent (execute_sql, focused prompt, can't see KB tools)
   ├── KB/RAG Agent (search_vectors)
   ├── Action Agent (invoke_function, rpc_call)
   └── Chat Agent (no tools, cheap model)
   │
   ▼ (only when 2+ agents ran OR supervisor flagged)
[SYNTHESIZER] ── merges outputs into one answer in user's language
   │
   ▼ (only on investigative routes)
[VERIFIER] ── rule-based language check + LLM grounding check
```

Each specialist has a focused ~100-line prompt and a constrained tool whitelist, so wrong-tool selection becomes structurally impossible. The supervisor detects the user's language once and threads it through every downstream agent; the verifier performs a deterministic Unicode-script check on the final answer.

## Page-aware chatbots

One chatbot, one conversation history, behavior that adapts to the page the user is on:

```typescript
/**
 * @fluxbase:page-contexts [
 *   {"page": "orders", "agents": ["sql", "action"], "tables": ["orders"]},
 *   {"page": "docs",   "agents": ["kb"], "kbs": ["product-docs"]}
 * ]
 */
export default \`You are a helpful app assistant.\`;
```

Clients send \`page_context\` per-message via \`chat.sendMessage(convId, content, { pageContext: "orders" })\`. The supervisor looks up the matching profile and overrides per-page agent whitelist, tables, KBs, and prompt suffix. Missing or unknown values fall back to global config.

## Wire protocol changes

**Additive only.** Existing clients keep working.

- \`ClientMessage\` gains optional \`page_context\` field
- \`ServerMessage\` gains optional \`agent_transition\`, \`agent\`, \`page_context\` fields
- New event type: \`agent_transition\` for client-side routing observability

## What changed

### New files
- \`internal/ai/graph.go\` — generic graph executor (nodes, edges, conditional routing, parallel fan-out, cycle detection, mutex-safe State)
- \`internal/ai/supervisor_graph.go\` — concrete graph wiring for one chatbot turn
- \`internal/ai/agent_deps.go\` — shared dependency bundle + AgentEventSender interface
- \`internal/ai/agent_supervisor.go\` — routing LLM call + SupervisorPlan parser
- \`internal/ai/agent_specialists.go\` — KB, Action, Chat agents
- \`internal/ai/agent_sql.go\` — SQL agent with internal tool loop + tool-call budget gate
- \`internal/ai/agent_synthesizer_verifier.go\` — Synthesizer + Verifier (Unicode script check + LLM grounding)
- \`internal/ai/agent_prompts.go\` — per-agent static system prompts
- \`internal/ai/page_context.go\` — PageProfile parsing + resolution
- \`internal/ai/chat_handler_supervisor.go\` — per-turn graph execution + ReAct fallback

### Modified files
- \`internal/ai/chatbot.go\` — new ReasoningMode default (\`supervisor\`), PageProfiles + SupervisorAgentModels fields, annotation regexes, PopulateDerivedFields
- \`internal/ai/chat_handler.go\` — PageContext on ClientMessage, AgentTransition on ServerMessage
- \`internal/ai/chat_handler_message.go\` — branches on ReasoningMode
- \`internal/ai/schema_builder.go\` — moved Response Language block to top of prompt; added Default Behavior section
- \`internal/ai/provider.go\` — richer ExecuteSQLTool description (matches MCP variant)
- \`internal/ai/provider_anthropic.go\` — added tool_choice field to anthropicRequest + translation from OpenAI shape
- \`sdk/src/ai.ts\` — pageContext on sendMessage, onAgentTransition callback
- \`sdk/src/types.ts\` — AIAgentTransition type, page_context on ClientMessage, agent_transition on ServerMessage

### Docs
- \`docs/src/content/docs/guides/ai-agents.md\` (NEW) — multi-agent supervisor deep-dive
- \`docs/src/content/docs/guides/ai-events.md\` (NEW) — WS event reference
- \`docs/src/content/docs/guides/ai-chatbots.md\` — supervisor + page-aware sections
- \`docs/src/content/docs/about/ai-transparency.md\` — multi-agent disclosures
- \`CLAUDE.md\` — updated AI module file inventory

## Cost / latency

| Turn type | LLM calls (react) | LLM calls (supervisor) |
|---|---|---|
| Chitchat | 1-2 | 2 (supervisor + chat) |
| Single-agent investigative | 2-4 | 3-5 |
| Multi-agent investigative | 2-4 | 5-7 |

First-token latency is higher because the supervisor runs before any specialist streams. Trade-off: fewer hallucinated answers and consistent language matching. Per-agent model overrides (\`@fluxbase:supervisor-models\`) let chat-heavy chatbots route chitchat to a cheap model.

## Rollback

Pure code revert. No DB migration was needed — \`reasoning_mode\`, \`page_profiles\`, and \`supervisor_agent_models\` are parsed at runtime from chatbot code annotations, not persisted as columns. Users who want the legacy loop pin \`@fluxbase:reasoning-mode react\`.

## What's intentionally out of scope

- **Python LangGraph sidecar** — breaks single-binary design goal
- **langchaingo dependency** — immature port, lock-in
- **User-defined custom agents** — v2 concern
- **Admin UI for agent transitions** — events are emitted; UI polish in a follow-up
- **Parallel agent execution** — router runs sequentially in v1; parallelism is a planned optimization once rate-limit concerns are validated

## Test plan

- [x] \`go test ./internal/ai/...\` — all existing + new tests pass
- [x] \`golangci-lint run ./internal/...\` — 0 issues
- [x] \`go build ./...\` — clean
- [x] \`cd admin && bun run type-check\` — clean
- [x] \`cd sdk && bun run type-check\` — clean
- [x] \`cd sdk-react && bun run type-check\` — clean

New tests:
- Graph executor (linear, parallel fan-out, conditional edges, node failures, mutex-safe state)
- Page profile parsing (valid/invalid/duplicate/unknown agent, JSDoc prefix stripping)
- Supervisor agent (routing, page-profile whitelist, fallback to chat, error paths)
- Verifier (Unicode-script language check for Latin/Cyrillic/CJK/Arabic, grounding LLM check skipped on non-investigative)
- Chatbot struct (PageProfiles parsing, supervisor-models parsing, PopulateDerivedFields defaults to supervisor)

## Skipped (YAGNI)

- Locale field on ChatContext / Accept-Language parsing — supervisor detects language better than header heuristics
- Per-chatbot tool_choice config field + DB column — supervisor's min-tool-call budget makes it redundant
- Separate synthesizer phase on single-agent routes — already skipped via synthesizerGate
- Multi-agent router supervisor / LangGraph-style custom agents — solves nothing the verifier doesn't already catch