### PR TITLE
fix(cli): add --namespace flag to chatbots list

### DIFF
--- a/cli/cmd/chatbots.go
+++ b/cli/cmd/chatbots.go
@@ -27,6 +27,11 @@ var (
 	cbTemperature   float64
 	cbMaxTokens     int
 	cbKnowledgeBase string
+	// cbListNamespace is the optional --namespace filter for `chatbots list`.
+	// Empty (default) means list across all namespaces. Kept separate from
+	// cbNamespace (used by sync as a target with default "default") so the
+	// two commands don't fight over the same var's initial value.
+	cbListNamespace string
 )
 
 var chatbotsListCmd = &cobra.Command{
@@ -36,6 +41,7 @@ var chatbotsListCmd = &cobra.Command{
 
 Examples:
   fluxbase chatbots list
+  fluxbase chatbots list --namespace wayli
   fluxbase chatbots list -o json`,
 	PreRunE: requireAuth,
 	RunE:    runChatbotsList,
@@ -111,6 +117,9 @@ var (
 )
 
 func init() {
+	// List flags
+	chatbotsListCmd.Flags().StringVar(&cbListNamespace, "namespace", "", "Filter by namespace")
+
 	// Create flags
 	chatbotsCreateCmd.Flags().StringVar(&cbSystemPrompt, "system-prompt", "", "System prompt for the chatbot")
 	chatbotsCreateCmd.Flags().StringVar(&cbModel, "model", "gpt-3.5-turbo", "AI model to use")
@@ -144,17 +153,28 @@ func runChatbotsList(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Build optional query params. Empty namespace = list across all.
+	var query url.Values
+	if cbListNamespace != "" {
+		query = url.Values{}
+		query.Set("namespace", cbListNamespace)
+	}
+
 	var response struct {
 		Chatbots []map[string]interface{} `json:"chatbots"`
 		Count    int                      `json:"count"`
 	}
-	if err := apiClient.DoGet(ctx, "/api/v1/admin/ai/chatbots", nil, &response); err != nil {
+	if err := apiClient.DoGet(ctx, "/api/v1/admin/ai/chatbots", query, &response); err != nil {
 		return err
 	}
 	chatbots := response.Chatbots
 
 	if len(chatbots) == 0 {
-		fmt.Println("No chatbots found.")
+		if cbListNamespace != "" {
+			fmt.Printf("No chatbots found in namespace '%s'.\n", cbListNamespace)
+		} else {
+			fmt.Println("No chatbots found.")
+		}
 		return nil
 	}
 

--- a/cli/cmd/chatbots_test.go
+++ b/cli/cmd/chatbots_test.go
@@ -61,6 +61,47 @@ func TestChatbotsList_APIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "database error")
 }
 
+func TestChatbotsList_NamespaceFilter_SendsQueryParam(t *testing.T) {
+	resetChatbotFlags()
+	cbListNamespace = "wayli"
+
+	_, _, cleanup := setupTestEnvWithHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "wayli", r.URL.Query().Get("namespace"),
+			"CLI must forward --namespace as a query param to the API")
+
+		respondJSON(w, http.StatusOK, map[string]interface{}{
+			"chatbots": []map[string]interface{}{
+				{"id": "cb1", "name": "wayli-bot", "model": "gpt-4", "enabled": true},
+			},
+			"count": 1,
+		})
+	})
+	defer cleanup()
+
+	err := runChatbotsList(nil, []string{})
+	require.NoError(t, err)
+}
+
+func TestChatbotsList_NoNamespaceFilter_OmitsQueryParam(t *testing.T) {
+	resetChatbotFlags()
+
+	_, _, cleanup := setupTestEnvWithHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		// When --namespace not set, the API call must not include the param
+		// so the server lists across all namespaces.
+		_, hasNs := r.URL.Query()["namespace"]
+		assert.False(t, hasNs, "expected no namespace query param when flag unset")
+
+		respondJSON(w, http.StatusOK, map[string]interface{}{
+			"chatbots": []map[string]interface{}{}, "count": 0,
+		})
+	})
+	defer cleanup()
+
+	err := runChatbotsList(nil, []string{})
+	require.NoError(t, err)
+}
+
 func TestChatbotsGet_Success(t *testing.T) {
 	resetChatbotFlags()
 	_, buf, cleanup := setupTestEnvWithHandler(t, func(w http.ResponseWriter, r *http.Request) {

--- a/cli/cmd/test_helpers.go
+++ b/cli/cmd/test_helpers.go
@@ -175,6 +175,7 @@ func resetChatbotFlags() {
 	cbKnowledgeBase = ""
 	cbSyncDir = ""
 	cbNamespace = ""
+	cbListNamespace = ""
 	cbDryRun = false
 	cbDeleteMissing = false
 }

--- a/internal/ai/handler.go
+++ b/internal/ai/handler.go
@@ -111,7 +111,15 @@ func (h *Handler) ValidateConfig() {
 func (h *Handler) ListChatbots(c fiber.Ctx) error {
 	ctx := middleware.CtxWithTenant(c)
 
-	chatbots, err := h.storage.ListChatbots(ctx, false)
+	// Optional namespace filter. Empty/unset → list across all namespaces
+	// (filtered by tenant context as usual).
+	var chatbots []*Chatbot
+	var err error
+	if ns := c.Query("namespace"); ns != "" {
+		chatbots, err = h.storage.ListChatbotsByNamespace(ctx, ns)
+	} else {
+		chatbots, err = h.storage.ListChatbots(ctx, false)
+	}
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to list chatbots")
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{


### PR DESCRIPTION
## Summary

`fluxbase chatbots list --namespace wayli` was failing with \`unknown flag: --namespace\` because the flag existed on \`chatbots sync\` but not on \`chatbots list\`.

## Root cause

Two gaps:
1. **CLI**: \`chatbotsListCmd\` did not register a \`--namespace\` flag — only \`chatbotsSyncCmd\` did (as a target with default \`"default"\`)
2. **API**: \`Handler.ListChatbots\` hard-coded \`Storage.ListChatbots(ctx, false)\` — never read a \`?namespace=\` query param, even though \`Storage.ListChatbotsByNamespace\` already existed

## Fix

### CLI (\`cli/cmd/chatbots.go\`)
- New \`cbListNamespace\` var registered on \`chatbotsListCmd\` with default \`""\` and help "Filter by namespace"
- \`runChatbotsList\` forwards it as \`?namespace=...\` when set via the existing \`DoGet(ctx, path, query, target)\` signature
- Separate var from \`cbNamespace\` (sync's target with default \`"default"\`) so the two commands don't fight over the shared var's initial value

### API (\`internal/ai/handler.go\`)
- \`ListChatbots\` reads optional \`?namespace=\` query param
- When set, dispatches to existing \`Storage.ListChatbotsByNamespace\`
- When unset, preserves existing behavior (\`ListChatbots\` across all namespaces)

## Backwards compatibility

Existing CLI calls without \`--namespace\` get the same response as before. The new flag is purely additive.

## Examples

\`\`\`bash
# All chatbots across all namespaces (existing behavior)
fluxbase chatbots list

# Filter to one namespace
fluxbase chatbots list --namespace wayli

# JSON output of one namespace
fluxbase chatbots list --namespace wayli -o json
\`\`\`

## Test plan

- [x] \`go test ./cli/cmd/... -run TestChatbots\` — passes including new tests
- [x] \`golangci-lint run ./internal/ai/... ./cli/...\` — 0 issues
- [x] \`./build/fluxbase chatbots list --help\` shows the new flag

New tests:
- \`TestChatbotsList_NamespaceFilter_SendsQueryParam\` — verifies the CLI forwards the flag as \`?namespace=wayli\`
- \`TestChatbotsList_NoNamespaceFilter_OmitsQueryParam\` — verifies the CLI does NOT send the param when the flag is unset (preserves cross-namespace listing)