### PR TITLE
fix(ai): invoke_rpc nil-deref crash + supervisor router panic recovery

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -62,8 +62,13 @@ timeout = 30
 # Maximum number of concurrent requests (lower to avoid rate limits)
 max_concurrency = 8
 
-# Don't check fragments/anchors (can be flaky for external sites)
-include_fragments = false
+# Don't check fragments/anchors (can be flaky for external sites).
+# In lychee v0.24+, this option takes a string strategy, not a boolean:
+#   "none"        — don't check fragments (was `false` pre-v0.24)
+#   "anchor-only" — check only anchor fragments like `#section`
+#   "text-only"   — check only text fragments like `#:~:text=example`
+#   "full"        — check both anchor and text fragments
+include_fragments = "none"
 
 # User agent to use for requests
 user_agent = "Mozilla/5.0 (compatible; lychee-link-checker)"

--- a/internal/ai/agent_synthesizer_verifier.go
+++ b/internal/ai/agent_synthesizer_verifier.go
@@ -223,7 +223,8 @@ func (a *VerifierAgent) languageCheck(ctx context.Context, response, expectedLan
 		`Is the following text written in %s? Reply with a JSON object: {"yes": true} or {"yes": false}.
 
 Text:
-%s`, expectedLanguage, response)
+%s`, expectedLanguage, response,
+	)
 
 	messages := []Message{
 		{Role: RoleSystem, Content: "You are a language classifier. Reply with JSON only, no prose."},

--- a/internal/ai/router_panic_test.go
+++ b/internal/ai/router_panic_test.go
@@ -1,0 +1,135 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// panickingNode is a Node whose Run panics. Used to verify the routerNode's
+// goroutine recovery converts panics into graph errors instead of crashing
+// the server.
+type panickingNode struct {
+	name string
+}
+
+func (n *panickingNode) Name() string { return n.name }
+
+func (n *panickingNode) Run(_ context.Context, _ *State) error {
+	panic("simulated nil-deref — production stack trace had this in invoke.go:296")
+}
+
+// errorNode returns a clean error. Used alongside panickingNode to verify
+// recovery doesn't suppress normal errors.
+type errorNode struct {
+	name string
+	err  error
+}
+
+func (n *errorNode) Name() string { return n.name }
+
+func (n *errorNode) Run(_ context.Context, _ *State) error { return n.err }
+
+// safeRecordingNode records that it ran. Used to verify sibling agents
+// still execute after a panic in one agent.
+type safeRecordingNode struct {
+	name string
+	log  *[]string
+	mu   *sync.Mutex
+}
+
+func (n *safeRecordingNode) Name() string { return n.name }
+
+func (n *safeRecordingNode) Run(_ context.Context, _ *State) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	*n.log = append(*n.log, n.name)
+	return nil
+}
+
+// TestRouterNode_AgentPanic_RecoveredAndSurfaced is the regression test
+// for the production server crash at invoke.go:296 (nil proc deref) and
+// the broader "any agent panic kills the server" class of bugs.
+//
+// Before Layer 2's recovery, a panic in any specialist goroutine
+// propagated up and crashed the process. After recovery, the panic is
+// converted to an error that the supervisor graph surfaces to the chat
+// handler, which falls back to the legacy ReAct loop.
+//
+// This test pins the recovery behavior so a future refactor that removes
+// the defer/recover (or moves the goroutine launch) can't silently
+// re-introduce the crash.
+func TestRouterNode_AgentPanic_RecoveredAndSurfaced(t *testing.T) {
+	deps := &AgentDeps{Chatbot: &Chatbot{Name: "test"}}
+	router := &routerNode{
+		deps: deps,
+		agents: map[string]Node{
+			"panic": &panickingNode{name: "panic"},
+		},
+	}
+
+	state := NewState()
+	state.Set(SupervisorPlanKey, &SupervisorPlan{Route: []string{"panic"}})
+
+	err := router.Run(context.Background(), state)
+	require.Error(t, err, "router must surface recovered panic as an error")
+	assert.Contains(t, err.Error(), "panicked",
+		"error message must indicate a panic so it's diagnosable in logs")
+	assert.Contains(t, err.Error(), "panic",
+		"error message must name the agent that panicked")
+}
+
+// TestRouterNode_PanicInOneAgent_OthersStillRun verifies sibling agents
+// execute even when one agent in the route panics. Important for
+// multi-agent routes — partial results are better than no results.
+func TestRouterNode_PanicInOneAgent_OthersStillRun(t *testing.T) {
+	var log []string
+	var mu sync.Mutex
+
+	deps := &AgentDeps{Chatbot: &Chatbot{Name: "test"}}
+	router := &routerNode{
+		deps: deps,
+		agents: map[string]Node{
+			"panic": &panickingNode{name: "panic"},
+			"safe1": &safeRecordingNode{name: "safe1", log: &log, mu: &mu},
+			"safe2": &safeRecordingNode{name: "safe2", log: &log, mu: &mu},
+		},
+	}
+
+	state := NewState()
+	state.Set(SupervisorPlanKey, &SupervisorPlan{Route: []string{"safe1", "panic", "safe2"}})
+
+	err := router.Run(context.Background(), state)
+	require.Error(t, err, "router must report the panic from one agent")
+	// Sibling agents must still have run — partial results matter.
+	assert.Contains(t, log, "safe1", "safe1 must run before the panic")
+	assert.Contains(t, log, "safe2", "safe2 must run after the panic (recovery doesn't stop siblings)")
+}
+
+// TestRouterNode_NormalError_NotWrappedAsPanic verifies the recovery path
+// only fires on actual panics. Normal errors should pass through cleanly
+// without the "panicked" wrapper text.
+func TestRouterNode_NormalError_NotWrappedAsPanic(t *testing.T) {
+	deps := &AgentDeps{Chatbot: &Chatbot{Name: "test"}}
+	myErr := errors.New("provider rate limited")
+	router := &routerNode{
+		deps: deps,
+		agents: map[string]Node{
+			"sql": &errorNode{name: "sql", err: myErr},
+		},
+	}
+
+	state := NewState()
+	state.Set(SupervisorPlanKey, &SupervisorPlan{Route: []string{"sql"}})
+
+	err := router.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "panicked",
+		"normal errors must not be wrapped as panics")
+	assert.Contains(t, err.Error(), "provider rate limited",
+		"original error message must be preserved")
+}

--- a/internal/ai/supervisor_graph.go
+++ b/internal/ai/supervisor_graph.go
@@ -120,13 +120,25 @@ func (n *routerNode) Run(ctx context.Context, state *State) error {
 		}
 	}
 
-	// Single-agent path: run inline (no goroutines)
+	// Single-agent path: run inline (no goroutines). Still wrap with
+	// recover so a panic in the agent surfaces as a graph error rather
+	// than crashing the server. Same defense-in-depth as the multi-agent
+	// goroutine path below.
 	if len(route) == 1 {
 		node, ok := n.agents[route[0]]
 		if !ok {
 			return fmt.Errorf("router: unknown agent %q", route[0])
 		}
-		return node.Run(ctx, state)
+		var agentErr error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					agentErr = fmt.Errorf("agent %q panicked: %v", node.Name(), r)
+				}
+			}()
+			agentErr = node.Run(ctx, state)
+		}()
+		return agentErr
 	}
 
 	// Multi-agent path: run all routed specialists in parallel.
@@ -161,8 +173,23 @@ func (n *routerNode) Run(ctx context.Context, state *State) error {
 			// ponytail: serial fan-out for v1 — the supervisor graph's
 			// multi-agent case is rare; the parallel speedup didn't earn
 			// its complexity yet.
-			err := node.Run(ctx, state)
-			results[i] = result{err: err}
+			//
+			// Each iteration gets its own deferred recover so a panic in
+			// one specialist (nil deref, unexpected state, provider bug)
+			// surfaces as a graph error instead of crashing the server.
+			// The caller (chat_handler_message.go) already has a graceful
+			// fallback to the legacy ReAct loop on graph errors, so a
+			// recovered panic becomes "supervisor failed, retrying with
+			// react" rather than "server down".
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						results[i] = result{err: fmt.Errorf("agent %q panicked: %v", node.Name(), r)}
+					}
+				}()
+				err := node.Run(ctx, state)
+				results[i] = result{err: err}
+			}()
 		}
 	}()
 

--- a/internal/mcp/tools/invoke.go
+++ b/internal/mcp/tools/invoke.go
@@ -112,6 +112,16 @@ func (t *InvokeFunctionTool) Execute(ctx context.Context, args map[string]any, a
 			IsError: true,
 		}, nil
 	}
+	// Defense in depth: GetFunctionByNamespace currently wraps ErrNoRows as
+	// an error, but GetProcedureByName returns (nil, nil) for not-found.
+	// The storage contracts are asymmetric; nil-check both before dereffing
+	// so a future storage refactor can't reintroduce the panic.
+	if fn == nil {
+		return &mcp.ToolResult{
+			Content: []mcp.Content{mcp.ErrorContent(fmt.Sprintf("Function not found: %s", name))},
+			IsError: true,
+		}, nil
+	}
 
 	// Check if enabled
 	if !fn.Enabled {
@@ -277,15 +287,30 @@ func (t *InvokeRPCTool) Execute(ctx context.Context, args map[string]any, authCt
 		namespace = ns
 	}
 
-	// Get procedure
+	// Get procedure. When the LLM specified a namespace, look there.
+	// Otherwise fall back to ANY namespace (ordered so "default" wins) so
+	// procedures synced to non-empty namespaces are still reachable.
+	// Without this fallback, invoke_rpc defaults to namespace="" and
+	// returns "not found" for every procedure synced to "default" or a
+	// chatbot-specific namespace — which the supervisor's action agent
+	// can't recover from because it doesn't know the chatbot's namespace.
 	var proc *rpc.Procedure
 	var err error
 	if namespace != "" {
 		proc, err = t.storage.GetProcedureByName(ctx, namespace, name)
 	} else {
-		proc, err = t.storage.GetProcedureByName(ctx, "", name)
+		proc, err = t.storage.GetProcedureByNameAnyNamespace(ctx, name)
 	}
 	if err != nil {
+		return &mcp.ToolResult{
+			Content: []mcp.Content{mcp.ErrorContent(fmt.Sprintf("Procedure not found: %s", name))},
+			IsError: true,
+		}, nil
+	}
+	// GetProcedureByName returns (nil, nil) for not-found — must nil-check
+	// before dereffing proc.Enabled below. This is the fix for the
+	// production SIGSEGV at invoke.go:296 (original line number).
+	if proc == nil {
 		return &mcp.ToolResult{
 			Content: []mcp.Content{mcp.ErrorContent(fmt.Sprintf("Procedure not found: %s", name))},
 			IsError: true,

--- a/internal/rpc/storage.go
+++ b/internal/rpc/storage.go
@@ -287,6 +287,53 @@ func (s *Storage) GetProcedureByName(ctx context.Context, namespace, name string
 	return proc, nil
 }
 
+// GetProcedureByNameAnyNamespace retrieves a procedure by name across all
+// namespaces, ordered so the "default" namespace wins ties. Mirrors the
+// existing GetFunction behavior (functions.storage.go:185) for callers
+// that don't know which namespace to look in.
+//
+// Used by invoke_rpc when the LLM didn't specify a namespace — without
+// this fallback, invoke_rpc defaults to namespace="" and misses procedures
+// synced to "default" or a chatbot-specific namespace. The supervisor's
+// action agent doesn't carry namespace context in its tool args, so this
+// fallback is what makes invoke_rpc actually find procedures.
+//
+// Returns (nil, nil) when no procedure by that name exists in any
+// namespace — same not-found contract as GetProcedureByName.
+func (s *Storage) GetProcedureByNameAnyNamespace(ctx context.Context, name string) (*Procedure, error) {
+	tenantID := database.TenantFromContext(ctx)
+	query := `
+		SELECT id, name, namespace, description, sql_query, original_code,
+			input_schema, output_schema, allowed_tables, allowed_schemas,
+			max_execution_time_seconds, require_roles, is_public, disable_execution_logs, schedule,
+			enabled, version, source, created_by, created_at, updated_at
+		FROM rpc.procedures
+		WHERE name = $1
+		  AND (tenant_id = $2 OR ($2 IS NULL AND tenant_id IS NULL))
+		ORDER BY namespace
+		LIMIT 1
+	`
+
+	proc := &Procedure{}
+	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, query, name, database.TenantOrNil(tenantID)).Scan(
+			&proc.ID, &proc.Name, &proc.Namespace, &proc.Description, &proc.SQLQuery, &proc.OriginalCode,
+			&proc.InputSchema, &proc.OutputSchema, &proc.AllowedTables, &proc.AllowedSchemas,
+			&proc.MaxExecutionTimeSeconds, &proc.RequireRoles, &proc.IsPublic, &proc.DisableExecutionLogs, &proc.Schedule,
+			&proc.Enabled, &proc.Version, &proc.Source, &proc.CreatedBy, &proc.CreatedAt, &proc.UpdatedAt,
+		)
+	})
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get procedure by name (any namespace): %w", err)
+	}
+
+	return proc, nil
+}
+
 // ListProcedures lists all procedures, optionally filtered by namespace
 func (s *Storage) ListProcedures(ctx context.Context, namespace string) ([]*Procedure, error) {
 	tenantID := database.TenantFromContext(ctx)


### PR DESCRIPTION
## Summary

Fixes another supervisor-path server crash, same chatbot as #251 but a layer deeper. Stack trace:

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
github.com/nimbleflux/fluxbase/internal/mcp/tools.(*InvokeRPCTool).Execute
    /build/internal/mcp/tools/invoke.go:296 +0x128
github.com/nimbleflux/fluxbase/internal/ai.(*MCPToolExecutor).ExecuteTool
github.com/nimbleflux/fluxbase/internal/ai.(*ActionAgent).executeActionTool
github.com/nimbleflux/fluxbase/internal/ai.(*ActionAgent).Run
github.com/nimbleflux/fluxbase/internal/ai.(*routerNode).Run.func1
\`\`\`

## Root cause

The LLM called \`invoke_rpc\` with \`{"name":"get_trip_plan"}\` and no namespace. \`invoke.go:296\` dereffed \`proc.Enabled\` without checking \`proc == nil\`. \`rpc.Storage.GetProcedureByName\` returns \`(nil, nil)\` on not-found (intentional — used by \`sync_rpc.go\` as a create-vs-update sentinel), but the invoke_rpc caller forgot to nil-check.

The procedure lookup also missed because \`invoke.go\` defaulted the lookup namespace to \`""\` when the LLM didn't pass one — so procedures synced to \`"default"\` or \`"wayli"\` were unreachable.

## Three layers of fix

### Layer 1 — immediate crash fix
\`internal/mcp/tools/invoke.go\`:
- \`invoke_rpc\`: nil-check \`proc\` after lookup; return clean \"Procedure not found\" MCP error
- \`invoke_function\`: same defensive nil-check for \`fn\` (currently safe via \`GetFunction\`'s err-wrapping, but the storage contract is asymmetric — defense in depth against future refactors)

### Layer 2 — supervisor router panic recovery (higher-leverage safety net)
\`internal/ai/supervisor_graph.go\`:
- Wrap each specialist agent \`Run()\` in \`defer recover()\` so any panic surfaces as a graph error instead of crashing the server
- Applied to **both** the single-agent inline path (line 129) and the multi-agent goroutine path (line 154)
- Existing chat-handler fallback turns recovered panic into \"supervisor failed → retry with legacy ReAct loop\"

This closes the whole \"agent panic crashes server\" bug class. The specific nil-deref from this report is fixed by Layer 1 directly, but Layer 2 means the next similar bug (in any specialist, any tool) won't take the server down.

### Layer 3 — namespace fallback
\`internal/rpc/storage.go\`: new \`GetProcedureByNameAnyNamespace(ctx, name)\` method, mirrors the existing \`GetFunction\` behavior — orders by namespace, returns first match so \"default\" wins ties.

\`internal/mcp/tools/invoke.go\`: \`invoke_rpc\` calls the new method when no namespace is specified, instead of defaulting to \`namespace=""\`. Procedures in any namespace are now reachable from supervisor-mode chatbots without app-side prompt changes.

## Tests

\`internal/ai/router_panic_test.go\` (new):
- \`TestRouterNode_AgentPanic_RecoveredAndSurfaced\` — panicking fake node, verify error contains \"panicked\" + agent name
- \`TestRouterNode_PanicInOneAgent_OthersStillRun\` — sibling agents in multi-agent routes still execute after one panics
- \`TestRouterNode_NormalError_NotWrappedAsPanic\` — normal errors pass through cleanly without \"panicked\" wrapper

Layer 1's nil-check is hard to unit-test without refactoring \`InvokeRPCTool.storage\` to an interface (scope creep). Layer 2's recovery is the safety net that catches the bug class including any future similar bug.

## App-side note

Users who added \`@fluxbase:system-prompt\` hints telling the LLM to pass \`namespace=\"...\"\` can remove them after this PR ships — the supervisor finds procedures in any namespace automatically.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`golangci-lint run ./internal/...\` — 0 issues
- [x] \`go test ./internal/ai/... ./internal/rpc/... ./internal/mcp/...\` — all pass
- [x] \`cd sdk && bun run type-check\` — clean (no SDK changes)