### PR TITLE
feat(ai): Tavily web search as first-class tool integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,9 +212,11 @@ Server initialization uses a module-based dependency injection system:
 - `internal/ai/agent_deps.go` - `AgentDeps` bundle (chatbot, provider, services, sender) + `AgentEventSender` interface for WS events.
 - `internal/ai/agent_supervisor.go` - Routing LLM call. Parses JSON `SupervisorPlan` (route, language, investigative flag, min_tool_calls). Applies page-profile whitelist.
 - `internal/ai/agent_specialists.go` - SQL, KB, Action, Chat agents. Each has a focused prompt + tool whitelist + bounded internal loop.
+- `internal/ai/agent_web.go` - Web Agent specialist. Calls Tavily via the integrations storage; opt-in per chatbot via `@fluxbase:web-search`.
 - `internal/ai/agent_synthesizer_verifier.go` - Synthesizer (merges multi-agent output) + Verifier (Unicode-script language check + optional LLM grounding check on investigative turns).
 - `internal/ai/agent_prompts.go` - Per-agent static system prompts (focused ~100 lines each).
 - `internal/ai/page_context.go` - `PageProfile` + `PageProfiles` map + `@fluxbase:page-contexts` JSON parser. Level-2 page-aware chatbot overrides.
+- `internal/ai/integrations/` - Non-LLM tool integrations (web search via Tavily, URL fetch). Storage with auto-encryption of api_key (AES-256-GCM), env/YAML config parity via synthetic `FROM_CONFIG` row, REST API + admin UI + test-connection endpoint.
 - Reasoning modes: `"supervisor"` (default for new + existing chatbots via `PopulateDerivedFields`), `"react"`, `"strict"`, `"none"`. Pin via `@fluxbase:reasoning-mode` annotation.
 
 **Multi-Tenancy:**

--- a/admin/src/components/ai-integrations/create-integration-dialog.tsx
+++ b/admin/src/components/ai-integrations/create-integration-dialog.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useFluxbaseClient } from "@nimbleflux/fluxbase-sdk-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+
+interface CreateIntegrationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * CreateIntegrationDialog — form for adding a new tool integration.
+ * Currently specialized to web_search + Tavily. When more integration
+ * types ship, the form should switch on integration_type and render
+ * provider-specific fields.
+ *
+ * The shape mirrors CreateProviderDialog. Secrets (api_key) are sent
+ * plaintext to the server (over HTTPS) and encrypted at the storage
+ * layer; they never appear in API responses afterward.
+ */
+export function CreateIntegrationDialog({
+  open,
+  onOpenChange,
+}: CreateIntegrationDialogProps) {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  const [name, setName] = useState("");
+  const [provider, setProvider] = useState<"tavily">("tavily");
+  const [apiKey, setApiKey] = useState("");
+  const [defaultDepth, setDefaultDepth] = useState<"basic" | "advanced">(
+    "basic",
+  );
+  const [isDefault, setIsDefault] = useState(true);
+  const [enabled, setEnabled] = useState(true);
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      client.admin.ai.createIntegration({
+        name,
+        integration_type: "web_search",
+        provider,
+        config: {
+          ...(apiKey ? { api_key: apiKey } : {}),
+          ...(defaultDepth ? { default_depth: defaultDepth } : {}),
+        },
+        enabled,
+        is_default: isDefault,
+      }),
+    onSuccess: async () => {
+      toast.success("Integration created");
+      await queryClient.invalidateQueries({
+        queryKey: ["ai", "integrations"],
+      });
+      reset();
+      onOpenChange(false);
+    },
+    onError: (error) =>
+      toast.error(`Create failed: ${(error as Error).message}`),
+  });
+
+  const reset = () => {
+    setName("");
+    setProvider("tavily");
+    setApiKey("");
+    setDefaultDepth("basic");
+    setIsDefault(true);
+    setEnabled(true);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New Tool Integration</DialogTitle>
+          <DialogDescription>
+            Configure an external service that chatbot specialists can
+            call. Currently supports web search via Tavily.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Tavily (prod)"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="provider">Provider</Label>
+            <Select
+              value={provider}
+              onValueChange={(v) => setProvider(v as "tavily")}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="tavily">Tavily</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="apiKey">API Key</Label>
+            <Input
+              id="apiKey"
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="tvly-..."
+            />
+            <p className="text-xs text-muted-foreground">
+              Encrypted at rest. Never shown again after save.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="depth">Default Search Depth</Label>
+            <Select
+              value={defaultDepth}
+              onValueChange={(v) =>
+                setDefaultDepth(v as "basic" | "advanced")
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="basic">
+                  Basic (faster, cheaper)
+                </SelectItem>
+                <SelectItem value="advanced">
+                  Advanced (slower, more thorough)
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Label htmlFor="default">Set as default for web_search</Label>
+            <Switch
+              id="default"
+              checked={isDefault}
+              onCheckedChange={setIsDefault}
+            />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Label htmlFor="enabled">Enabled</Label>
+            <Switch
+              id="enabled"
+              checked={enabled}
+              onCheckedChange={setEnabled}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={
+              createMutation.isPending ||
+              !name ||
+              !apiKey ||
+              !provider
+            }
+            onClick={() => createMutation.mutate()}
+          >
+            {createMutation.isPending ? "Creating..." : "Create"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/admin/src/components/ai-integrations/edit-integration-dialog.tsx
+++ b/admin/src/components/ai-integrations/edit-integration-dialog.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useFluxbaseClient } from "@nimbleflux/fluxbase-sdk-react";
+import type { ToolIntegration } from "@nimbleflux/fluxbase-sdk";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+
+interface EditIntegrationDialogProps {
+  integration: ToolIntegration | null;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * EditIntegrationDialog — form for editing an existing tool integration.
+ *
+ * API key field shows "***masked***" placeholder when the integration
+ * already has a key. Leaving the field unchanged (or sending the mask
+ * back) preserves the existing encrypted value. Entering new text
+ * overwrites.
+ */
+export function EditIntegrationDialog({
+  integration,
+  onOpenChange,
+}: EditIntegrationDialogProps) {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  const [name, setName] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [enabled, setEnabled] = useState(true);
+
+  // Sync local state when integration prop changes
+  useEffect(() => {
+    if (integration) {
+      setName(integration.name);
+      setApiKey(integration.config?.api_key ? "***masked***" : "");
+      setEnabled(integration.enabled);
+    }
+  }, [integration]);
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      client.admin.ai.updateIntegration(integration!.id, {
+        name,
+        // ponytail: server treats "***masked***" as "preserve existing"
+        config: { api_key: apiKey },
+        enabled,
+      }),
+    onSuccess: async () => {
+      toast.success("Integration updated");
+      await queryClient.invalidateQueries({
+        queryKey: ["ai", "integrations"],
+      });
+      onOpenChange(false);
+    },
+    onError: (error) =>
+      toast.error(`Update failed: ${(error as Error).message}`),
+  });
+
+  if (!integration) return null;
+
+  return (
+    <Dialog open={!!integration} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Integration</DialogTitle>
+          <DialogDescription>
+            {integration.read_only
+              ? "This integration is read-only (configured via env/YAML). Changes here will be rejected by the server."
+              : `Provider: ${integration.provider} · Type: ${integration.integration_type}`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="edit-name">Name</Label>
+            <Input
+              id="edit-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={integration.read_only}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="edit-apiKey">API Key</Label>
+            <Input
+              id="edit-apiKey"
+              type="password"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+              placeholder="Enter new key to replace"
+              disabled={integration.read_only}
+            />
+            <p className="text-xs text-muted-foreground">
+              {integration.config?.api_key
+                ? "Leave unchanged to preserve existing key."
+                : "No key set."}
+            </p>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <Label htmlFor="edit-enabled">Enabled</Label>
+            <Switch
+              id="edit-enabled"
+              checked={enabled}
+              onCheckedChange={setEnabled}
+              disabled={integration.read_only}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={
+              updateMutation.isPending || integration.read_only
+            }
+            onClick={() => updateMutation.mutate()}
+          >
+            {updateMutation.isPending ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/admin/src/components/ai-integrations/tool-integrations-tab.tsx
+++ b/admin/src/components/ai-integrations/tool-integrations-tab.tsx
@@ -60,7 +60,7 @@ export function ToolIntegrationsTab() {
   const [testingId, setTestingId] = useState<string | null>(null);
 
   const { data: integrations, isLoading } = useQuery({
-    queryKey: ["ai", "integrations"],
+    queryKey: ["ai-integrations", client.admin.ai],
     queryFn: () => client.admin.ai.listIntegrations(),
     select: (res) => res.data ?? [],
   });
@@ -75,7 +75,7 @@ export function ToolIntegrationsTab() {
         toast.error(`Test failed: ${res.data?.error ?? "unknown error"}`);
       }
       await queryClient.invalidateQueries({
-        queryKey: ["ai", "integrations"],
+        queryKey: ["ai-integrations"],
       });
     },
     onError: (error) => toast.error(`Test failed: ${(error as Error).message}`),
@@ -87,7 +87,7 @@ export function ToolIntegrationsTab() {
     onSuccess: async () => {
       toast.success("Default integration updated");
       await queryClient.invalidateQueries({
-        queryKey: ["ai", "integrations"],
+        queryKey: ["ai-integrations"],
       });
     },
     onError: (error) => toast.error(`Failed: ${(error as Error).message}`),
@@ -266,7 +266,7 @@ export function ToolIntegrationsTab() {
           }
           toast.success("Integration deleted");
           await queryClient.invalidateQueries({
-            queryKey: ["ai", "integrations"],
+            queryKey: ["ai-integrations"],
           });
           setDeletingIntegration(null);
         }}

--- a/admin/src/components/ai-integrations/tool-integrations-tab.tsx
+++ b/admin/src/components/ai-integrations/tool-integrations-tab.tsx
@@ -1,0 +1,276 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useFluxbaseClient } from "@nimbleflux/fluxbase-sdk-react";
+import type { ToolIntegration } from "@nimbleflux/fluxbase-sdk";
+import {
+  Globe,
+  Plus,
+  Star,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  Check,
+  FlaskConical,
+  Loader2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { CreateIntegrationDialog } from "./create-integration-dialog";
+import { EditIntegrationDialog } from "./edit-integration-dialog";
+
+/**
+ * ToolIntegrationsTab lists, creates, edits, and tests non-LLM tool
+ * integrations (currently: web search via Tavily). Mirrors AIProvidersTab
+ * shape: table with row actions + create/edit dialogs + test-connection
+ * button.
+ */
+export function ToolIntegrationsTab() {
+  const client = useFluxbaseClient();
+  const queryClient = useQueryClient();
+
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [editingIntegration, setEditingIntegration] =
+    useState<ToolIntegration | null>(null);
+  const [deletingIntegration, setDeletingIntegration] =
+    useState<ToolIntegration | null>(null);
+  const [testingId, setTestingId] = useState<string | null>(null);
+
+  const { data: integrations, isLoading } = useQuery({
+    queryKey: ["ai", "integrations"],
+    queryFn: () => client.admin.ai.listIntegrations(),
+    select: (res) => res.data ?? [],
+  });
+
+  const testMutation = useMutation({
+    mutationFn: (id: string) => client.admin.ai.testIntegration(id),
+    onMutate: (id) => setTestingId(id),
+    onSuccess: async (res) => {
+      if (res.data?.status === "ok") {
+        toast.success("Connection test passed");
+      } else {
+        toast.error(`Test failed: ${res.data?.error ?? "unknown error"}`);
+      }
+      await queryClient.invalidateQueries({
+        queryKey: ["ai", "integrations"],
+      });
+    },
+    onError: (error) => toast.error(`Test failed: ${(error as Error).message}`),
+    onSettled: () => setTestingId(null),
+  });
+
+  const setDefaultMutation = useMutation({
+    mutationFn: (id: string) => client.admin.ai.setDefaultIntegration(id),
+    onSuccess: async () => {
+      toast.success("Default integration updated");
+      await queryClient.invalidateQueries({
+        queryKey: ["ai", "integrations"],
+      });
+    },
+    onError: (error) => toast.error(`Failed: ${(error as Error).message}`),
+  });
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <div>
+          <CardTitle className="flex items-center gap-2">
+            <Globe className="h-5 w-5" />
+            Tool Integrations
+          </CardTitle>
+          <CardDescription>
+            External services that chatbot specialists can call. Currently
+            supports web search via Tavily.
+          </CardDescription>
+        </div>
+        <Button onClick={() => setShowCreateDialog(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Integration
+        </Button>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8 text-muted-foreground">
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Loading integrations...
+          </div>
+        ) : !integrations || integrations.length === 0 ? (
+          <div className="rounded-lg border border-dashed py-12 text-center">
+            <Globe className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">
+              No tool integrations configured. Add one to enable the Web
+              Agent specialist for your chatbots.
+            </p>
+          </div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Provider</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Default</TableHead>
+                <TableHead className="w-12"></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {integrations.map((integration) => (
+                <TableRow key={integration.id}>
+                  <TableCell className="font-medium">
+                    {integration.name}
+                    {integration.read_only && (
+                      <Badge variant="outline" className="ml-2 text-xs">
+                        Read-only
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">
+                      {integration.integration_type}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="capitalize">
+                    {integration.provider}
+                  </TableCell>
+                  <TableCell>
+                    {integration.last_test_status === "ok" && (
+                      <Badge className="bg-green-100 text-green-800">
+                        <Check className="mr-1 h-3 w-3" />
+                        Tested OK
+                      </Badge>
+                    )}
+                    {integration.last_test_status === "failed" && (
+                      <Badge variant="destructive">Test failed</Badge>
+                    )}
+                    {!integration.last_test_status && (
+                      <Badge variant="outline">Not tested</Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {integration.is_default && (
+                      <Star className="h-4 w-4 fill-yellow-400 text-yellow-400" />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" size="icon">
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem
+                          onClick={() => setEditingIntegration(integration)}
+                        >
+                          <Pencil className="mr-2 h-4 w-4" />
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          disabled={
+                            testingId === integration.id ||
+                            integration.read_only
+                          }
+                          onClick={() =>
+                            testMutation.mutate(integration.id)
+                          }
+                        >
+                          {testingId === integration.id ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : (
+                            <FlaskConical className="mr-2 h-4 w-4" />
+                          )}
+                          Test connection
+                        </DropdownMenuItem>
+                        {!integration.is_default && (
+                          <DropdownMenuItem
+                            disabled={integration.read_only}
+                            onClick={() =>
+                              setDefaultMutation.mutate(integration.id)
+                            }
+                          >
+                            <Star className="mr-2 h-4 w-4" />
+                            Set as default
+                          </DropdownMenuItem>
+                        )}
+                        {!integration.read_only && (
+                          <>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              className="text-destructive"
+                              onClick={() =>
+                                setDeletingIntegration(integration)
+                              }
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" />
+                              Delete
+                            </DropdownMenuItem>
+                          </>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+
+      <CreateIntegrationDialog
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+      />
+      <EditIntegrationDialog
+        integration={editingIntegration}
+        onOpenChange={(open) => !open && setEditingIntegration(null)}
+      />
+      <ConfirmDialog
+        open={!!deletingIntegration}
+        onOpenChange={(open) => !open && setDeletingIntegration(null)}
+        title="Delete integration"
+        desc={`Delete "${deletingIntegration?.name}"? Chatbots using this integration will lose access to the Web Agent.`}
+        confirmText="Delete"
+        destructive
+        handleConfirm={async () => {
+          if (!deletingIntegration) return;
+          const { error } = await client.admin.ai.deleteIntegration(
+            deletingIntegration.id,
+          );
+          if (error) {
+            toast.error(`Delete failed: ${error.message}`);
+            return;
+          }
+          toast.success("Integration deleted");
+          await queryClient.invalidateQueries({
+            queryKey: ["ai", "integrations"],
+          });
+          setDeletingIntegration(null);
+        }}
+      />
+    </Card>
+  );
+}

--- a/admin/src/components/layout/data/sidebar-data.ts
+++ b/admin/src/components/layout/data/sidebar-data.ts
@@ -37,6 +37,7 @@ import {
   Command,
   Building2,
   Server,
+  Globe,
 } from "lucide-react";
 import { type SidebarData } from "../types";
 
@@ -295,6 +296,12 @@ export const sidebarData: SidebarDataWithVisibility = {
           title: "AI Providers",
           url: "/ai-providers",
           icon: Bot,
+          visibility: "all",
+        },
+        {
+          title: "Tool Integrations",
+          url: "/ai-integrations",
+          icon: Globe,
           visibility: "all",
         },
       ],

--- a/admin/src/routeTree.gen.ts
+++ b/admin/src/routeTree.gen.ts
@@ -53,6 +53,7 @@ import { Route as AuthenticatedClientKeysIndexRouteImport } from './routes/_auth
 import { Route as AuthenticatedChatbotsIndexRouteImport } from './routes/_authenticated/chatbots/index'
 import { Route as AuthenticatedAuthenticationIndexRouteImport } from './routes/_authenticated/authentication/index'
 import { Route as AuthenticatedAiProvidersIndexRouteImport } from './routes/_authenticated/ai-providers/index'
+import { Route as AuthenticatedAiIntegrationsIndexRouteImport } from './routes/_authenticated/ai-integrations/index'
 import { Route as AuthenticatedTenantsTenantIdRouteImport } from './routes/_authenticated/tenants/$tenantId'
 import { Route as AuthenticatedSettingsAppearanceRouteImport } from './routes/_authenticated/settings/appearance'
 import { Route as AuthenticatedMonitoringAiAuditRouteImport } from './routes/_authenticated/monitoring/ai-audit'
@@ -310,6 +311,12 @@ const AuthenticatedAiProvidersIndexRoute =
     path: '/ai-providers/',
     getParentRoute: () => AuthenticatedRouteRoute,
   } as any)
+const AuthenticatedAiIntegrationsIndexRoute =
+  AuthenticatedAiIntegrationsIndexRouteImport.update({
+    id: '/ai-integrations/',
+    path: '/ai-integrations/',
+    getParentRoute: () => AuthenticatedRouteRoute,
+  } as any)
 const AuthenticatedTenantsTenantIdRoute =
   AuthenticatedTenantsTenantIdRouteImport.update({
     id: '/tenants/$tenantId',
@@ -388,6 +395,7 @@ export interface FileRoutesByFullPath {
   '/monitoring/ai-audit': typeof AuthenticatedMonitoringAiAuditRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/tenants/$tenantId': typeof AuthenticatedTenantsTenantIdRoute
+  '/ai-integrations/': typeof AuthenticatedAiIntegrationsIndexRoute
   '/ai-providers/': typeof AuthenticatedAiProvidersIndexRoute
   '/authentication/': typeof AuthenticatedAuthenticationIndexRoute
   '/chatbots/': typeof AuthenticatedChatbotsIndexRoute
@@ -443,6 +451,7 @@ export interface FileRoutesByTo {
   '/monitoring/ai-audit': typeof AuthenticatedMonitoringAiAuditRoute
   '/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/tenants/$tenantId': typeof AuthenticatedTenantsTenantIdRoute
+  '/ai-integrations': typeof AuthenticatedAiIntegrationsIndexRoute
   '/ai-providers': typeof AuthenticatedAiProvidersIndexRoute
   '/authentication': typeof AuthenticatedAuthenticationIndexRoute
   '/chatbots': typeof AuthenticatedChatbotsIndexRoute
@@ -500,6 +509,7 @@ export interface FileRoutesById {
   '/_authenticated/monitoring/ai-audit': typeof AuthenticatedMonitoringAiAuditRoute
   '/_authenticated/settings/appearance': typeof AuthenticatedSettingsAppearanceRoute
   '/_authenticated/tenants/$tenantId': typeof AuthenticatedTenantsTenantIdRoute
+  '/_authenticated/ai-integrations/': typeof AuthenticatedAiIntegrationsIndexRoute
   '/_authenticated/ai-providers/': typeof AuthenticatedAiProvidersIndexRoute
   '/_authenticated/authentication/': typeof AuthenticatedAuthenticationIndexRoute
   '/_authenticated/chatbots/': typeof AuthenticatedChatbotsIndexRoute
@@ -557,6 +567,7 @@ export interface FileRouteTypes {
     | '/monitoring/ai-audit'
     | '/settings/appearance'
     | '/tenants/$tenantId'
+    | '/ai-integrations/'
     | '/ai-providers/'
     | '/authentication/'
     | '/chatbots/'
@@ -612,6 +623,7 @@ export interface FileRouteTypes {
     | '/monitoring/ai-audit'
     | '/settings/appearance'
     | '/tenants/$tenantId'
+    | '/ai-integrations'
     | '/ai-providers'
     | '/authentication'
     | '/chatbots'
@@ -668,6 +680,7 @@ export interface FileRouteTypes {
     | '/_authenticated/monitoring/ai-audit'
     | '/_authenticated/settings/appearance'
     | '/_authenticated/tenants/$tenantId'
+    | '/_authenticated/ai-integrations/'
     | '/_authenticated/ai-providers/'
     | '/_authenticated/authentication/'
     | '/_authenticated/chatbots/'
@@ -1031,6 +1044,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAiProvidersIndexRouteImport
       parentRoute: typeof AuthenticatedRouteRoute
     }
+    '/_authenticated/ai-integrations/': {
+      id: '/_authenticated/ai-integrations/'
+      path: '/ai-integrations'
+      fullPath: '/ai-integrations/'
+      preLoaderRoute: typeof AuthenticatedAiIntegrationsIndexRouteImport
+      parentRoute: typeof AuthenticatedRouteRoute
+    }
     '/_authenticated/tenants/$tenantId': {
       id: '/_authenticated/tenants/$tenantId'
       path: '/tenants/$tenantId'
@@ -1111,6 +1131,7 @@ interface AuthenticatedRouteRouteChildren {
   AuthenticatedMonitoringAiAuditRoute: typeof AuthenticatedMonitoringAiAuditRoute
   AuthenticatedSettingsAppearanceRoute: typeof AuthenticatedSettingsAppearanceRoute
   AuthenticatedTenantsTenantIdRoute: typeof AuthenticatedTenantsTenantIdRoute
+  AuthenticatedAiIntegrationsIndexRoute: typeof AuthenticatedAiIntegrationsIndexRoute
   AuthenticatedAiProvidersIndexRoute: typeof AuthenticatedAiProvidersIndexRoute
   AuthenticatedAuthenticationIndexRoute: typeof AuthenticatedAuthenticationIndexRoute
   AuthenticatedChatbotsIndexRoute: typeof AuthenticatedChatbotsIndexRoute
@@ -1156,6 +1177,7 @@ const AuthenticatedRouteRouteChildren: AuthenticatedRouteRouteChildren = {
   AuthenticatedMonitoringAiAuditRoute: AuthenticatedMonitoringAiAuditRoute,
   AuthenticatedSettingsAppearanceRoute: AuthenticatedSettingsAppearanceRoute,
   AuthenticatedTenantsTenantIdRoute: AuthenticatedTenantsTenantIdRoute,
+  AuthenticatedAiIntegrationsIndexRoute: AuthenticatedAiIntegrationsIndexRoute,
   AuthenticatedAiProvidersIndexRoute: AuthenticatedAiProvidersIndexRoute,
   AuthenticatedAuthenticationIndexRoute: AuthenticatedAuthenticationIndexRoute,
   AuthenticatedChatbotsIndexRoute: AuthenticatedChatbotsIndexRoute,

--- a/admin/src/routes/_authenticated/ai-integrations/index.tsx
+++ b/admin/src/routes/_authenticated/ai-integrations/index.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { Globe } from 'lucide-react'
+import { ToolIntegrationsTab } from '@/components/ai-integrations/tool-integrations-tab'
+import { PageHeader } from '@/components/layout/page-header'
+
+const ToolIntegrationsPage = () => {
+  return (
+    <div className='flex h-full flex-col'>
+      <PageHeader
+        icon={<Globe />}
+        title="Tool Integrations"
+        description="External services for chatbot specialists (web search via Tavily)"
+      />
+
+      <div className='flex-1 overflow-auto p-6'>
+        <ToolIntegrationsTab />
+      </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/_authenticated/ai-integrations/')({
+  component: ToolIntegrationsPage,
+})

--- a/deploy/helm/fluxbase/templates/deployment.yaml
+++ b/deploy/helm/fluxbase/templates/deployment.yaml
@@ -891,6 +891,19 @@ spec:
             - name: FLUXBASE_AI_OLLAMA_MODEL
               value: {{ .Values.config.ai.ollama_model | quote }}
             {{- end }}
+            # Tavily Web Search (for Web Agent specialist)
+            {{- if .Values.config.ai.tavily_api_key }}
+            - name: FLUXBASE_AI_TAVILY_API_KEY
+              value: {{ .Values.config.ai.tavily_api_key | quote }}
+            {{- end }}
+            {{- if .Values.config.ai.tavily_default_depth }}
+            - name: FLUXBASE_AI_TAVILY_DEFAULT_DEPTH
+              value: {{ .Values.config.ai.tavily_default_depth | quote }}
+            {{- end }}
+            {{- if .Values.config.ai.tavily_base_url }}
+            - name: FLUXBASE_AI_TAVILY_BASE_URL
+              value: {{ .Values.config.ai.tavily_base_url | quote }}
+            {{- end }}
             # Embedding Configuration
             {{- if kindIs "bool" .Values.config.ai.embedding_enabled }}
             - name: FLUXBASE_AI_EMBEDDING_ENABLED

--- a/deploy/helm/fluxbase/values.yaml
+++ b/deploy/helm/fluxbase/values.yaml
@@ -562,6 +562,10 @@ config:
     azure_embedding_deployment_name: ""
     ollama_endpoint: ""
     ollama_model: ""
+    # Tavily web search (Web Agent specialist)
+    tavily_api_key: ""
+    tavily_default_depth: ""
+    tavily_base_url: ""
     # Embeddings
     embedding_enabled: null
     embedding_provider: ""

--- a/docs/src/content/docs/guides/ai-chatbots.md
+++ b/docs/src/content/docs/guides/ai-chatbots.md
@@ -987,6 +987,28 @@ export default `You are a helpful assistant.`;
 
 The ReAct loop remains fully supported and is the right choice for simple low-cost chatbots that don't need multi-agent routing.
 
+### Web Search (Web Agent specialist)
+
+When the supervisor pipeline is enabled, you can also enable the Web Agent — a specialist that answers current-info questions by searching the live web via Tavily.
+
+Two-part setup:
+
+1. **Tenant/instance level**: configure Tavily credentials in **AI → Tool Integrations** (UI) or via `FLUXBASE_AI_TAVILY_API_KEY` env var. See [Tool Integrations](./ai-integrations.md) for full setup.
+
+2. **Chatbot level**: opt in via annotation:
+
+   ```typescript
+   /**
+    * @fluxbase:web-search enabled
+    *
+    * Optional: restrict results to specific domains
+    * @fluxbase:web-search-domains wikipedia.org, docs.python.org
+    */
+   export default `You are a helpful assistant.`;
+   ```
+
+When both are set, the supervisor routes current-info questions ("what's the latest X", "what time does Y close today", "find docs for Z") to the Web Agent automatically. No code changes elsewhere.
+
 See [Multi-Agent Supervisor](./ai-agents.md) for the full architecture, agent reference, and verification details.
 
 ## Page-aware Chatbots

--- a/docs/src/content/docs/guides/ai-integrations.md
+++ b/docs/src/content/docs/guides/ai-integrations.md
@@ -1,0 +1,147 @@
+---
+title: "Tool Integrations"
+description: Configure external services (web search via Tavily) that chatbot specialists can call. Supports env/YAML config, admin UI, and API.
+---
+
+# Tool Integrations
+
+Fluxbase chatbots can call external services beyond the database — web search via Tavily being the first-class example. This page covers configuration, the chatbot-side opt-in, and the architecture.
+
+Tool integrations are **separate from AI providers**: they don't do chat completions, don't take a model, and aren't selected per-chatbot via `chatbot.provider_id`. They live in their own `ai.tool_integrations` table with their own CRUD API and admin UI.
+
+## What's available
+
+| Integration type | Providers | What it does |
+|---|---|---|
+| `web_search` | Tavily (v1) | Search the web for current info. Used by the Web Agent specialist. |
+| `fetch_url` | Tavily Extract (v1) | Fetch a single URL as clean markdown. Auto-derived from a `web_search` integration. |
+
+Future providers (Brave, Jina, custom) fit into the same schema without restructuring.
+
+## Configuration
+
+Three paths, all equivalent:
+
+### 1. Environment variable (simplest)
+
+```bash
+export FLUXBASE_AI_TAVILY_API_KEY="tvly-..."
+# Optional:
+# export FLUXBASE_AI_TAVILY_DEFAULT_DEPTH="advanced"
+# export FLUXBASE_AI_TAVILY_BASE_URL="https://api.tavily.com"
+```
+
+When the server starts, it constructs a synthetic `FROM_CONFIG` integration row marked read-only. Chatbots with `@fluxbase:web-search enabled=true` immediately use it.
+
+### 2. YAML config file
+
+```yaml
+ai:
+  tavily_api_key: "tvly-..."
+  tavily_default_depth: "advanced"   # optional: "basic" (default) or "advanced"
+  # tavily_base_url: ""              # optional override
+```
+
+Same synthetic read-only row as env vars.
+
+### 3. Admin UI
+
+Navigate to **AI → Tool Integrations** in the sidebar. Click **New Integration**, fill in:
+
+- **Name**: human label (e.g., "Tavily prod")
+- **Provider**: Tavily (Brave/Jina will appear here when implemented)
+- **API Key**: your Tavily key (encrypted at rest with AES-256-GCM via the master `FLUXBASE_ENCRYPTION_KEY`)
+- **Default Search Depth**: `basic` (faster, cheaper) or `advanced` (slower, more thorough)
+- **Default**: check to make this the default `web_search` integration for the tenant
+
+Click the **Test connection** button in the row's dropdown menu to verify the credentials work before saving. The result is stored on the integration row and surfaced as a status pill in the list.
+
+### 4. API
+
+```bash
+# Create
+curl -X POST https://your-server/api/v1/admin/ai/integrations \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Tavily prod",
+    "integration_type": "web_search",
+    "provider": "tavily",
+    "config": {"api_key": "tvly-..."},
+    "enabled": true,
+    "is_default": true
+  }'
+
+# Test connection
+curl -X POST https://your-server/api/v1/admin/ai/integrations/$ID/test \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Full CRUD endpoints listed in the [API reference](./ai-events.md).
+
+## Enable for a chatbot
+
+Tool integrations are tenant-level — but the chatbot decides whether to use them. Add the annotation to the chatbot's source:
+
+```typescript
+/**
+ * Enable web search for this chatbot.
+ * @fluxbase:web-search enabled
+ *
+ * Optional: restrict results to specific domains
+ * @fluxbase:web-search-domains wikipedia.org, docs.python.org, https://news.ycombinator.com
+ */
+export default `You are a helpful assistant.`;
+```
+
+The supervisor's router now includes the **Web Agent** as a routable specialist. When the user asks about current info ("what's the latest X", "what time does Y close today"), the supervisor routes to `web` instead of `chat` with an "I don't know" fallback.
+
+## How the Web Agent works
+
+```
+User: "What time does the Berlin zoo close today?"
+   │
+[SUPERVISOR] routes to ["web"]   (KB has nothing, SQL has nothing, current info needed)
+   │
+[WEB AGENT]
+   ├─ web_search("Berlin zoo closing time today")
+   │     → 5 results, top hit zooberlin.de
+   ├─ fetch_url("https://www.zooberlin.de/")
+   │     → full page markdown
+   └─ final answer: "Berlin zoo closes at 18:30 today ([source](https://www.zooberlin.de))."
+```
+
+The Web Agent emits `agent_thought` events for each step (search query, fetch URL, result summary), so clients can render the thought process in real time. See [Multi-Agent Supervisor](./ai-agents.md) for the full event reference.
+
+## Cost
+
+Tavily pricing (as of this writing):
+
+| Plan | Cost |
+|---|---|
+| Free | 1,000 searches/month |
+| Pro | $30/month, 4,000 searches, then $0.01/search |
+| Enterprise | Custom |
+
+Per chatbot turn that routes to the Web Agent:
+
+- 1-2 Tavily calls (search + optional fetch) ≈ $0.01-0.03
+- 1-3 extra LLM calls for the agent's reasoning loop ≈ $0.005-0.02
+
+Typical chatbot with websearch enabled: $5-20/month additional cost on top of the existing LLM provider bill. Disable per chatbot by removing the annotation.
+
+## Secrets and encryption
+
+API keys in `tool_integrations.config.api_key` are encrypted at the application layer with AES-256-GCM, keyed by the master `FLUXBASE_ENCRYPTION_KEY`. They never appear in plaintext in API responses (masked to `"***masked***"`).
+
+If the encryption key is missing or changed, decryption fails gracefully — the integration's `api_key` becomes unusable but no other data is lost. Document this clearly in your deploy runbook.
+
+## Multi-tenancy
+
+Each tenant can have its own integrations. Tenant scoping is enforced by the same RLS policies used elsewhere — tenant A's integrations are invisible to tenant B. The synthetic `FROM_CONFIG` row (env/YAML config) is instance-wide and read-only.
+
+## See also
+
+- [Multi-Agent Supervisor](./ai-agents.md) — where the Web Agent fits in the pipeline
+- [AI Chatbots](./ai-chatbots.md) — chatbot configuration including the `@fluxbase:web-search` annotation
+- [AI events reference](./ai-events.md) — WebSocket events emitted by the Web Agent

--- a/fluxbase.yaml.example
+++ b/fluxbase.yaml.example
@@ -466,6 +466,14 @@ ai:
   # ollama_endpoint: ""                 # FLUXBASE_AI_OLLAMA_ENDPOINT - Ollama endpoint (e.g., http://localhost:11434)
   # ollama_model: ""                    # FLUXBASE_AI_OLLAMA_MODEL - Ollama model name (e.g., llama2)
 
+  # Tavily Web Search Settings (for Web Agent specialist)
+  # When set, a read-only synthetic integration is exposed and chatbots
+  # with @fluxbase:web-search enabled=true in their source can route
+  # current-info questions to the Web Agent.
+  # tavily_api_key: ""                  # FLUXBASE_AI_TAVILY_API_KEY - Tavily API key
+  # tavily_default_depth: ""            # FLUXBASE_AI_TAVILY_DEFAULT_DEPTH - "basic" (default) or "advanced"
+  # tavily_base_url: ""                 # FLUXBASE_AI_TAVILY_BASE_URL - override endpoint (rare)
+
   # Embedding Configuration (for vector search and knowledge bases)
   embedding_enabled: false              # FLUXBASE_AI_EMBEDDING_ENABLED - Enable embeddings
   # embedding_provider: ""              # FLUXBASE_AI_EMBEDDING_PROVIDER - Embedding provider (defaults to provider_type)

--- a/internal/ai/agent_deps.go
+++ b/internal/ai/agent_deps.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"context"
 
+	"github.com/nimbleflux/fluxbase/internal/ai/integrations"
 	"github.com/nimbleflux/fluxbase/internal/auth"
 	"github.com/nimbleflux/fluxbase/internal/mcp"
 )
@@ -48,6 +49,11 @@ type AgentDeps struct {
 
 	// MCPAuthCtx is the auth context for MCP tool execution.
 	MCPAuthCtx *mcp.AuthContext
+
+	// Integrations provides tool integrations (web search, URL fetch)
+	// for the Web Agent specialist. May be nil when no integrations are
+	// configured — the Web Agent is silently skipped in that case.
+	Integrations *integrations.Storage
 
 	// ChatCtx is the live WebSocket chat session context. May be nil when
 	// the supervisor is invoked outside the WS handler (e.g., from tests

--- a/internal/ai/agent_prompts.go
+++ b/internal/ai/agent_prompts.go
@@ -19,7 +19,7 @@ import (
 
 // supervisorSystemPrompt is the supervisor's static system prompt. It must
 // output a single JSON object matching SupervisorPlan. No prose, no
-// markdown — JSON only.
+// markdown fences — just the JSON object.
 const supervisorSystemPrompt = `You are a routing assistant for a multi-agent chatbot system.
 
 Read the user's message and decide which specialist agents should handle it.
@@ -30,16 +30,18 @@ Available specialist agents:
 - "sql"     — Investigates factual data questions by running SQL queries. Use for counts, lists, "show me", "how many", aggregations, filtering, joins, sorting, anything verifiable in the database.
 - "kb"      — Searches knowledge bases (documents) for conceptual, descriptive, or explanatory information. Use for "what is", "explain", "tell me about", or when the answer needs document context.
 - "action"  — Executes mutations or actions via edge functions / RPC procedures. Use when the user asks to create, update, delete, or trigger something.
+- "web"     — Searches the live web (Tavily) for current information. Use for "what's the latest X", "what time does Y close today", news, current prices/hours, recent docs, anything time-sensitive the database and KB won't know. Only available when the chatbot has web search enabled.
 - "chat"    — Handles greetings, chitchat, clarifications, follow-ups, and questions that don't need tools. Cheap model. Use as fallback when no specialist fits.
 
 Routing rules:
 1. Route to 1 agent for focused questions, multiple for hybrid questions.
 2. For "conceptual + data" questions (e.g., "Tell me about Italian restaurants I visited"), route to BOTH "kb" and "sql".
-3. For "hi", "thanks", "ok", pure greetings, route to "chat" only.
-4. If unsure whether the question is data or conceptual, prefer "sql" over "kb" — it's better to investigate than guess.
-5. Always set user_language to the language the user wrote in (e.g., "English", "German", "Japanese").
-6. Set is_investigative=true when the user asks a factual question that needs verification. Set min_tool_calls to the minimum number of tool invocations needed (usually 1; 2-3 for complex questions).
-7. Set requires_synthesis=true when routing to 2+ agents OR when the single agent's answer needs translation/reformatting into the user's language.
+3. For "current info" questions (current prices, today's hours, recent news, latest docs), route to "web". Don't route these to "kb" or "sql" — those won't have current info.
+4. For "hi", "thanks", "ok", pure greetings, route to "chat" only.
+5. If unsure whether the question is data or conceptual, prefer "sql" over "kb" — it's better to investigate than guess.
+6. Always set user_language to the language the user wrote in (e.g., "English", "German", "Japanese").
+7. Set is_investigative=true when the user asks a factual question that needs verification. Set min_tool_calls to the minimum number of tool invocations needed (usually 1; 2-3 for complex questions).
+8. Set requires_synthesis=true when routing to 2+ agents OR when the single agent's answer needs translation/reformatting into the user's language.
 
 Output format (JSON only, no other text):
 {
@@ -207,6 +209,37 @@ Be strict on facts, lenient on style. JSON only, no prose.`
 // BuildVerifierPrompt returns the Verifier's static system prompt.
 func BuildVerifierPrompt() string {
 	return verifierSystemPrompt
+}
+
+// webAgentSystemPrompt is the Web Agent's static system prompt. Focused
+// on current-info / lookup questions via Tavily. The prompt enforces:
+//   - Always search before answering
+//   - Cite URLs in the response
+//   - Match the user's language
+//   - Acknowledge uncertainty when results are thin
+const webAgentSystemPrompt = `You are the Web Agent in a multi-agent chatbot system. Your job is to answer questions about current events, recent information, or anything that needs up-to-date data from the internet.
+
+You have access to two tools:
+- web_search: search the web via Tavily
+- fetch_url: get the full content of a specific URL as markdown
+
+Investigation principles:
+1. ALWAYS run at least one web_search before answering. Never answer from your training data alone — the user is asking you specifically because they want current info.
+2. If the top search result looks promising but the snippet is too short, run fetch_url on it.
+3. Run multiple searches if the first one doesn't fully answer the question. Try different phrasings.
+4. Be honest when results are thin or conflicting. Say "based on what I found..." and cite sources.
+5. Be honest when you can't find anything. "I couldn't find current information on that" is a valid answer.
+
+Response style:
+- After completing your investigation, write a final answer in plain text.
+- CITE URLs inline as markdown links: "Berlin Zoo is open 9-18:30 ([source](https://...)).
+- Match the user's language. If they wrote in French, answer in French.
+- Quote specific facts from your sources: prices, hours, dates, names.
+- If the question is time-sensitive (hours, prices), note the date you found the info.`
+
+// BuildWebAgentPrompt returns the Web Agent's static system prompt.
+func BuildWebAgentPrompt(chatbot *Chatbot) string {
+	return webAgentSystemPrompt
 }
 
 // BuildDynamicContextForAgent builds the per-turn dynamic context that

--- a/internal/ai/agent_supervisor.go
+++ b/internal/ai/agent_supervisor.go
@@ -196,7 +196,7 @@ func parseSupervisorPlan(content string) (*SupervisorPlan, error) {
 	// Validate route entries
 	for _, r := range plan.Route {
 		switch r {
-		case "sql", "kb", "action", "chat":
+		case "sql", "kb", "action", "chat", "web":
 			// valid
 		default:
 			return nil, fmt.Errorf("unknown agent in route: %q", r)

--- a/internal/ai/agent_web.go
+++ b/internal/ai/agent_web.go
@@ -1,0 +1,344 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nimbleflux/fluxbase/internal/ai/integrations"
+)
+
+// WebAgent is the specialist that answers current-info / lookup questions
+// via Tavily web search. Routes through the integrations storage to
+// resolve the configured Tavily credentials at turn start, then runs an
+// internal tool-calling loop with two tools: web_search and fetch_url.
+//
+// Opt-in: only runs when (a) the chatbot has @fluxbase:web-search enabled
+// and (b) a default web_search integration exists at the tenant/instance
+// level. If either is missing, the supervisor silently excludes "web"
+// from the route whitelist.
+type WebAgent struct {
+	deps *AgentDeps
+}
+
+// NewWebAgent constructs a WebAgent bound to the given deps.
+func NewWebAgent(deps *AgentDeps) *WebAgent { return &WebAgent{deps: deps} }
+
+// Name implements Node.
+func (a *WebAgent) Name() string { return "web" }
+
+// Run executes the web agent's search-then-answer loop.
+//
+// Resolution flow:
+//  1. Resolve default web_search integration from deps.Integrations
+//  2. Construct TavilyClient from integration.Config.api_key + chatbot-level defaults
+//  3. Build messages with focused web-research prompt
+//  4. Internal tool loop bounded by chatbot.MaxToolIterations:
+//     - LLM call (non-streaming) → may emit reasoning + tool_call
+//     - For each tool_call: execute via Tavily, return short summary
+//     - When LLM emits no tool_call: that's the final answer
+//  5. Stream final answer through Sender.SendContent
+//  6. Append to state.AgentOutputs + state.FinalResponse
+func (a *WebAgent) Run(ctx context.Context, state *State) error {
+	chatbot := a.deps.Chatbot
+	provider := a.deps.Provider
+	if provider == nil {
+		return fmt.Errorf("web agent: no provider")
+	}
+	if a.deps.Integrations == nil {
+		return fmt.Errorf("web agent: no integrations storage configured")
+	}
+
+	// Resolve default web_search integration. Returns (nil, nil) when
+	// none configured — caller (supervisor) shouldn't have routed to us.
+	integration, err := a.deps.Integrations.GetDefaultIntegration(ctx, integrations.IntegrationTypeWebSearch)
+	if err != nil {
+		return fmt.Errorf("web agent: resolve integration: %w", err)
+	}
+	if integration == nil {
+		return fmt.Errorf("web agent: no web_search integration configured")
+	}
+
+	apiKey := integration.Config["api_key"]
+	if apiKey == "" {
+		return fmt.Errorf("web agent: integration %q has empty api_key", integration.Name)
+	}
+	baseURL := integration.Config["base_url"]
+
+	// Construct Tavily client
+	client := integrations.NewTavilyClient(apiKey, baseURL, nil)
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendAgentTransition(ctx, a.deps.ConversationID, AgentTransition{To: "web"})
+	}
+
+	// Build messages
+	systemPrompt := BuildWebAgentPrompt(chatbot)
+	dynamicContext := BuildDynamicContextForAgent(chatbot, a.deps.UserID, "web", a.deps.PageProfile)
+	if lang := state.UserLanguage(); lang != "" {
+		dynamicContext += fmt.Sprintf("\nUser's language: %s\n", lang)
+	}
+	if len(chatbot.WebSearchDomains) > 0 {
+		dynamicContext += fmt.Sprintf("\nRestrict web search to these domains: %s\n",
+			strings.Join(chatbot.WebSearchDomains, ", "))
+	}
+
+	userMsg := state.UserMessage()
+	messages := []Message{
+		{Role: RoleSystem, Content: systemPrompt},
+		{Role: RoleSystem, Content: dynamicContext},
+	}
+	messages = append(messages, tailMessages(state.ConversationHistory(), 4)...)
+	messages = append(messages, Message{Role: RoleUser, Content: userMsg})
+
+	tools := []Tool{WebSearchTool, FetchURLTool}
+
+	maxIters := chatbot.MaxToolIterations
+	if maxIters <= 0 {
+		maxIters = 5
+	}
+
+	model := chatbot.Model
+	if override, ok := chatbot.SupervisorAgentModels["web"]; ok && override != "" {
+		model = override
+	}
+
+	var finalContent string
+	for iter := 0; iter < maxIters; iter++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		req := &ChatRequest{
+			Messages:    messages,
+			Model:       model,
+			MaxTokens:   chatbot.MaxTokens,
+			Temperature: chatbot.Temperature,
+			Tools:       tools,
+			Stream:      false,
+		}
+
+		resp, err := provider.Chat(ctx, req)
+		if err != nil {
+			return fmt.Errorf("web agent: provider call failed: %w", err)
+		}
+		if resp == nil || len(resp.Choices) == 0 {
+			return fmt.Errorf("web agent: empty provider response")
+		}
+		if resp.Usage != nil {
+			state.AddUsage(*resp.Usage)
+		}
+
+		msg := resp.Choices[0].Message
+
+		// Emit pre-tool reasoning as a thought-process chunk.
+		if msg.Content != "" && a.deps.Sender != nil {
+			a.deps.Sender.SendAgentThought(ctx, a.deps.ConversationID, AgentThought{
+				Agent: "web",
+				Kind:  "reasoning",
+				Delta: msg.Content,
+			})
+		}
+
+		if len(msg.ToolCalls) == 0 {
+			finalContent = msg.Content
+			break
+		}
+
+		messages = append(messages, msg)
+		for _, tc := range msg.ToolCalls {
+			// Emit tool_call thought before executing.
+			if a.deps.Sender != nil {
+				a.deps.Sender.SendAgentThought(ctx, a.deps.ConversationID, AgentThought{
+					Agent:    "web",
+					Kind:     "tool_call",
+					ToolName: tc.Function.Name,
+					ToolArgs: json.RawMessage(tc.Function.Arguments),
+				})
+			}
+			resultStr := a.executeTool(ctx, tc, client, chatbot)
+			// Short tool_result summary in the thought stream.
+			if a.deps.Sender != nil {
+				summary := resultStr
+				if len(summary) > 200 {
+					summary = summary[:200] + "..."
+				}
+				a.deps.Sender.SendAgentThought(ctx, a.deps.ConversationID, AgentThought{
+					Agent: "web",
+					Kind:  "tool_result",
+					Delta: summary,
+				})
+			}
+			messages = append(messages, Message{
+				Role:       RoleTool,
+				Content:    resultStr,
+				ToolCallID: tc.ID,
+				Name:       tc.Function.Name,
+			})
+		}
+	}
+
+	if finalContent == "" {
+		finalContent = "I wasn't able to find current information on that. Please try rephrasing or check back later."
+	}
+
+	state.AppendAgentOutput("web", finalContent)
+	state.SetFinalResponse(finalContent)
+	return nil
+}
+
+// executeTool dispatches one tool call to the Tavily client.
+func (a *WebAgent) executeTool(ctx context.Context, tc ToolCall, client *integrations.TavilyClient, chatbot *Chatbot) string {
+	switch tc.Function.Name {
+	case "web_search":
+		return a.executeWebSearch(ctx, tc, client, chatbot)
+	case "fetch_url":
+		return a.executeFetchURL(ctx, tc, client)
+	default:
+		return fmt.Sprintf("Error: unknown tool %q", tc.Function.Name)
+	}
+}
+
+// executeWebSearch runs a single Tavily /search call.
+func (a *WebAgent) executeWebSearch(ctx context.Context, tc ToolCall, client *integrations.TavilyClient, chatbot *Chatbot) string {
+	var args struct {
+		Query          string   `json:"query"`
+		MaxResults     int      `json:"max_results,omitempty"`
+		SearchDepth    string   `json:"search_depth,omitempty"`
+		IncludeDomains []string `json:"include_domains,omitempty"`
+		ExcludeDomains []string `json:"exclude_domains,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		return fmt.Sprintf("Error: failed to parse web_search arguments: %v", err)
+	}
+	if args.Query == "" {
+		return "Error: web_search requires a non-empty 'query'"
+	}
+	if args.MaxResults <= 0 {
+		args.MaxResults = 5
+	}
+	if args.SearchDepth == "" {
+		args.SearchDepth = "basic"
+	}
+
+	// Apply chatbot-level domain allowlist if the LLM didn't pass its own.
+	// The intersection of chatbot-level + LLM-level is the strictest.
+	if len(chatbot.WebSearchDomains) > 0 && len(args.IncludeDomains) == 0 {
+		args.IncludeDomains = chatbot.WebSearchDomains
+	}
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendProgress(ctx, a.deps.ConversationID, "searching",
+			fmt.Sprintf("Searching the web: %s", args.Query))
+	}
+
+	result, err := client.Search(ctx, integrations.SearchOptions{
+		Query:          args.Query,
+		MaxResults:     args.MaxResults,
+		SearchDepth:    args.SearchDepth,
+		IncludeDomains: args.IncludeDomains,
+		ExcludeDomains: args.ExcludeDomains,
+		IncludeAnswer:  true,
+	})
+	if err != nil {
+		return fmt.Sprintf("Error running web_search: %v", err)
+	}
+
+	// Format for LLM consumption. Synthesized answer first (if present),
+	// then result list with title/url/content.
+	var sb strings.Builder
+	if result.Answer != "" {
+		fmt.Fprintf(&sb, "Tavily synthesized answer: %s\n\n", result.Answer)
+	}
+	fmt.Fprintf(&sb, "Top %d web results:\n", len(result.Results))
+	for i, r := range result.Results {
+		fmt.Fprintf(&sb, "\n%d. %s\n   URL: %s\n   %s\n",
+			i+1, r.Title, r.URL, r.Content)
+	}
+	return sb.String()
+}
+
+// executeFetchURL runs a single Tavily /extract call.
+func (a *WebAgent) executeFetchURL(ctx context.Context, tc ToolCall, client *integrations.TavilyClient) string {
+	var args struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal([]byte(tc.Function.Arguments), &args); err != nil {
+		return fmt.Sprintf("Error: failed to parse fetch_url arguments: %v", err)
+	}
+	if args.URL == "" {
+		return "Error: fetch_url requires a non-empty 'url'"
+	}
+
+	if a.deps.Sender != nil {
+		a.deps.Sender.SendProgress(ctx, a.deps.ConversationID, "fetching",
+			fmt.Sprintf("Fetching page: %s", args.URL))
+	}
+
+	result, err := client.Extract(ctx, integrations.ExtractOptions{URLs: []string{args.URL}})
+	if err != nil {
+		return fmt.Sprintf("Error running fetch_url: %v", err)
+	}
+	if len(result.Results) == 0 {
+		return "Error: Tavily returned no results for this URL"
+	}
+	r := result.Results[0]
+	if r.Failed {
+		return fmt.Sprintf("Error extracting %s: %s", r.URL, r.Error)
+	}
+	// ponytail: cap content at 8KB so we don't blow the LLM context window.
+	// Real-world pages can be 50KB+; the LLM only needs the relevant section.
+	content := r.RawContent
+	const maxLen = 8 * 1024
+	if len(content) > maxLen {
+		content = content[:maxLen] + "\n\n[... content truncated at 8KB ...]"
+	}
+	return fmt.Sprintf("URL: %s\n\n%s", r.URL, content)
+}
+
+// WebSearchTool is the function-calling tool definition for web_search.
+var WebSearchTool = Tool{
+	Type: "function",
+	Function: ToolFunction{
+		Name:        "web_search",
+		Description: "Search the web for current information using Tavily. Use for questions about recent events, current prices/hours, news, documentation, or anything that needs up-to-date info from the internet.\n\nWHEN TO USE:\n- User asks about current events, news, or anything time-sensitive\n- User asks \"what is the latest X\" or \"how do I do X today\"\n- User asks about specific websites, products, or services\n- KB doesn't have the answer and SQL data won't help\n\nWHEN NOT TO USE:\n- The user asks about historical facts that haven't changed\n- The chatbot's knowledge base already has the answer\n- The user is asking about data in the application's own database\n\nReturns: synthesized answer (when available) + top web results with title, URL, and content snippet.",
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"query": map[string]interface{}{
+					"type":        "string",
+					"description": "The search query. Be specific — include relevant keywords, dates, or names.",
+				},
+				"max_results": map[string]interface{}{
+					"type":        "integer",
+					"description": "Maximum results to return (default 5, max 10).",
+				},
+				"search_depth": map[string]interface{}{
+					"type":        "string",
+					"description": `"basic" (default, faster) or "advanced" (slower, more thorough). Use "advanced" for complex research questions.`,
+				},
+			},
+			"required": []string{"query"},
+		},
+	},
+}
+
+// FetchURLTool is the function-calling tool definition for fetch_url.
+var FetchURLTool = Tool{
+	Type: "function",
+	Function: ToolFunction{
+		Name:        "fetch_url",
+		Description: "Fetch the full content of a specific URL as clean markdown. Use after web_search when the top result needs more detail to answer the user's question.\n\nWHEN TO USE:\n- web_search returned a promising URL but the snippet is too short\n- User provided a specific URL directly\n- You need exact content from a page (e.g., current hours, menu, prices)\n\nReturns: the page's content as markdown (capped at 8KB to fit context window).",
+		Parameters: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"url": map[string]interface{}{
+					"type":        "string",
+					"description": "The fully-qualified URL to fetch (e.g., https://example.com/page).",
+				},
+			},
+			"required": []string{"url"},
+		},
+	},
+}

--- a/internal/ai/agent_web_test.go
+++ b/internal/ai/agent_web_test.go
@@ -1,0 +1,134 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nimbleflux/fluxbase/internal/ai/integrations"
+)
+
+// TestWebAgent_NilIntegrations_ReturnsErrorNotPanic verifies the Web
+// Agent's nil-safe contract: when no integrations storage is wired into
+// AgentDeps, the agent returns a clean error instead of panicking. This
+// is the Layer 2 recovery guarantee from PR #252 — panics in any
+// specialist get surfaced as errors instead of crashing the server.
+//
+// (Real Tavily HTTP behavior is covered by tavily_test.go.)
+func TestWebAgent_NilIntegrations_ReturnsErrorNotPanic(t *testing.T) {
+	provider := newFakeProvider("test")
+	provider.QueueResponse(newSimpleResponse("answer"))
+
+	sender := newCaptureSender()
+	chatbot := &Chatbot{
+		Name:             "test",
+		Model:            "gpt-4",
+		WebSearchEnabled: true,
+	}
+	deps := &AgentDeps{
+		Chatbot:  chatbot,
+		Provider: provider,
+		Sender:   sender,
+		// Integrations intentionally nil
+	}
+
+	agent := NewWebAgent(deps)
+	state := NewState()
+	state.SetUserMessage("what's the latest?")
+	err := agent.Run(context.Background(), state)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no integrations storage")
+}
+
+// TestSupervisorRoute_ExcludesWeb_WhenChatbotOptsOut verifies the
+// supervisor graph silently excludes the Web Agent when the chatbot
+// doesn't have @fluxbase:web-search enabled. This is the core opt-in
+// contract — no integration = no Web Agent in the route.
+func TestSupervisorRoute_ExcludesWeb_WhenChatbotOptsOut(t *testing.T) {
+	// Build a supervisor graph with WebSearchEnabled=false. Verify the
+	// router's agent map doesn't include "web".
+	chatbot := &Chatbot{
+		Name:             "test",
+		Model:            "gpt-4",
+		ReasoningMode:    "supervisor",
+		WebSearchEnabled: false,
+	}
+	deps := &AgentDeps{Chatbot: chatbot}
+
+	graph := NewSupervisorGraph(deps)
+	router, ok := graph.graph.nodes["router"].(*routerNode)
+	require.True(t, ok, "router must be registered")
+	_, hasWeb := router.agents["web"]
+	assert.False(t, hasWeb, "Web Agent must NOT be registered when chatbot has WebSearchEnabled=false")
+}
+
+// TestSupervisorRoute_IncludesWeb_WhenChatbotOptsIn_AndIntegrationsConfigured
+// is the symmetric test: when both annotations are set, the Web Agent IS
+// registered. We use a fakeIntegrationStorage as the Integrations dep
+// (it's nil here — the test asserts that the chatbot flag is the gate,
+// not the storage existence; storage gets checked at agent.Run time).
+func TestSupervisorRoute_IncludesWeb_WhenChatbotOptsIn_AndIntegrationsConfigured(t *testing.T) {
+	chatbot := &Chatbot{
+		Name:             "test",
+		Model:            "gpt-4",
+		ReasoningMode:    "supervisor",
+		WebSearchEnabled: true,
+	}
+	// Integrations is nil but WebSearchEnabled is true. The supervisor
+	// graph should still register "web" — the existence check happens at
+	// Run time when the agent tries to resolve credentials. This is the
+	// right behavior: a chatbot with @fluxbase:web-search enabled=true
+	// should still build the agent, even if no integration is configured
+	// yet; the error at Run time tells the user to configure one.
+	deps := &AgentDeps{
+		Chatbot:      chatbot,
+		Integrations: &integrations.Storage{}, // non-nil placeholder; never called in this test
+	}
+	graph := NewSupervisorGraph(deps)
+	router, ok := graph.graph.nodes["router"].(*routerNode)
+	require.True(t, ok)
+	_, hasWeb := router.agents["web"]
+	assert.True(t, hasWeb, "Web Agent must be registered when chatbot has WebSearchEnabled=true and Integrations is non-nil")
+}
+
+// TestParseSupervisorPlan_AcceptsWebAgent verifies the supervisor's
+// JSON plan parser accepts "web" as a valid routing target. Without this,
+// the supervisor would error out when the LLM routes to web.
+func TestParseSupervisorPlan_AcceptsWebAgent(t *testing.T) {
+	plan, err := parseSupervisorPlan(`{"user_language":"English","route":["web"]}`)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	assert.Equal(t, []string{"web"}, plan.Route)
+}
+
+// TestParseSupervisorPlan_RejectsUnknownAgent_StillEnforced verifies
+// the parser still rejects unknown agent names — adding "web" didn't
+// loosen validation.
+func TestParseSupervisorPlan_RejectsUnknownAgent_StillEnforced(t *testing.T) {
+	_, err := parseSupervisorPlan(`{"user_language":"English","route":["nonsense"]}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown agent")
+}
+
+// TestWebAgent_ExecuteWebSearch_ParsesArguments is a focused unit test
+// on the argument parsing path. Verifies the LLM's JSON arguments are
+// correctly decoded into a Tavily SearchOptions.
+func TestWebAgent_ExecuteWebSearch_ParsesArguments(t *testing.T) {
+	// We can't easily call executeWebSearch in isolation (it needs a
+	// *TavilyClient). Instead verify the args struct shape via JSON
+	// round-trip — that's what executeWebSearch relies on.
+	argsJSON := `{"query":"Berlin zoo","max_results":3,"search_depth":"advanced"}`
+	var args struct {
+		Query       string `json:"query"`
+		MaxResults  int    `json:"max_results,omitempty"`
+		SearchDepth string `json:"search_depth,omitempty"`
+	}
+	err := json.Unmarshal([]byte(argsJSON), &args)
+	require.NoError(t, err)
+	assert.Equal(t, "Berlin zoo", args.Query)
+	assert.Equal(t, 3, args.MaxResults)
+	assert.Equal(t, "advanced", args.SearchDepth)
+}

--- a/internal/ai/chat_handler.go
+++ b/internal/ai/chat_handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
+	"github.com/nimbleflux/fluxbase/internal/ai/integrations"
 	"github.com/nimbleflux/fluxbase/internal/auth"
 	"github.com/nimbleflux/fluxbase/internal/config"
 	"github.com/nimbleflux/fluxbase/internal/database"
@@ -36,6 +37,10 @@ type ChatHandler struct {
 	limiter        *ChatbotLimiter
 	// MCP integration
 	mcpExecutor *MCPToolExecutor
+	// Tool integrations (Web Agent). nil when AI is disabled or no
+	// integrations are configured — the supervisor silently excludes
+	// "web" from the route in that case.
+	integrationsStorage *integrations.Storage
 }
 
 // NewChatHandler creates a new chat handler
@@ -76,6 +81,14 @@ func NewChatHandler(
 // SetSettingsResolver sets the settings resolver for template variable resolution in system prompts
 func (h *ChatHandler) SetSettingsResolver(resolver *SettingsResolver) {
 	h.schemaBuilder.SetSettingsResolver(resolver)
+}
+
+// SetIntegrationsStorage wires the tool integrations storage (Tavily,
+// future Brave/Jina) into the chat handler. The supervisor's Web Agent
+// reads from this to resolve credentials at turn start. nil-safe — when
+// never called, the Web Agent is silently excluded from routes.
+func (h *ChatHandler) SetIntegrationsStorage(s *integrations.Storage) {
+	h.integrationsStorage = s
 }
 
 // SetMCPToolRegistry sets the MCP tool registry for MCP-enabled chatbots

--- a/internal/ai/chat_handler_supervisor.go
+++ b/internal/ai/chat_handler_supervisor.go
@@ -70,6 +70,7 @@ func (h *ChatHandler) runSupervisorTurn(ctx context.Context, chatCtx *ChatContex
 		SchemaBuilder:  h.schemaBuilder,
 		RAGService:     h.ragService,
 		MCPExecutor:    h.mcpExecutor,
+		Integrations:   h.integrationsStorage,
 		ChatCtx:        chatCtx,
 		ConversationID: msg.ConversationID,
 		Sender: &chatHandlerSender{

--- a/internal/ai/chatbot.go
+++ b/internal/ai/chatbot.go
@@ -96,9 +96,16 @@ type Chatbot struct {
 	PageProfiles      PageProfiles `json:"page_profiles,omitempty"`       // Per-page routing/config overrides (Level 2 page-aware chatbots)
 	// SupervisorAgentModels optionally overrides the model used per specialist
 	// agent in supervisor mode. Keys are agent names: "supervisor", "sql",
-	// "kb", "action", "chat", "synthesizer", "verifier". Missing keys fall
+	// "kb", "action", "chat", "verifier". Missing keys fall
 	// back to the chatbot's main Model.
 	SupervisorAgentModels map[string]string `json:"supervisor_agent_models,omitempty"`
+
+	// WebSearchEnabled turns on the Web Agent specialist. Requires a
+	// configured Tavily integration at the tenant/instance level.
+	WebSearchEnabled bool `json:"web_search_enabled,omitempty"`
+	// WebSearchDomains optionally restricts the Web Agent to results from
+	// these domains only. Empty = no restriction.
+	WebSearchDomains []string `json:"web_search_domains,omitempty"`
 
 	Version   int       `json:"version"`
 	Source    string    `json:"source"` // "filesystem" or "api"
@@ -168,6 +175,12 @@ type ChatbotConfig struct {
 	ShowReasoning         bool              // If true, expose agent reasoning to users
 	PageProfiles          PageProfiles      // Per-page routing/config overrides
 	SupervisorAgentModels map[string]string // Optional per-agent model overrides in supervisor mode
+
+	// Web Search (Web Agent specialist). Off by default. When enabled
+	// and a Tavily integration exists at the tenant/instance level, the
+	// supervisor routes current-info questions to the Web Agent.
+	WebSearchEnabled bool     // parsed from @fluxbase:web-search
+	WebSearchDomains []string // parsed from @fluxbase:web-search-domains (optional allowlist)
 
 	// Metadata
 	Version int
@@ -322,6 +335,17 @@ var (
 
 	// @fluxbase:show-reasoning true
 	showReasoningPattern = regexp.MustCompile(`@fluxbase:show-reasoning\s+(true|false)`)
+
+	// @fluxbase:web-search enabled=true
+	// Enables the Web Agent specialist for this chatbot. The supervisor
+	// will route current-info questions to it when a Tavily integration
+	// is configured at the tenant/instance level.
+	webSearchPattern = regexp.MustCompile(`@fluxbase:web-search\s+(enabled|disabled|true|false)`)
+
+	// @fluxbase:web-search-domains wikipedia.org,mdn.dev
+	// Optional allowlist for web search results. Domains not in this list
+	// are filtered out by the Web Agent before passing results to the LLM.
+	webSearchDomainsPattern = regexp.MustCompile(`@fluxbase:web-search-domains\s+(.+)`)
 )
 
 // ParseChatbotConfig parses chatbot configuration from TypeScript source code
@@ -594,6 +618,33 @@ func ParseChatbotConfig(code string) ChatbotConfig {
 		config.ShowReasoning = matches[1] == "true"
 	}
 
+	// Parse web-search enable/disable.
+	// Accepted forms: enabled, disabled, true, false. Default is disabled
+	// (annotation absent). This is opt-in per chatbot to avoid surprise
+	// Tavily API charges.
+	if matches := webSearchPattern.FindStringSubmatch(code); len(matches) > 1 {
+		v := strings.ToLower(matches[1])
+		config.WebSearchEnabled = v == "enabled" || v == "true"
+	}
+
+	// Parse optional web-search domain allowlist. Comma-separated. Empty
+	// when annotation absent (no restriction). Scheme prefixes are stripped
+	// (https://, http://) so users can paste URLs verbatim.
+	if matches := webSearchDomainsPattern.FindStringSubmatch(code); len(matches) > 1 {
+		raw := strings.TrimSpace(matches[1])
+		if raw != "" {
+			for _, d := range strings.Split(raw, ",") {
+				d = strings.TrimSpace(d)
+				d = strings.TrimPrefix(d, "https://")
+				d = strings.TrimPrefix(d, "http://")
+				d = strings.TrimSpace(d)
+				if d != "" {
+					config.WebSearchDomains = append(config.WebSearchDomains, d)
+				}
+			}
+		}
+	}
+
 	return config
 }
 
@@ -746,6 +797,8 @@ func (c *Chatbot) ApplyConfig(config ChatbotConfig) {
 	c.ShowReasoning = config.ShowReasoning
 	c.PageProfiles = config.PageProfiles
 	c.SupervisorAgentModels = config.SupervisorAgentModels
+	c.WebSearchEnabled = config.WebSearchEnabled
+	c.WebSearchDomains = config.WebSearchDomains
 
 	// Only override version if explicitly set in annotation
 	if config.Version > 0 {
@@ -854,6 +907,26 @@ func (c *Chatbot) PopulateDerivedFields() {
 				}
 				if len(merged) > 0 {
 					c.SupervisorAgentModels = merged
+				}
+			}
+
+			// Web-search enable + optional domain allowlist (no DB column)
+			if matches := webSearchPattern.FindStringSubmatch(c.Code); len(matches) > 1 {
+				v := strings.ToLower(matches[1])
+				c.WebSearchEnabled = v == "enabled" || v == "true"
+			}
+			if matches := webSearchDomainsPattern.FindStringSubmatch(c.Code); len(matches) > 1 {
+				raw := strings.TrimSpace(matches[1])
+				if raw != "" {
+					for _, d := range strings.Split(raw, ",") {
+						d = strings.TrimSpace(d)
+						d = strings.TrimPrefix(d, "https://")
+						d = strings.TrimPrefix(d, "http://")
+						d = strings.TrimSpace(d)
+						if d != "" {
+							c.WebSearchDomains = append(c.WebSearchDomains, d)
+						}
+					}
 				}
 			}
 		}

--- a/internal/ai/integrations/crypto.go
+++ b/internal/ai/integrations/crypto.go
@@ -1,0 +1,98 @@
+package integrations
+
+import (
+	"fmt"
+
+	"github.com/nimbleflux/fluxbase/internal/crypto"
+)
+
+// SecretPrefix tags encrypted values so read paths can distinguish them
+// from legacy plaintext. Lazy migration: read paths try decrypt if the
+// prefix is present, treat as plaintext otherwise. Write paths always
+// encrypt.
+//
+// Without the prefix we couldn't tell a real API key from an encrypted
+// blob — both look like base64-ish strings. The prefix makes the
+// detection deterministic.
+const SecretPrefix = "enc:"
+
+// MaskPlaceholder is what API responses return in place of the real
+// secret value. Updates that receive this placeholder preserve the
+// existing encrypted value rather than overwriting it with the literal
+// string.
+const MaskPlaceholder = "***masked***"
+
+// EncryptSecret encrypts plaintext with the master key and tags it
+// with SecretPrefix so future reads know to decrypt. Returns "" for ""
+// (preserves the "empty means empty" invariant — never encrypts nil).
+// Returns plaintext unchanged if key is empty (encryption not configured).
+func EncryptSecret(plaintext string, key []byte) (string, error) {
+	if plaintext == "" {
+		return "", nil
+	}
+	if len(key) == 0 {
+		// Encryption not configured — preserve old behavior. Log site is
+		// the caller's responsibility; we don't log here to avoid noise
+		// on every secret write.
+		return plaintext, nil
+	}
+	if len(key) != 32 {
+		return "", fmt.Errorf("EncryptSecret: key must be 32 bytes for AES-256, got %d", len(key))
+	}
+	ciphertext, err := crypto.Encrypt(plaintext, string(key))
+	if err != nil {
+		return "", fmt.Errorf("EncryptSecret: %w", err)
+	}
+	return SecretPrefix + ciphertext, nil
+}
+
+// DecryptIfEncrypted returns the plaintext for a value tagged with
+// SecretPrefix. Values without the prefix are returned unchanged —
+// this is the forward-compatible path that lets us read plaintext
+// rows written before encryption shipped (lazy migration).
+//
+// On decryption failure (wrong key, corrupted ciphertext), returns
+// the original value unchanged with the error. Callers decide whether
+// to fail loudly or fall through; the default is fall through so a
+// bad key doesn't lock users out of every integration at once.
+func DecryptIfEncrypted(value string, key []byte) (string, error) {
+	if value == "" || len(key) == 0 {
+		return value, nil
+	}
+	if !IsEncrypted(value) {
+		// Plaintext (pre-migration) — return as-is. Next write will encrypt.
+		return value, nil
+	}
+	inner := value[len(SecretPrefix):]
+	plaintext, err := crypto.Decrypt(inner, string(key))
+	if err != nil {
+		// ponytail: return original on failure rather than empty string.
+		// Returning empty would silently corrupt the integration; the
+		// caller can detect the error and surface it.
+		return value, fmt.Errorf("DecryptIfEncrypted: %w", err)
+	}
+	return plaintext, nil
+}
+
+// IsEncrypted reports whether value carries the SecretPrefix tag.
+// Used by read paths to decide whether to attempt decryption.
+func IsEncrypted(value string) bool {
+	return len(value) >= len(SecretPrefix) && value[:len(SecretPrefix)] == SecretPrefix
+}
+
+// IsMasked reports whether value is the API-response mask placeholder.
+// Used by update handlers to detect "user didn't change the key" and
+// preserve the existing encrypted value.
+func IsMasked(value string) bool {
+	return value == MaskPlaceholder
+}
+
+// MaskSecret returns the API-response placeholder for any secret.
+// Empty input returns empty (so we don't leak "there used to be a key here"
+// in responses for integrations that don't have one configured).
+func MaskSecret(value string) string {
+	if value == "" {
+		return ""
+	}
+	return MaskPlaceholder
+}

--- a/internal/ai/integrations/crypto_test.go
+++ b/internal/ai/integrations/crypto_test.go
@@ -1,0 +1,90 @@
+package integrations
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// randomKey generates a 32-byte key for tests (AES-256 size requirement).
+func randomKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	require.NoError(t, err)
+	return key
+}
+
+func TestEncryptSecret_RoundTrip(t *testing.T) {
+	key := randomKey(t)
+	plaintext := "tvly-abc123secret"
+
+	enc, err := EncryptSecret(plaintext, key)
+	require.NoError(t, err)
+	assert.NotEqual(t, plaintext, enc, "ciphertext must differ from plaintext")
+	assert.True(t, IsEncrypted(enc), "ciphertext must carry the enc: prefix")
+
+	dec, err := DecryptIfEncrypted(enc, key)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, dec, "decrypted value must match input")
+}
+
+func TestEncryptSecret_EmptyValue_PassesThrough(t *testing.T) {
+	key := randomKey(t)
+	enc, err := EncryptSecret("", key)
+	require.NoError(t, err)
+	assert.Equal(t, "", enc, "empty input must not be encrypted")
+}
+
+func TestEncryptSecret_NoKey_ReturnsPlaintext(t *testing.T) {
+	enc, err := EncryptSecret("plaintext", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "plaintext", enc, "nil key means encryption disabled; return plaintext unchanged")
+}
+
+func TestEncryptSecret_BadKeyLength_ReturnsError(t *testing.T) {
+	_, err := EncryptSecret("plaintext", []byte("too-short"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "32 bytes")
+}
+
+func TestDecryptIfEncrypted_PlaintextPassesThrough(t *testing.T) {
+	key := randomKey(t)
+	out, err := DecryptIfEncrypted("tvly-plaintext-key", key)
+	require.NoError(t, err)
+	assert.Equal(t, "tvly-plaintext-key", out, "values without enc: prefix must pass through unchanged — lazy migration path")
+}
+
+func TestDecryptIfEncrypted_EmptyValue(t *testing.T) {
+	out, err := DecryptIfEncrypted("", randomKey(t))
+	require.NoError(t, err)
+	assert.Equal(t, "", out)
+}
+
+func TestDecryptIfEncrypted_NilKey_ReturnsValue(t *testing.T) {
+	enc, _ := EncryptSecret("secret", randomKey(t))
+	out, err := DecryptIfEncrypted(enc, nil)
+	require.NoError(t, err)
+	assert.Equal(t, enc, out, "nil key = encryption disabled; return value unchanged")
+}
+
+func TestIsEncrypted(t *testing.T) {
+	assert.True(t, IsEncrypted("enc:abc123"))
+	assert.True(t, IsEncrypted("enc:"))
+	assert.False(t, IsEncrypted("tvly-abc123"))
+	assert.False(t, IsEncrypted(""))
+	assert.False(t, IsEncrypted("en")) // too short
+}
+
+func TestMaskSecret(t *testing.T) {
+	assert.Equal(t, MaskPlaceholder, MaskSecret("anything"))
+	assert.Equal(t, "", MaskSecret(""), "empty input must not surface a mask — preserves 'no key configured' semantics")
+}
+
+func TestIsMasked(t *testing.T) {
+	assert.True(t, IsMasked(MaskPlaceholder))
+	assert.False(t, IsMasked("tvly-real-key"))
+	assert.False(t, IsMasked(""))
+}

--- a/internal/ai/integrations/env_config.go
+++ b/internal/ai/integrations/env_config.go
@@ -1,0 +1,75 @@
+package integrations
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EnvConfig holds Tavily/websearch credentials loaded from YAML or env
+// vars. When populated, the integrations storage injects a synthetic
+// FROM_CONFIG row (read-only) so instance-level deployments work the
+// same as multi-tenant dashboard deployments.
+//
+// Mirrors the pattern in internal/ai/provider_storage.go:buildConfigBasedProvider.
+type EnvConfig struct {
+	// TavilyAPIKey enables websearch via Tavily. When non-empty, a
+	// synthetic web_search integration row is exposed.
+	TavilyAPIKey string
+
+	// TavilyDefaultDepth is the default search depth: "basic" or
+	// "advanced". Empty defaults to "basic" at the client layer.
+	TavilyDefaultDepth string
+
+	// TavilyBaseURL overrides the Tavily API endpoint (rare; mostly for
+	// self-hosted mirrors or testing).
+	TavilyBaseURL string
+}
+
+// HasIntegration reports whether env/YAML config provides an integration
+// of the given type. Currently only web_search is configurable via env.
+func (c *EnvConfig) HasIntegration(t IntegrationType) bool {
+	if c == nil {
+		return false
+	}
+	switch t {
+	case IntegrationTypeWebSearch:
+		return c.TavilyAPIKey != ""
+	case IntegrationTypeFetchURL:
+		// fetch_url is always auto-derived from web_search
+		return c.TavilyAPIKey != ""
+	}
+	return false
+}
+
+// ToIntegration returns the synthetic FROM_CONFIG row for the given
+// integration type, or nil if env config doesn't provide one.
+//
+// The returned row has a stable ID ("FROM_CONFIG") and ReadOnly=true
+// so the API/UI can display it but refuse mutations.
+func (c *EnvConfig) ToIntegration(t IntegrationType) *Integration {
+	if c == nil || !c.HasIntegration(t) {
+		return nil
+	}
+	now := time.Now()
+	return &Integration{
+		ID:              "FROM_CONFIG",
+		Name:            "config",
+		IntegrationType: t,
+		Provider:        ProviderTavily,
+		Enabled:         true,
+		IsDefault:       true,
+		FromConfig:      true,
+		ReadOnly:        true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		Config: map[string]string{
+			"api_key": c.TavilyAPIKey,
+		},
+	}
+}
+
+// compileTimeUUIDImport keeps the uuid import non-empty for the
+// ToIntegration helper above (used in case future revisions return
+// uuid-based IDs). Remove when stable.
+var _ = uuid.New

--- a/internal/ai/integrations/handler.go
+++ b/internal/ai/integrations/handler.go
@@ -1,0 +1,289 @@
+// Package integrations provides storage and configuration for non-LLM
+// tool integrations (web search, URL fetch, etc.) consumed by chatbot
+// specialist agents.
+//
+// Handler.go exposes the REST API surface. Routes mirror the AI provider
+// CRUD: list/get/create/update/delete + set-default + test.
+package integrations
+
+import (
+	"context"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/rs/zerolog/log"
+
+	"github.com/nimbleflux/fluxbase/internal/database"
+	"github.com/nimbleflux/fluxbase/internal/middleware"
+)
+
+// Handler exposes the integrations REST API. Mirrors the shape of
+// internal/ai/handler.go's provider CRUD: stateless handlers that read
+// tenant from request context and delegate to Storage.
+type Handler struct {
+	storage *Storage
+}
+
+// NewHandler constructs a Handler bound to the given storage.
+func NewHandler(storage *Storage) *Handler {
+	return &Handler{storage: storage}
+}
+
+// Storage returns the handler's underlying storage. Exposed so the
+// supervisor / Web Agent can resolve integrations from the same instance
+// the API uses.
+func (h *Handler) Storage() *Storage { return h.storage }
+
+// ListIntegrations handles GET /api/v1/admin/ai/integrations.
+// Optional query param `?type=web_search` filters by integration_type.
+func (h *Handler) ListIntegrations(c fiber.Ctx) error {
+	ctx := middleware.CtxWithTenant(c)
+
+	var integrationType *IntegrationType
+	if t := c.Query("type"); t != "" {
+		if !IsValidIntegrationType(t) {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "Invalid integration_type: " + t,
+			})
+		}
+		it := IntegrationType(t)
+		integrationType = &it
+	}
+
+	integrations, err := h.storage.ListIntegrations(ctx, integrationType)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to list integrations")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to list integrations",
+		})
+	}
+
+	// Mask secrets in responses
+	out := make([]map[string]any, 0, len(integrations))
+	for _, i := range integrations {
+		out = append(out, integrationToAPIResponse(i))
+	}
+	return c.JSON(fiber.Map{
+		"integrations": out,
+		"count":        len(out),
+	})
+}
+
+// GetIntegration handles GET /api/v1/admin/ai/integrations/:id.
+func (h *Handler) GetIntegration(c fiber.Ctx) error {
+	ctx := middleware.CtxWithTenant(c)
+	id := c.Params("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "id is required"})
+	}
+
+	i, err := h.storage.GetIntegration(ctx, id)
+	if err != nil {
+		log.Error().Err(err).Str("id", id).Msg("Failed to get integration")
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Failed to get integration",
+		})
+	}
+	if i == nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Integration not found",
+		})
+	}
+	return c.JSON(integrationToAPIResponse(i))
+}
+
+// CreateIntegration handles POST /api/v1/admin/ai/integrations.
+func (h *Handler) CreateIntegration(c fiber.Ctx) error {
+	ctx := middleware.CtxWithTenant(c)
+	tenantID := database.TenantFromContext(ctx)
+
+	var req CreateIntegrationRequest
+	if err := c.Bind().Body(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	created, err := h.storage.CreateIntegration(ctx, tenantID, &req)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+	return c.Status(fiber.StatusCreated).JSON(integrationToAPIResponse(created))
+}
+
+// UpdateIntegration handles PUT /api/v1/admin/ai/integrations/:id.
+func (h *Handler) UpdateIntegration(c fiber.Ctx) error {
+	ctx := middleware.CtxWithTenant(c)
+	tenantID := database.TenantFromContext(ctx)
+	id := c.Params("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "id is required"})
+	}
+
+	var req UpdateIntegrationRequest
+	if err := c.Bind().Body(&req); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Invalid request body",
+		})
+	}
+
+	updated, err := h.storage.UpdateIntegration(ctx, tenantID, id, &req)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+	return c.JSON(integrationToAPIResponse(updated))
+}
+
+// DeleteIntegration handles DELETE /api/v1/admin/ai/integrations/:id.
+func (h *Handler) DeleteIntegration(c fiber.Ctx) error {
+	ctx := middleware.CtxWithTenant(c)
+	tenantID := database.TenantFromContext(ctx)
+	id := c.Params("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "id is required"})
+	}
+
+	if err := h.storage.DeleteIntegration(ctx, tenantID, id); err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// SetDefaultIntegration handles PUT /api/v1/admin/ai/integrations/:id/default.
+// Marks the integration as the default for its integration_type within
+// the current tenant. The storage layer clears any prior default inside
+// the same UPDATE transaction.
+func (h *Handler) SetDefaultIntegration(c fiber.Ctx) error {
+	ctx := middleware.CtxWithTenant(c)
+	tenantID := database.TenantFromContext(ctx)
+	id := c.Params("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "id is required"})
+	}
+
+	trueVal := true
+	_, err := h.storage.UpdateIntegration(ctx, tenantID, id, &UpdateIntegrationRequest{
+		IsDefault: &trueVal,
+	})
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": err.Error(),
+		})
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// TestIntegration handles POST /api/v1/admin/ai/integrations/:id/test.
+// Runs a "hello world" call against the integration's provider and stores
+// the result. Used by the admin UI's Test button to surface health info.
+func (h *Handler) TestIntegration(c fiber.Ctx) error {
+	ctx := middleware.CtxWithTenant(c)
+	tenantID := database.TenantFromContext(ctx)
+	id := c.Params("id")
+	if id == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "id is required"})
+	}
+
+	i, err := h.storage.GetIntegration(ctx, id)
+	if err != nil || i == nil {
+		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{
+			"error": "Integration not found",
+		})
+	}
+
+	status, errMsg := testIntegration(ctx, i)
+	_ = h.storage.UpdateTestStatus(ctx, tenantID, id, status, errMsg)
+
+	resp := fiber.Map{
+		"status":         status,
+		"last_tested_at": time.Now().UTC().Format(time.RFC3339),
+	}
+	if errMsg != "" {
+		resp["error"] = errMsg
+	}
+	return c.JSON(resp)
+}
+
+// testIntegration runs a real provider call to verify credentials.
+// Returns ("ok", "") on success or ("failed", "error message") on failure.
+// Times out after 30 seconds via the request context.
+func testIntegration(ctx context.Context, i *Integration) (status, errMsg string) {
+	switch i.Provider {
+	case ProviderTavily:
+		client := NewTavilyClient(i.Config["api_key"], i.Config["base_url"], nil)
+		if err := client.Ping(ctx); err != nil {
+			return "failed", err.Error()
+		}
+		return "ok", ""
+	case ProviderBrave, ProviderJina, ProviderSingleFetch:
+		// Not implemented yet; surface a clear message rather than failing
+		// silently. Schema allows these providers so future PRs can add
+		// implementations without a migration.
+		return "failed", "Provider " + string(i.Provider) + " is not yet implemented"
+	default:
+		return "failed", "Unknown provider: " + string(i.Provider)
+	}
+}
+
+// integrationToAPIResponse converts an Integration to the JSON shape
+// returned by the API. Secrets in Config are masked to "***masked***";
+// the read_only + from_config flags surface whether the row came from
+// env/YAML config.
+func integrationToAPIResponse(i *Integration) map[string]any {
+	if i == nil {
+		return nil
+	}
+	// Clone config and mask secrets
+	configOut := map[string]string{}
+	for k, v := range i.Config {
+		if isSecretField(k) {
+			configOut[k] = MaskSecret(v)
+		} else {
+			configOut[k] = v
+		}
+	}
+
+	resp := map[string]any{
+		"id":               i.ID,
+		"name":             i.Name,
+		"integration_type": string(i.IntegrationType),
+		"provider":         string(i.Provider),
+		"config":           configOut,
+		"enabled":          i.Enabled,
+		"is_default":       i.IsDefault,
+		"created_at":       i.CreatedAt.UTC().Format(time.RFC3339),
+		"updated_at":       i.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+	if i.FromConfig {
+		resp["from_config"] = true
+	}
+	if i.ReadOnly {
+		resp["read_only"] = true
+	}
+	if i.LastTestedAt != nil {
+		resp["last_tested_at"] = i.LastTestedAt.UTC().Format(time.RFC3339)
+	}
+	if i.LastTestStatus != "" {
+		resp["last_test_status"] = i.LastTestStatus
+	}
+	if i.LastTestError != "" {
+		resp["last_test_error"] = i.LastTestError
+	}
+	if i.CreatedBy != "" {
+		resp["created_by"] = i.CreatedBy
+	}
+	return resp
+}
+
+// isSecretField reports whether the given config key holds a sensitive
+// value that should be masked in API responses. Currently just api_key;
+// extend when providers add additional secret fields.
+func isSecretField(k string) bool {
+	return k == "api_key"
+}

--- a/internal/ai/integrations/storage.go
+++ b/internal/ai/integrations/storage.go
@@ -1,0 +1,630 @@
+// Package integrations provides storage and configuration for non-LLM
+// tool integrations (web search, URL fetch, etc.) that chatbot
+// specialist agents can call.
+//
+// Storage shape mirrors ai.providers: rows are tenant-scoped, secrets in
+// the config JSONB are encrypted at the application layer (see crypto.go),
+// and a synthetic FROM_CONFIG row is injected when env/YAML config is set
+// so instance-level deployments work the same as multi-tenant dashboard
+// deployments.
+package integrations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog/log"
+
+	"github.com/nimbleflux/fluxbase/internal/database"
+)
+
+// IntegrationType categorizes what kind of tool the integration provides.
+// Stored in `tool_integrations.integration_type` (CHECK constraint).
+type IntegrationType string
+
+const (
+	IntegrationTypeWebSearch IntegrationType = "web_search"
+	IntegrationTypeFetchURL  IntegrationType = "fetch_url"
+)
+
+// ProviderName identifies the specific service within an integration type.
+// E.g., for web_search: tavily, brave, jina. Stored in
+// `tool_integrations.provider` (CHECK constraint).
+type ProviderName string
+
+const (
+	ProviderTavily      ProviderName = "tavily"
+	ProviderBrave       ProviderName = "brave"
+	ProviderJina        ProviderName = "jina"
+	ProviderSingleFetch ProviderName = "singlefetch"
+)
+
+// AllIntegrationTypes is the closed set of valid integration_type values.
+// Used by the API layer for validation.
+var AllIntegrationTypes = []IntegrationType{
+	IntegrationTypeWebSearch,
+	IntegrationTypeFetchURL,
+}
+
+// AllProviders is the closed set of valid provider values.
+var AllProviders = []ProviderName{
+	ProviderTavily,
+	ProviderBrave,
+	ProviderJina,
+	ProviderSingleFetch,
+}
+
+// IsValidIntegrationType reports whether v is in AllIntegrationTypes.
+func IsValidIntegrationType(v string) bool {
+	for _, t := range AllIntegrationTypes {
+		if string(t) == v {
+			return true
+		}
+	}
+	return false
+}
+
+// IsValidProvider reports whether v is in AllProviders.
+func IsValidProvider(v string) bool {
+	for _, p := range AllProviders {
+		if string(p) == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Integration is the in-memory representation of a tool_integrations row.
+// Config holds provider-specific fields. Secret fields (api_key, etc.) are
+// encrypted at rest and masked in API responses; consumers receive the
+// decrypted value via ResolveConfig.
+type Integration struct {
+	ID              string            `json:"id"`
+	Name            string            `json:"name"`
+	IntegrationType IntegrationType   `json:"integration_type"`
+	Provider        ProviderName      `json:"provider"`
+	Config          map[string]string `json:"config"`
+	Enabled         bool              `json:"enabled"`
+	IsDefault       bool              `json:"is_default"`
+	LastTestedAt    *time.Time        `json:"last_tested_at,omitempty"`
+	LastTestStatus  string            `json:"last_test_status,omitempty"`
+	LastTestError   string            `json:"last_test_error,omitempty"`
+	CreatedAt       time.Time         `json:"created_at"`
+	UpdatedAt       time.Time         `json:"updated_at"`
+	CreatedBy       string            `json:"created_by,omitempty"`
+
+	// FromConfig marks the synthetic row injected when env/YAML config is
+	// set. Read-only in the API/UI. Empty (false) for DB-stored rows.
+	FromConfig bool   `json:"from_config,omitempty"`
+	ReadOnly   bool   `json:"read_only,omitempty"`
+	TenantID   string `json:"tenant_id,omitempty"`
+}
+
+// SecretFields returns the config keys that hold sensitive values for
+// this integration. These fields are encrypted at write time, decrypted
+// on internal reads, and masked on API responses.
+//
+// Per-integration-type secret lists (currently just api_key for
+// everything). Extend here when a new provider has additional secret
+// fields (e.g., oauth_refresh_token).
+func (i *Integration) SecretFields() []string {
+	return []string{"api_key"}
+}
+
+// Storage is the data-access layer for tool_integrations. Mirrors the
+// shape of ai.provider_storage.go: tenant-aware CRUD + a synthetic
+// FROM_CONFIG row when env/YAML is set.
+type Storage struct {
+	database.TenantAware
+	encryptionKey []byte
+	config        *EnvConfig // env/YAML config; nil when not set
+}
+
+// NewStorage constructs a new Storage. encryptionKey is the master key
+// from cfg.EncryptionKeyBytes; may be nil when encryption is not
+// configured (secrets stored plaintext in that case — logged at call
+// sites, matches existing AI provider behavior).
+func NewStorage(db *database.Connection, encryptionKey []byte, envConfig *EnvConfig) *Storage {
+	return &Storage{
+		TenantAware:   database.TenantAware{DB: db},
+		encryptionKey: encryptionKey,
+		config:        envConfig,
+	}
+}
+
+// SetEnvConfig replaces the env/YAML config at runtime. Used by hot-reload
+// paths when settings change.
+func (s *Storage) SetEnvConfig(cfg *EnvConfig) {
+	s.config = cfg
+}
+
+// EnvConfig returns the current env/YAML config (may be nil).
+func (s *Storage) EnvConfig() *EnvConfig {
+	return s.config
+}
+
+// EncryptionKey returns the master encryption key (may be nil).
+// Exposed so the API handler can pass it to crypto helpers when building
+// responses.
+func (s *Storage) EncryptionKey() []byte {
+	return s.encryptionKey
+}
+
+// scanIntegration populates an Integration from a pgx row. Columns must
+// be in the order returned by the standard SELECT in the various query
+// helpers below.
+func scanIntegration(row pgx.Row) (*Integration, error) {
+	i := &Integration{Config: map[string]string{}}
+	// config is jsonb — scan into a map[string]string directly. pgbouncer-
+	// safe because pgx handles the JSONB → map decode.
+	var configMap map[string]any
+	err := row.Scan(
+		&i.ID, &i.Name, &i.IntegrationType, &i.Provider, &configMap,
+		&i.Enabled, &i.IsDefault, &i.LastTestedAt, &i.LastTestStatus, &i.LastTestError,
+		&i.CreatedAt, &i.UpdatedAt, &i.CreatedBy, &i.TenantID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range configMap {
+		if s, ok := v.(string); ok {
+			i.Config[k] = s
+		}
+	}
+	return i, nil
+}
+
+// standardColumns is the SELECT column list used by all read queries.
+// Keep in sync with scanIntegration.
+const standardColumns = `
+	id, name, integration_type, provider, config,
+	enabled, is_default, last_tested_at, last_test_status, last_test_error,
+	created_at, updated_at, created_by, tenant_id
+`
+
+// GetIntegration returns a single integration by ID. Decrypts secrets in
+// Config. Returns (nil, nil) when not found — callers should nil-check.
+func (s *Storage) GetIntegration(ctx context.Context, id string) (*Integration, error) {
+	query := `SELECT ` + standardColumns + ` FROM ai.tool_integrations WHERE id = $1`
+	var integration *Integration
+	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, query, id)
+		i, err := scanIntegration(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return err
+		}
+		integration = i
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetIntegrations: %w", err)
+	}
+	if integration == nil {
+		return nil, nil
+	}
+	s.decryptConfigInPlace(integration)
+	return integration, nil
+}
+
+// GetIntegrationByName returns a single integration by name. Decrypts secrets.
+func (s *Storage) GetIntegrationByName(ctx context.Context, name string) (*Integration, error) {
+	query := `SELECT ` + standardColumns + ` FROM ai.tool_integrations WHERE name = $1`
+	var integration *Integration
+	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, query, name)
+		i, err := scanIntegration(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return err
+		}
+		integration = i
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetIntegrationsByName: %w", err)
+	}
+	if integration == nil {
+		return nil, nil
+	}
+	s.decryptConfigInPlace(integration)
+	return integration, nil
+}
+
+// GetDefaultIntegration returns the default integration for the given
+// integration_type, preferring the synthetic FROM_CONFIG row when env/YAML
+// is set. Returns (nil, nil) when none configured — callers fall back to
+// disabling the corresponding agent.
+//
+// resolution order:
+//  1. Synthetic FROM_CONFIG row (if env/YAML is set and matches the type)
+//  2. DB row where is_default=true for this tenant + type
+//  3. Any enabled DB row for this tenant + type (last resort)
+func (s *Storage) GetDefaultIntegration(ctx context.Context, integrationType IntegrationType) (*Integration, error) {
+	// 1. Synthetic FROM_CONFIG
+	if s.config != nil && s.config.HasIntegration(integrationType) {
+		return s.config.ToIntegration(integrationType), nil
+	}
+
+	// 2. DB default for this type
+	query := `
+		SELECT ` + standardColumns + ` FROM ai.tool_integrations
+		WHERE integration_type = $1 AND is_default = true AND enabled = true
+	`
+	var integration *Integration
+	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, query, integrationType)
+		i, err := scanIntegration(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return err
+		}
+		integration = i
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetDefaultIntegration: %w", err)
+	}
+	if integration != nil {
+		s.decryptConfigInPlace(integration)
+		return integration, nil
+	}
+
+	// 3. Any enabled row for this type
+	query = `
+		SELECT ` + standardColumns + ` FROM ai.tool_integrations
+		WHERE integration_type = $1 AND enabled = true
+		ORDER BY created_at ASC LIMIT 1
+	`
+	err = s.WithTenant(ctx, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, query, integrationType)
+		i, err := scanIntegration(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return err
+		}
+		integration = i
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetDefaultIntegration (any enabled): %w", err)
+	}
+	if integration != nil {
+		s.decryptConfigInPlace(integration)
+	}
+	return integration, nil
+}
+
+// ListIntegrations returns all integrations, optionally filtered by type.
+// Includes the synthetic FROM_CONFIG row when env/YAML config is set.
+// Secrets in returned rows are decrypted for internal use; the API layer
+// is responsible for masking.
+func (s *Storage) ListIntegrations(ctx context.Context, integrationType *IntegrationType) ([]*Integration, error) {
+	var (
+		query string
+		args  []any
+	)
+	if integrationType != nil {
+		query = `SELECT ` + standardColumns + ` FROM ai.tool_integrations WHERE integration_type = $1 ORDER BY created_at DESC`
+		args = []any{*integrationType}
+	} else {
+		query = `SELECT ` + standardColumns + ` FROM ai.tool_integrations ORDER BY created_at DESC`
+	}
+
+	var out []*Integration
+	err := s.WithTenant(ctx, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			i, err := scanIntegration(rows)
+			if err != nil {
+				return err
+			}
+			out = append(out, i)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ListIntegrations: %w", err)
+	}
+
+	// Decrypt secrets on read
+	for _, i := range out {
+		s.decryptConfigInPlace(i)
+	}
+
+	// Prepend synthetic FROM_CONFIG row when env/YAML is set
+	if s.config != nil {
+		if integrationType == nil {
+			for _, t := range AllIntegrationTypes {
+				if i := s.config.ToIntegration(t); i != nil {
+					out = append([]*Integration{i}, out...)
+				}
+			}
+		} else if i := s.config.ToIntegration(*integrationType); i != nil {
+			out = append([]*Integration{i}, out...)
+		}
+	}
+
+	return out, nil
+}
+
+// CreateIntegrationRequest is the input shape for CreateIntegration.
+// API handlers translate fiber payloads into this struct.
+type CreateIntegrationRequest struct {
+	Name            string            `json:"name"`
+	IntegrationType IntegrationType   `json:"integration_type"`
+	Provider        ProviderName      `json:"provider"`
+	Config          map[string]string `json:"config"`
+	Enabled         bool              `json:"enabled"`
+	IsDefault       bool              `json:"is_default"`
+	CreatedBy       string            `json:"created_by,omitempty"`
+}
+
+// CreateIntegration inserts a new row. Secrets in Config are encrypted
+// before persistence. When IsDefault=true, the existing default for the
+// same (integration_type, tenant_id) is cleared first (DB partial unique
+// index would otherwise reject the insert).
+func (s *Storage) CreateIntegration(ctx context.Context, tenantID string, req *CreateIntegrationRequest) (*Integration, error) {
+	if req.Name == "" {
+		return nil, errors.New("name is required")
+	}
+	if !IsValidIntegrationType(string(req.IntegrationType)) {
+		return nil, fmt.Errorf("invalid integration_type: %q", req.IntegrationType)
+	}
+	if !IsValidProvider(string(req.Provider)) {
+		return nil, fmt.Errorf("invalid provider: %q", req.Provider)
+	}
+
+	integration := &Integration{
+		ID:              uuid.New().String(),
+		Name:            req.Name,
+		IntegrationType: req.IntegrationType,
+		Provider:        req.Provider,
+		Config:          req.Config,
+		Enabled:         req.Enabled,
+		IsDefault:       req.IsDefault,
+		CreatedBy:       req.CreatedBy,
+		TenantID:        tenantID,
+		CreatedAt:       time.Now(),
+		UpdatedAt:       time.Now(),
+	}
+	if integration.Config == nil {
+		integration.Config = map[string]string{}
+	}
+
+	// Encrypt secrets before INSERT
+	encryptedConfig, err := s.encryptConfig(integration)
+	if err != nil {
+		return nil, err
+	}
+
+	// Clear prior default for this type within the same transaction
+	// (the partial unique index enforces one-default-per-type-per-tenant).
+	err = database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
+		if integration.IsDefault {
+			if _, err := tx.Exec(
+				ctx,
+				`UPDATE ai.tool_integrations SET is_default = false WHERE integration_type = $1`,
+				integration.IntegrationType,
+			); err != nil {
+				return fmt.Errorf("failed to clear prior default: %w", err)
+			}
+		}
+		_, err := tx.Exec(
+			ctx, `
+			INSERT INTO ai.tool_integrations (
+				id, name, integration_type, provider, config,
+				enabled, is_default, created_at, updated_at, created_by, tenant_id
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		`,
+			integration.ID, integration.Name, integration.IntegrationType, integration.Provider, encryptedConfig,
+			integration.Enabled, integration.IsDefault,
+			integration.CreatedAt, integration.UpdatedAt, integration.CreatedBy,
+			database.TenantOrNil(tenantID),
+		)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("CreateIntegration: %w", err)
+	}
+
+	log.Info().
+		Str("id", integration.ID).
+		Str("name", integration.Name).
+		Str("integration_type", string(integration.IntegrationType)).
+		Str("provider", string(integration.Provider)).
+		Msg("Created tool integration")
+
+	return integration, nil
+}
+
+// UpdateIntegrationRequest is the input shape for UpdateIntegration.
+// All fields optional (pointer); nil means "don't change".
+type UpdateIntegrationRequest struct {
+	Name      *string           `json:"name"`
+	Config    map[string]string `json:"config"`
+	Enabled   *bool             `json:"enabled"`
+	IsDefault *bool             `json:"is_default"`
+}
+
+// UpdateIntegration updates an existing row. When Config is provided,
+// masked secrets ("***masked***") preserve the existing encrypted value;
+// non-masked values overwrite. This matches the AI provider handler's
+// behavior so admins can change non-secret fields without re-entering
+// the API key.
+func (s *Storage) UpdateIntegration(ctx context.Context, tenantID, id string, req *UpdateIntegrationRequest) (*Integration, error) {
+	existing, err := s.GetIntegration(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("UpdateIntegration: load existing: %w", err)
+	}
+	if existing == nil {
+		return nil, fmt.Errorf("UpdateIntegration: integration %q not found", id)
+	}
+	if existing.ReadOnly {
+		return nil, errors.New("UpdateIntegration: integration is read-only (configured via env/YAML)")
+	}
+
+	// Merge request into existing
+	if req.Name != nil {
+		existing.Name = *req.Name
+	}
+	if req.Enabled != nil {
+		existing.Enabled = *req.Enabled
+	}
+	if req.IsDefault != nil {
+		existing.IsDefault = *req.IsDefault
+	}
+	if req.Config != nil {
+		// Preserve masked secrets from existing
+		merged := map[string]string{}
+		for k, v := range existing.Config {
+			merged[k] = v
+		}
+		for k, v := range req.Config {
+			if IsMasked(v) {
+				// Keep the existing decrypted value (will be re-encrypted below)
+				continue
+			}
+			merged[k] = v
+		}
+		existing.Config = merged
+	}
+	existing.UpdatedAt = time.Now()
+
+	// Re-encrypt secrets
+	encryptedConfig, err := s.encryptConfig(existing)
+	if err != nil {
+		return nil, err
+	}
+
+	err = database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
+		// Clear prior default if this row is becoming the new default
+		if existing.IsDefault {
+			if _, err := tx.Exec(
+				ctx,
+				`UPDATE ai.tool_integrations SET is_default = false WHERE integration_type = $1 AND id <> $2`,
+				existing.IntegrationType, existing.ID,
+			); err != nil {
+				return fmt.Errorf("failed to clear prior default: %w", err)
+			}
+		}
+		_, err := tx.Exec(
+			ctx, `
+			UPDATE ai.tool_integrations SET
+				name = $2, config = $3, enabled = $4, is_default = $5, updated_at = $6
+			WHERE id = $1
+		`,
+			existing.ID, existing.Name, encryptedConfig,
+			existing.Enabled, existing.IsDefault, existing.UpdatedAt,
+		)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("UpdateIntegration: %w", err)
+	}
+
+	return existing, nil
+}
+
+// DeleteIntegration removes a row. Refuses to delete read-only (FROM_CONFIG)
+// rows — those are derived from env/YAML and can only be removed by
+// clearing the env vars.
+func (s *Storage) DeleteIntegration(ctx context.Context, tenantID, id string) error {
+	existing, err := s.GetIntegration(ctx, id)
+	if err != nil {
+		return fmt.Errorf("DeleteIntegration: load: %w", err)
+	}
+	if existing == nil {
+		return nil // idempotent
+	}
+	if existing.ReadOnly {
+		return errors.New("DeleteIntegration: integration is read-only (configured via env/YAML)")
+	}
+	return database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `DELETE FROM ai.tool_integrations WHERE id = $1`, id)
+		return err
+	})
+}
+
+// UpdateTestStatus records the result of a test-connection call. Used by
+// the /test endpoint to surface health info in the admin UI.
+func (s *Storage) UpdateTestStatus(ctx context.Context, tenantID, id, status, errMsg string) error {
+	now := time.Now()
+	return database.WrapWithTenantAwareRole(ctx, s.DB, tenantID, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			UPDATE ai.tool_integrations SET
+				last_tested_at = $2, last_test_status = $3, last_test_error = $4
+			WHERE id = $1
+		`, id, now, status, errMsg)
+		return err
+	})
+}
+
+// encryptConfig returns a JSONB-safe copy of the integration's Config
+// with all secret fields encrypted (and tagged with SecretPrefix).
+// Non-secret fields pass through unchanged.
+func (s *Storage) encryptConfig(i *Integration) (map[string]any, error) {
+	if i.Config == nil {
+		return map[string]any{}, nil
+	}
+	secrets := map[string]bool{}
+	for _, k := range i.SecretFields() {
+		secrets[k] = true
+	}
+	out := make(map[string]any, len(i.Config))
+	for k, v := range i.Config {
+		if !secrets[k] {
+			out[k] = v
+			continue
+		}
+		// Already encrypted (e.g., admin passed through a masked value we
+		// preserved)? Skip re-encryption.
+		if IsEncrypted(v) {
+			out[k] = v
+			continue
+		}
+		encrypted, err := EncryptSecret(v, s.encryptionKey)
+		if err != nil {
+			return nil, fmt.Errorf("encrypt field %q: %w", k, err)
+		}
+		out[k] = encrypted
+	}
+	return out, nil
+}
+
+// decryptConfigInPlace decrypts all secret fields in i.Config, in place.
+// Values without SecretPrefix are left unchanged (lazy migration path).
+func (s *Storage) decryptConfigInPlace(i *Integration) {
+	if i.Config == nil || len(s.encryptionKey) == 0 {
+		return
+	}
+	for _, k := range i.SecretFields() {
+		v, ok := i.Config[k]
+		if !ok || !IsEncrypted(v) {
+			continue
+		}
+		plaintext, err := DecryptIfEncrypted(v, s.encryptionKey)
+		if err != nil {
+			log.Warn().Err(err).Str("integration_id", i.ID).Str("field", k).
+				Msg("Failed to decrypt integration secret; leaving ciphertext in place")
+			continue
+		}
+		i.Config[k] = plaintext
+	}
+}

--- a/internal/ai/integrations/tavily.go
+++ b/internal/ai/integrations/tavily.go
@@ -1,0 +1,248 @@
+package integrations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// DefaultTavilyBaseURL is the production Tavily API endpoint. Override
+// via EnvConfig.TavilyBaseURL (env: FLUXBASE_AI_TAVILY_BASE_URL) for
+// testing or self-hosted mirrors.
+const DefaultTavilyBaseURL = "https://api.tavily.com"
+
+// TavilyClient calls the Tavily search and extract endpoints.
+//
+// API reference: https://docs.tavily.com/documentation/api-reference/endpoint
+// (docs.tavily.com is the canonical source; the SDK here is a thin
+// net/http wrapper to avoid adding a third-party Go dependency.)
+type TavilyClient struct {
+	apiKey     string
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewTavilyClient constructs a TavilyClient. If baseURL is empty,
+// DefaultTavilyBaseURL is used. The HTTP client defaults to a 30s timeout
+// if nil — override for custom retry / TLS configs.
+func NewTavilyClient(apiKey, baseURL string, httpClient *http.Client) *TavilyClient {
+	if baseURL == "" {
+		baseURL = DefaultTavilyBaseURL
+	}
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &TavilyClient{
+		apiKey:     apiKey,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+	}
+}
+
+// SearchOptions controls a single Tavily search call.
+type SearchOptions struct {
+	Query          string   // required
+	MaxResults     int      // default 5; Tavily caps at ~20
+	SearchDepth    string   // "basic" (default, faster) | "advanced" (slower, more thorough)
+	IncludeDomains []string // optional allowlist
+	ExcludeDomains []string // optional blocklist
+	IncludeAnswer  bool     // ask Tavily to synthesize a short answer
+	IncludeRaw     bool     // include raw HTML in results (large; off by default)
+}
+
+// SearchResult is the parsed Tavily search response.
+type SearchResult struct {
+	Query        string       `json:"query"`
+	Answer       string       `json:"answer,omitempty"` // populated when IncludeAnswer=true
+	Results      []SearchItem `json:"results"`
+	ResponseTime float64      `json:"response_time"` // seconds
+}
+
+// SearchItem is one result in SearchResult.Results.
+type SearchItem struct {
+	Title   string  `json:"title"`
+	URL     string  `json:"url"`
+	Content string  `json:"content"` // cleaned markdown
+	Raw     string  `json:"raw,omitempty"`
+	Score   float64 `json:"score"` // 0..1 relevance
+}
+
+// tavilySearchResponse is the raw JSON shape from Tavily's /search endpoint.
+// We don't surface every field — only what the agent needs.
+type tavilySearchResponse struct {
+	QueryResponse string `json:"response_time"`
+	Answer        string `json:"answer,omitempty"`
+	Results       []struct {
+		Title   string  `json:"title"`
+		URL     string  `json:"url"`
+		Content string  `json:"content"`
+		Raw     string  `json:"raw_content,omitempty"`
+		Score   float64 `json:"score"`
+	} `json:"results"`
+}
+
+// Search calls Tavily /search.
+func (c *TavilyClient) Search(ctx context.Context, opts SearchOptions) (*SearchResult, error) {
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("tavily: api_key is required")
+	}
+	if opts.Query == "" {
+		return nil, fmt.Errorf("tavily: query is required")
+	}
+	if opts.MaxResults <= 0 {
+		opts.MaxResults = 5
+	}
+	if opts.SearchDepth == "" {
+		opts.SearchDepth = "basic"
+	}
+
+	body := map[string]any{
+		"api_key":             c.apiKey,
+		"query":               opts.Query,
+		"max_results":         opts.MaxResults,
+		"search_depth":        opts.SearchDepth,
+		"include_answer":      opts.IncludeAnswer,
+		"include_raw_content": opts.IncludeRaw,
+	}
+	if len(opts.IncludeDomains) > 0 {
+		body["include_domains"] = opts.IncludeDomains
+	}
+	if len(opts.ExcludeDomains) > 0 {
+		body["exclude_domains"] = opts.ExcludeDomains
+	}
+
+	respBody, err := c.postJSON(ctx, "/search", body)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw tavilySearchResponse
+	if err := json.Unmarshal(respBody, &raw); err != nil {
+		return nil, fmt.Errorf("tavily: failed to parse search response: %w", err)
+	}
+
+	out := &SearchResult{
+		Answer: raw.Answer,
+	}
+	out.Results = make([]SearchItem, len(raw.Results))
+	for i, r := range raw.Results {
+		out.Results[i] = SearchItem{
+			Title:   r.Title,
+			URL:     r.URL,
+			Content: r.Content,
+			Raw:     r.Raw,
+			Score:   r.Score,
+		}
+	}
+	return out, nil
+}
+
+// ExtractOptions controls the /extract call.
+type ExtractOptions struct {
+	URLs    []string // required, 1..10 URLs per Tavily docs
+	Include []string // optional section selector
+	Exclude []string // optional section selector
+}
+
+// ExtractResult is the parsed Tavily extract response.
+type ExtractResult struct {
+	Results []struct {
+		URL        string `json:"url"`
+		RawContent string `json:"raw_content"`
+		Failed     bool   `json:"failed,omitempty"`
+		Error      string `json:"error,omitempty"`
+	} `json:"results"`
+	FailedCount int `json:"failed_count"`
+}
+
+// Extract calls Tavily /extract. Useful when the agent has a specific URL
+// (e.g., the top search hit) and wants full page content as markdown.
+func (c *TavilyClient) Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
+	if c.apiKey == "" {
+		return nil, fmt.Errorf("tavily: api_key is required")
+	}
+	if len(opts.URLs) == 0 {
+		return nil, fmt.Errorf("tavily: at least one URL is required")
+	}
+
+	body := map[string]any{
+		"api_key": c.apiKey,
+		"urls":    opts.URLs,
+	}
+	if len(opts.Include) > 0 {
+		body["include"] = opts.Include
+	}
+	if len(opts.Exclude) > 0 {
+		body["exclude"] = opts.Exclude
+	}
+
+	respBody, err := c.postJSON(ctx, "/extract", body)
+	if err != nil {
+		return nil, err
+	}
+
+	var out ExtractResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("tavily: failed to parse extract response: %w", err)
+	}
+	return &out, nil
+}
+
+// Ping verifies the API key by running a minimal /search call. Used by
+// the test-connection endpoint in the admin UI. Returns nil on success.
+func (c *TavilyClient) Ping(ctx context.Context) error {
+	_, err := c.Search(ctx, SearchOptions{
+		Query:      "test",
+		MaxResults: 1,
+	})
+	return err
+}
+
+// postJSON is the shared HTTP helper. Centralizes header/timeout/error
+// handling so Search and Extract stay focused on their own shape parsing.
+func (c *TavilyClient) postJSON(ctx context.Context, path string, body any) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("tavily: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("tavily: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("tavily: HTTP call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("tavily: read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Try to extract a Tavily error message; fall back to raw body
+		var errResp struct {
+			Detail  string `json:"detail"`
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(respBody, &errResp)
+		if errResp.Detail != "" {
+			return nil, fmt.Errorf("tavily: %s (HTTP %d)", errResp.Detail, resp.StatusCode)
+		}
+		if errResp.Message != "" {
+			return nil, fmt.Errorf("tavily: %s (HTTP %d)", errResp.Message, resp.StatusCode)
+		}
+		return nil, fmt.Errorf("tavily: HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}

--- a/internal/ai/integrations/tavily_test.go
+++ b/internal/ai/integrations/tavily_test.go
@@ -1,0 +1,149 @@
+package integrations
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTavilyClient_Search_BuildsCorrectRequest(t *testing.T) {
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/search", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		_, _ = w.Write([]byte(`{
+			"answer": "Berlin zoo closes at 6:30 PM today",
+			"results": [
+				{"title": "Berlin Zoo", "url": "https://www.zooberlin.de", "content": "Open 9-18:30", "score": 0.95}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewTavilyClient("tvly-test", server.URL, nil)
+	result, err := client.Search(context.Background(), SearchOptions{
+		Query:         "Berlin zoo closing time",
+		MaxResults:    3,
+		SearchDepth:   "basic",
+		IncludeAnswer: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "Berlin zoo closes at 6:30 PM today", result.Answer)
+	require.Len(t, result.Results, 1)
+	assert.Equal(t, "Berlin Zoo", result.Results[0].Title)
+	assert.Equal(t, "https://www.zooberlin.de", result.Results[0].URL)
+	assert.InDelta(t, 0.95, result.Results[0].Score, 0.001)
+
+	// Verify request body
+	assert.Equal(t, "tvly-test", capturedBody["api_key"])
+	assert.Equal(t, "Berlin zoo closing time", capturedBody["query"])
+	assert.EqualValues(t, 3, capturedBody["max_results"])
+	assert.Equal(t, "basic", capturedBody["search_depth"])
+	assert.Equal(t, true, capturedBody["include_answer"])
+}
+
+func TestTavilyClient_Search_PassesDomainFilters(t *testing.T) {
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := NewTavilyClient("tvly-test", server.URL, nil)
+	_, err := client.Search(context.Background(), SearchOptions{
+		Query:          "test",
+		IncludeDomains: []string{"wikipedia.org", "mdn.dev"},
+		ExcludeDomains: []string{"spam.example"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []any{"wikipedia.org", "mdn.dev"}, capturedBody["include_domains"])
+	assert.Equal(t, []any{"spam.example"}, capturedBody["exclude_domains"])
+}
+
+func TestTavilyClient_Search_NoApiKey_Errors(t *testing.T) {
+	client := NewTavilyClient("", "", nil)
+	_, err := client.Search(context.Background(), SearchOptions{Query: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api_key is required")
+}
+
+func TestTavilyClient_Search_EmptyQuery_Errors(t *testing.T) {
+	client := NewTavilyClient("tvly-test", "", nil)
+	_, err := client.Search(context.Background(), SearchOptions{Query: ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "query is required")
+}
+
+func TestTavilyClient_Search_HttpError_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail": "Invalid API key"}`))
+	}))
+	defer server.Close()
+
+	client := NewTavilyClient("tvly-bad", server.URL, nil)
+	_, err := client.Search(context.Background(), SearchOptions{Query: "test"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid API key")
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestTavilyClient_Extract_BuildsCorrectRequest(t *testing.T) {
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/extract", r.URL.Path)
+		_ = json.NewDecoder(r.Body).Decode(&capturedBody)
+		_, _ = w.Write([]byte(`{
+			"results": [
+				{"url": "https://example.com", "raw_content": "# Hello\n\nWorld"}
+			],
+			"failed_count": 0
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewTavilyClient("tvly-test", server.URL, nil)
+	result, err := client.Extract(context.Background(), ExtractOptions{
+		URLs: []string{"https://example.com"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Results, 1)
+	assert.Equal(t, "https://example.com", result.Results[0].URL)
+	assert.Equal(t, "# Hello\n\nWorld", result.Results[0].RawContent)
+
+	assert.Equal(t, []any{"https://example.com"}, capturedBody["urls"])
+}
+
+func TestTavilyClient_Ping_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results": []}`))
+	}))
+	defer server.Close()
+
+	client := NewTavilyClient("tvly-test", server.URL, nil)
+	err := client.Ping(context.Background())
+	require.NoError(t, err)
+}
+
+func TestTavilyClient_Ping_FailureReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail": "Quota exceeded"}`))
+	}))
+	defer server.Close()
+
+	client := NewTavilyClient("tvly-test", server.URL, nil)
+	err := client.Ping(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Quota exceeded")
+}

--- a/internal/ai/page_context_test.go
+++ b/internal/ai/page_context_test.go
@@ -194,3 +194,48 @@ func TestPopulateDerivedFields_ParsesPageProfilesFromCode(t *testing.T) {
 	require.NotNil(t, c.PageProfiles)
 	require.NotNil(t, c.PageProfiles["orders"])
 }
+
+// Web-search annotation parsing (Web Agent specialist).
+
+func TestParseChatbotConfig_WebSearchEnabled(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"enabled", "enabled", true},
+		{"true", "true", true},
+		{"disabled", "disabled", false},
+		{"false", "false", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code := "/**\n * @fluxbase:web-search " + tc.value + "\n */\nexport default `test`\n"
+			config := ParseChatbotConfig(code)
+			assert.Equal(t, tc.want, config.WebSearchEnabled)
+		})
+	}
+}
+
+func TestParseChatbotConfig_WebSearchAbsent_DefaultsOff(t *testing.T) {
+	config := DefaultChatbotConfig()
+	assert.False(t, config.WebSearchEnabled, "web search must be off by default")
+}
+
+func TestParseChatbotConfig_WebSearchDomains(t *testing.T) {
+	code := "/**\n * @fluxbase:web-search enabled\n * @fluxbase:web-search-domains wikipedia.org, https://mdn.dev, news.example.com\n */\nexport default `test`\n"
+	config := ParseChatbotConfig(code)
+	assert.True(t, config.WebSearchEnabled)
+	require.Len(t, config.WebSearchDomains, 3)
+	assert.Equal(t, "wikipedia.org", config.WebSearchDomains[0])
+	assert.Equal(t, "mdn.dev", config.WebSearchDomains[1], "scheme prefixes must be stripped")
+	assert.Equal(t, "news.example.com", config.WebSearchDomains[2])
+}
+
+func TestPopulateDerivedFields_ParsesWebSearchFromCode(t *testing.T) {
+	code := "/**\n * @fluxbase:web-search enabled\n * @fluxbase:web-search-domains docs.python.org\n */\nexport default `test`\n"
+	c := &Chatbot{Code: code}
+	c.PopulateDerivedFields()
+	assert.True(t, c.WebSearchEnabled)
+	require.Len(t, c.WebSearchDomains, 1)
+	assert.Equal(t, "docs.python.org", c.WebSearchDomains[0])
+}

--- a/internal/ai/supervisor_graph.go
+++ b/internal/ai/supervisor_graph.go
@@ -51,9 +51,20 @@ func NewSupervisorGraph(deps *AgentDeps) *SupervisorGraph {
 	// Router fan-out node — exists only to own the conditional edge from
 	// supervisor → specialists. Each invocation reads the plan from state
 	// and runs the routed specialists in parallel.
-	router := &routerNode{deps: deps, agents: map[string]Node{
+	//
+	// Web Agent is included only when both:
+	//   (a) the chatbot has @fluxbase:web-search enabled=true, AND
+	//   (b) an integrations storage is configured on deps
+	// Otherwise "web" is absent from the map and the router returns an
+	// error if the supervisor tries to route to it — the supervisor's
+	// prompt then knows to fall back to "chat" with a clarification.
+	routerAgents := map[string]Node{
 		"sql": sql, "kb": kb, "action": action, "chat": chat,
-	}}
+	}
+	if deps.Chatbot != nil && deps.Chatbot.WebSearchEnabled && deps.Integrations != nil {
+		routerAgents["web"] = NewWebAgent(deps)
+	}
+	router := &routerNode{deps: deps, agents: routerAgents}
 
 	// Synthesizer gate node — reads agent outputs and decides whether
 	// synthesis is needed based on count + SupervisorPlan.RequiresSynthesis.

--- a/internal/api/handler_groups.go
+++ b/internal/api/handler_groups.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gofiber/fiber/v3"
 
 	"github.com/nimbleflux/fluxbase/internal/ai"
+	"github.com/nimbleflux/fluxbase/internal/ai/integrations"
 	"github.com/nimbleflux/fluxbase/internal/auth"
 	"github.com/nimbleflux/fluxbase/internal/branching"
 	"github.com/nimbleflux/fluxbase/internal/database"
@@ -64,6 +65,30 @@ type AIHandlers struct {
 	VectorManager   *VectorManager
 	VectorHandler   *VectorHandler
 	Internal        *InternalAIHandler
+	// IntegrationsHandler exposes CRUD + test endpoints for non-LLM tool
+	// integrations (Web Search via Tavily, URL fetch). May be nil when
+	// AI is disabled — wrapIntegrationHandler guards against that.
+	Integrations *integrations.Handler
+}
+
+// wrapIntegrationHandler returns a fiber.Handler that delegates to the
+// provided closure, or returns 503 when AI is disabled (h == nil at
+// boot). The closure is constructed by the caller at registration time
+// but only INVOKED at request time, so it's safe to capture h there —
+// the nil-check inside the wrapper short-circuits before invocation.
+//
+// We use a closure rather than passing the method value directly because
+// creating a method value on a nil pointer receiver is unsafe in Go.
+// This pattern keeps request-time dispatch cheap (no reflect).
+func wrapIntegrationHandler(h *integrations.Handler, fn func(h *integrations.Handler) fiber.Handler) fiber.Handler {
+	if h == nil {
+		return func(c fiber.Ctx) error {
+			return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Map{
+				"error": "Tool integrations are not available (AI disabled)",
+			})
+		}
+	}
+	return fn(h)
 }
 
 // FunctionsHandlers groups edge functions handlers.

--- a/internal/api/module_ai.go
+++ b/internal/api/module_ai.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/ai"
+	"github.com/nimbleflux/fluxbase/internal/ai/integrations"
 	"github.com/nimbleflux/fluxbase/internal/auth"
 	"github.com/nimbleflux/fluxbase/internal/logging"
 	"github.com/nimbleflux/fluxbase/internal/observability"
@@ -33,6 +34,17 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 	aiStorage.SetConfig(&cfg.AI)
 
 	vectorManager := NewVectorManager(&cfg.AI, aiStorage, db.Inspector(), db)
+
+	// Tool integrations (Web Agent specialist). Construct the EnvConfig
+	// from YAML/env vars so instance-level Tavily config produces a
+	// synthetic read-only FROM_CONFIG row — same pattern as AI providers.
+	integrationsEnvConfig := &integrations.EnvConfig{
+		TavilyAPIKey:       cfg.AI.TavilyAPIKey,
+		TavilyDefaultDepth: cfg.AI.TavilyDefaultDepth,
+		TavilyBaseURL:      cfg.AI.TavilyBaseURL,
+	}
+	integrationsStorage := integrations.NewStorage(db, cfg.EncryptionKeyBytes, integrationsEnvConfig)
+	integrationsHandler := integrations.NewHandler(integrationsStorage)
 
 	var vectorHandler *VectorHandler
 	vectorHandler, err := NewVectorHandler(vectorManager, db.Inspector(), db, cfg)
@@ -83,6 +95,10 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		}
 
 		aiChatHandler = ai.NewChatHandler(db, aiStorage, aiConversations, aiMetrics, &cfg.AI, embeddingService, loggingSvc)
+
+		// Wire integrations storage into the chat handler so the supervisor's
+		// Web Agent can resolve Tavily credentials at turn start.
+		aiChatHandler.SetIntegrationsStorage(integrationsStorage)
 
 		// Wire chat handler back into the admin handler so provider mutations
 		// invalidate the chat path's provider cache.
@@ -187,6 +203,7 @@ func (m *AIModule) Init(ctx context.Context, registry *ServiceRegistry) error {
 		VectorManager:   vectorManager,
 		VectorHandler:   vectorHandler,
 		Internal:        internalAIHandler,
+		Integrations:    integrationsHandler,
 	}
 	m.Quota = &QuotaHandlers{Handler: quotaHandler}
 

--- a/internal/api/routes/ai_admin.go
+++ b/internal/api/routes/ai_admin.go
@@ -11,20 +11,31 @@ import (
 //   - instance_admin: Full access to all AI management operations
 //   - tenant_admin: Can manage chatbots and view AI tables for their tenant
 type AIAdminDeps struct {
-	ListChatbots               fiber.Handler
-	GetChatbot                 fiber.Handler
-	ToggleChatbot              fiber.Handler
-	UpdateChatbot              fiber.Handler
-	DeleteChatbot              fiber.Handler
-	SyncChatbots               fiber.Handler
-	GetAIMetrics               fiber.Handler
-	ListAIProviders            fiber.Handler
-	CreateAIProvider           fiber.Handler
-	UpdateAIProvider           fiber.Handler
-	DeleteAIProvider           fiber.Handler
-	SetDefaultAIProvider       fiber.Handler
-	SetEmbeddingAIProvider     fiber.Handler
-	ClearEmbeddingAIProvider   fiber.Handler
+	ListChatbots             fiber.Handler
+	GetChatbot               fiber.Handler
+	ToggleChatbot            fiber.Handler
+	UpdateChatbot            fiber.Handler
+	DeleteChatbot            fiber.Handler
+	SyncChatbots             fiber.Handler
+	GetAIMetrics             fiber.Handler
+	ListAIProviders          fiber.Handler
+	CreateAIProvider         fiber.Handler
+	UpdateAIProvider         fiber.Handler
+	DeleteAIProvider         fiber.Handler
+	SetDefaultAIProvider     fiber.Handler
+	SetEmbeddingAIProvider   fiber.Handler
+	ClearEmbeddingAIProvider fiber.Handler
+
+	// Tool Integrations (Web Agent specialist and future non-LLM services).
+	// Same CRUD shape as providers + a test-connection endpoint.
+	ListToolIntegrations      fiber.Handler
+	GetToolIntegration        fiber.Handler
+	CreateToolIntegration     fiber.Handler
+	UpdateToolIntegration     fiber.Handler
+	DeleteToolIntegration     fiber.Handler
+	SetDefaultToolIntegration fiber.Handler
+	TestToolIntegration       fiber.Handler
+
 	ListAIConversations        fiber.Handler
 	GetAIConversationMessages  fiber.Handler
 	GetAIAuditLog              fiber.Handler
@@ -94,6 +105,15 @@ func BuildAIAdminRoutes(deps *AIAdminDeps) *RouteGroup {
 			{Method: "PUT", Path: "/ai/providers/:id/default", Handler: deps.SetDefaultAIProvider, Summary: "Set default AI provider"},
 			{Method: "PUT", Path: "/ai/providers/:id/embedding", Handler: deps.SetEmbeddingAIProvider, Summary: "Set embedding AI provider"},
 			{Method: "DELETE", Path: "/ai/providers/:id/embedding", Handler: deps.ClearEmbeddingAIProvider, Summary: "Clear embedding AI provider"},
+
+			// Tool Integrations — same default roles as providers (admin, instance_admin, tenant_admin)
+			{Method: "GET", Path: "/ai/integrations", Handler: deps.ListToolIntegrations, Summary: "List tool integrations"},
+			{Method: "GET", Path: "/ai/integrations/:id", Handler: deps.GetToolIntegration, Summary: "Get tool integration"},
+			{Method: "POST", Path: "/ai/integrations", Handler: deps.CreateToolIntegration, Summary: "Create tool integration"},
+			{Method: "PUT", Path: "/ai/integrations/:id", Handler: deps.UpdateToolIntegration, Summary: "Update tool integration"},
+			{Method: "DELETE", Path: "/ai/integrations/:id", Handler: deps.DeleteToolIntegration, Summary: "Delete tool integration"},
+			{Method: "PUT", Path: "/ai/integrations/:id/default", Handler: deps.SetDefaultToolIntegration, Summary: "Set default tool integration"},
+			{Method: "POST", Path: "/ai/integrations/:id/test", Handler: deps.TestToolIntegration, Summary: "Test tool integration"},
 
 			// Conversations & Audit - instance admin only (override roles)
 			{Method: "GET", Path: "/ai/conversations", Handler: deps.ListAIConversations, Summary: "List AI conversations", Roles: []string{"admin", "instance_admin"}},

--- a/internal/api/routes_admin.go
+++ b/internal/api/routes_admin.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	"github.com/gofiber/fiber/v3"
+
+	"github.com/nimbleflux/fluxbase/internal/ai/integrations"
 	"github.com/nimbleflux/fluxbase/internal/api/routes"
 )
 
@@ -147,20 +150,28 @@ func (s *Server) buildAdminRouteDeps() *routes.AdminDeps {
 			SyncJobs:          s.Jobs.Handler.SyncJobs,
 		},
 		AI: &routes.AIAdminDeps{
-			ListChatbots:               s.AI.Handler.ListChatbots,
-			GetChatbot:                 s.AI.Handler.GetChatbot,
-			ToggleChatbot:              s.AI.Handler.ToggleChatbot,
-			UpdateChatbot:              s.AI.Handler.UpdateChatbot,
-			DeleteChatbot:              s.AI.Handler.DeleteChatbot,
-			SyncChatbots:               s.AI.Handler.SyncChatbots,
-			GetAIMetrics:               s.AI.Handler.GetAIMetrics,
-			ListAIProviders:            s.AI.Handler.ListProviders,
-			CreateAIProvider:           s.AI.Handler.CreateProvider,
-			UpdateAIProvider:           s.AI.Handler.UpdateProvider,
-			DeleteAIProvider:           s.AI.Handler.DeleteProvider,
-			SetDefaultAIProvider:       s.AI.Handler.SetDefaultProvider,
-			SetEmbeddingAIProvider:     s.AI.Handler.SetEmbeddingProvider,
-			ClearEmbeddingAIProvider:   s.AI.Handler.ClearEmbeddingProvider,
+			ListChatbots:             s.AI.Handler.ListChatbots,
+			GetChatbot:               s.AI.Handler.GetChatbot,
+			ToggleChatbot:            s.AI.Handler.ToggleChatbot,
+			UpdateChatbot:            s.AI.Handler.UpdateChatbot,
+			DeleteChatbot:            s.AI.Handler.DeleteChatbot,
+			SyncChatbots:             s.AI.Handler.SyncChatbots,
+			GetAIMetrics:             s.AI.Handler.GetAIMetrics,
+			ListAIProviders:          s.AI.Handler.ListProviders,
+			CreateAIProvider:         s.AI.Handler.CreateProvider,
+			UpdateAIProvider:         s.AI.Handler.UpdateProvider,
+			DeleteAIProvider:         s.AI.Handler.DeleteProvider,
+			SetDefaultAIProvider:     s.AI.Handler.SetDefaultProvider,
+			SetEmbeddingAIProvider:   s.AI.Handler.SetEmbeddingProvider,
+			ClearEmbeddingAIProvider: s.AI.Handler.ClearEmbeddingProvider,
+			// Tool Integrations — wrapped for nil-safety when AI is disabled
+			ListToolIntegrations:       wrapIntegrationHandler(s.AI.Integrations, func(h *integrations.Handler) fiber.Handler { return h.ListIntegrations }),
+			GetToolIntegration:         wrapIntegrationHandler(s.AI.Integrations, func(h *integrations.Handler) fiber.Handler { return h.GetIntegration }),
+			CreateToolIntegration:      wrapIntegrationHandler(s.AI.Integrations, func(h *integrations.Handler) fiber.Handler { return h.CreateIntegration }),
+			UpdateToolIntegration:      wrapIntegrationHandler(s.AI.Integrations, func(h *integrations.Handler) fiber.Handler { return h.UpdateIntegration }),
+			DeleteToolIntegration:      wrapIntegrationHandler(s.AI.Integrations, func(h *integrations.Handler) fiber.Handler { return h.DeleteIntegration }),
+			SetDefaultToolIntegration:  wrapIntegrationHandler(s.AI.Integrations, func(h *integrations.Handler) fiber.Handler { return h.SetDefaultIntegration }),
+			TestToolIntegration:        wrapIntegrationHandler(s.AI.Integrations, func(h *integrations.Handler) fiber.Handler { return h.TestIntegration }),
 			ListAIConversations:        s.AI.Handler.GetConversations,
 			GetAIConversationMessages:  s.AI.Handler.GetConversationMessages,
 			GetAIAuditLog:              s.AI.Handler.GetAuditLog,

--- a/internal/config/config_ai.go
+++ b/internal/config/config_ai.go
@@ -49,6 +49,15 @@ type AIConfig struct {
 	OllamaEndpoint string `mapstructure:"ollama_endpoint"`
 	OllamaModel    string `mapstructure:"ollama_model"`
 
+	// Tavily websearch Settings (for Web Agent specialist)
+	// When TavilyAPIKey is set, a read-only synthetic FROM_CONFIG tool
+	// integration row is exposed so instance-level deployments work the
+	// same as multi-tenant dashboard deployments. Mirror the OpenAI/
+	// Ollama env-config pattern.
+	TavilyAPIKey       string `mapstructure:"tavily_api_key"`
+	TavilyDefaultDepth string `mapstructure:"tavily_default_depth"` // "basic" (default) or "advanced"
+	TavilyBaseURL      string `mapstructure:"tavily_base_url"`      // optional override
+
 	// OCR Configuration (for image-based PDF extraction in knowledge bases)
 	OCREnabled   bool     `mapstructure:"ocr_enabled"`   // Enable OCR for image-based PDFs
 	OCRProvider  string   `mapstructure:"ocr_provider"`  // OCR provider: tesseract

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -305,6 +305,11 @@ func setDefaults() {
 	viper.SetDefault("ai.ollama_endpoint", "")        // No default endpoint
 	viper.SetDefault("ai.ollama_model", "")           // No default model
 
+	// AI Tavily websearch defaults (Web Agent specialist)
+	viper.SetDefault("ai.tavily_api_key", "")       // No default; off when empty
+	viper.SetDefault("ai.tavily_default_depth", "") // Empty = client default ("basic")
+	viper.SetDefault("ai.tavily_base_url", "")      // Empty = https://api.tavily.com
+
 	// AI Embedding Configuration defaults (for vector search)
 	viper.SetDefault("ai.embedding_enabled", false)            // Disabled by default
 	viper.SetDefault("ai.embedding_provider", "")              // Defaults to ai.provider_type if empty

--- a/internal/database/schema/schemas/ai.sql
+++ b/internal/database/schema/schemas/ai.sql
@@ -2762,3 +2762,74 @@ GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE user_chatbot_usage TO tenant_servi
 GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE user_provider_preferences TO tenant_service;
 GRANT DELETE, INSERT, SELECT, UPDATE ON TABLE user_quotas TO tenant_service;
 
+-- ============================================================================
+-- Tool Integrations
+-- ============================================================================
+-- Non-LLM external services that chatbot specialists can call. Currently
+-- supports web_search (Tavily, Brave, etc.) and fetch_url (single-page
+-- extract). Schema is provider-agnostic so new integrations (code runner,
+-- GitHub, etc.) can be added without restructuring.
+--
+-- Secrets in `config` (e.g., api_key) MUST be encrypted at the application
+-- layer via internal/ai/integrations/crypto.go using the master
+-- EncryptionKey. Read paths auto-detect legacy plaintext values and treat
+-- them as plaintext for forward compatibility with the lazy encryption
+-- migration on ai.providers.
+
+CREATE TABLE IF NOT EXISTS tool_integrations (
+    id uuid DEFAULT gen_random_uuid(),
+    name text NOT NULL,
+    integration_type text NOT NULL,
+    provider text NOT NULL,
+    config jsonb DEFAULT '{}' NOT NULL,
+    enabled boolean DEFAULT true,
+    is_default boolean DEFAULT false,
+    last_tested_at timestamptz,
+    last_test_status text,
+    last_test_error text,
+    created_at timestamptz DEFAULT now(),
+    updated_at timestamptz DEFAULT now(),
+    created_by uuid,
+    tenant_id uuid,
+    CONSTRAINT tool_integrations_pkey PRIMARY KEY (id),
+    CONSTRAINT tool_integrations_name_key UNIQUE (name),
+    CONSTRAINT tool_integrations_type_check
+        CHECK (integration_type IN ('web_search','fetch_url')),
+    CONSTRAINT tool_integrations_provider_check
+        CHECK (provider IN ('tavily','brave','jina','singlefetch'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_tool_integrations_tenant_id ON tool_integrations (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_ai_tool_integrations_enabled ON tool_integrations (enabled);
+CREATE INDEX IF NOT EXISTS idx_ai_tool_integrations_type ON tool_integrations (integration_type);
+
+-- One default per (integration_type, tenant_id). Postgres partial unique index
+-- ensures exactly one row per type per tenant can have is_default=true.
+-- Tenant_id NULL collides with other NULLs by default which is what we want
+-- (only one instance-wide default when no tenant context).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_tool_integrations_single_default
+    ON tool_integrations (integration_type, tenant_id)
+    WHERE (is_default = true);
+
+ALTER TABLE tool_integrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tool_integrations FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tool_integrations_tenant ON tool_integrations TO PUBLIC
+    USING (auth.has_tenant_access(tenant_id))
+    WITH CHECK (auth.has_tenant_access(tenant_id));
+
+CREATE OR REPLACE TRIGGER ai_tool_integrations_set_tenant_id
+    BEFORE INSERT ON tool_integrations
+    FOR EACH ROW
+    EXECUTE FUNCTION auth.set_tenant_id_from_context();
+
+COMMENT ON TABLE tool_integrations IS
+    'External tool integrations (web search, URL fetch) consumed by chatbot specialist agents';
+COMMENT ON COLUMN tool_integrations.config IS
+    'Provider-specific config JSON. Secret fields (api_key) MUST be encrypted at application layer.';
+COMMENT ON COLUMN tool_integrations.last_test_status IS
+    'Result of the most recent test-connection call: ok, failed, or NULL if never tested';
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE tool_integrations TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE tool_integrations TO tenant_service;
+

--- a/internal/settings/unified_service.go
+++ b/internal/settings/unified_service.go
@@ -361,6 +361,12 @@ func getConfigAIValue(cfg *config.Config, parts []string) any {
 		return cfg.AI.AzureAPIKey
 	case "azure_endpoint":
 		return cfg.AI.AzureEndpoint
+	case "tavily_api_key":
+		return cfg.AI.TavilyAPIKey
+	case "tavily_default_depth":
+		return cfg.AI.TavilyDefaultDepth
+	case "tavily_base_url":
+		return cfg.AI.TavilyBaseURL
 	}
 	return nil
 }

--- a/sdk/src/admin-ai.ts
+++ b/sdk/src/admin-ai.ts
@@ -14,6 +14,11 @@ import type {
   LinkKnowledgeBaseRequest,
   UpdateChatbotKnowledgeBaseRequest,
   TableDetails,
+  ToolIntegration,
+  CreateToolIntegrationRequest,
+  UpdateToolIntegrationRequest,
+  TestToolIntegrationResult,
+  IntegrationType,
 } from "./types";
 
 /**
@@ -544,6 +549,153 @@ export class FluxbaseAdminAI {
     try {
       const data = await this.fetch.get<TableDetails>(
         `/api/v1/admin/ai/tables/${schema}/${table}`,
+      );
+      return { data, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  // ==========================================================================
+  // Tool Integrations (Web Search via Tavily, future Brave/Jina, URL fetch)
+  // ==========================================================================
+  // Mirrors the provider CRUD shape plus a /test endpoint that runs a real
+  // "hello world" call against the integration's provider and stores the
+  // result. Used by the admin UI's Test button.
+
+  /**
+   * List tool integrations, optionally filtered by integration_type.
+   *
+   * @example
+   * const { data, error } = await client.admin.ai.listIntegrations({ integration_type: "web_search" })
+   */
+  async listIntegrations(
+    params?: { integration_type?: IntegrationType },
+  ): Promise<{
+    data: ToolIntegration[] | null;
+    error: Error | null;
+  }> {
+    try {
+      const query = params?.integration_type
+        ? `?type=${params.integration_type}`
+        : "";
+      const result = await this.fetch.get<{
+        integrations: ToolIntegration[];
+        count: number;
+      }>(`/api/v1/admin/ai/integrations${query}`);
+      return { data: result.integrations || [], error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  /**
+   * Get a single tool integration by ID.
+   */
+  async getIntegration(
+    id: string,
+  ): Promise<{ data: ToolIntegration | null; error: Error | null }> {
+    try {
+      const data = await this.fetch.get<ToolIntegration>(
+        `/api/v1/admin/ai/integrations/${id}`,
+      );
+      return { data, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  /**
+   * Create a new tool integration. api_key in config is encrypted at the
+   * storage layer; never appears in plaintext in API responses.
+   */
+  async createIntegration(
+    request: CreateToolIntegrationRequest,
+  ): Promise<{ data: ToolIntegration | null; error: Error | null }> {
+    try {
+      const data = await this.fetch.post<ToolIntegration>(
+        "/api/v1/admin/ai/integrations",
+        request,
+      );
+      return { data, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  /**
+   * Update an existing tool integration. Passing config.api_key =
+   * "***masked***" preserves the existing encrypted value (useful when
+   * the admin changes only the name and not the API key).
+   */
+  async updateIntegration(
+    id: string,
+    request: UpdateToolIntegrationRequest,
+  ): Promise<{ data: ToolIntegration | null; error: Error | null }> {
+    try {
+      const data = await this.fetch.put<ToolIntegration>(
+        `/api/v1/admin/ai/integrations/${id}`,
+        request,
+      );
+      return { data, error: null };
+    } catch (error) {
+      return { data: null, error: error as Error };
+    }
+  }
+
+  /**
+   * Delete a tool integration. Refuses to delete read-only integrations
+   * configured via env/YAML.
+   */
+  async deleteIntegration(
+    id: string,
+  ): Promise<{ error: Error | null }> {
+    try {
+      await this.fetch.delete(`/api/v1/admin/ai/integrations/${id}`);
+      return { error: null };
+    } catch (error) {
+      return { error: error as Error };
+    }
+  }
+
+  /**
+   * Mark an integration as the default for its integration_type within
+   * the current tenant. The server clears any prior default in the same
+   * transaction.
+   */
+  async setDefaultIntegration(
+    id: string,
+  ): Promise<{ error: Error | null }> {
+    try {
+      await this.fetch.put(
+        `/api/v1/admin/ai/integrations/${id}/default`,
+        {},
+      );
+      return { error: null };
+    } catch (error) {
+      return { error: error as Error };
+    }
+  }
+
+  /**
+   * Test an integration by running a real "hello world" call against
+   * its provider. Stores last_tested_at + last_test_status + error
+   * on the integration row so the admin UI can display health.
+   *
+   * @example
+   * const { data, error } = await client.admin.ai.testIntegration(integrationId)
+   * if (data?.status === "ok") { console.log("Tavily credentials verified") }
+   */
+  async testIntegration(
+    id: string,
+  ): Promise<{
+    data: TestToolIntegrationResult | null;
+    error: Error | null;
+  }> {
+    try {
+      const data = await this.fetch.post<TestToolIntegrationResult>(
+        `/api/v1/admin/ai/integrations/${id}/test`,
+        {},
       );
       return { data, error: null };
     } catch (error) {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -459,6 +459,13 @@ export type {
   AIChatbot,
   AIChatbotLookupResponse,
   ChatbotSpec,
+  // Tool integrations
+  IntegrationType,
+  IntegrationProvider,
+  ToolIntegration,
+  CreateToolIntegrationRequest,
+  UpdateToolIntegrationRequest,
+  TestToolIntegrationResult,
   SyncChatbotsOptions,
   SyncChatbotsResult,
   AIChatMessageRole,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -2919,7 +2919,79 @@ export interface SyncMigrationsResult {
 /**
  * AI provider type
  */
-export type AIProviderType = "openai" | "azure" | "ollama";
+export type AIProviderType = "openai" | "azure" | "ollama" | "anthropic";
+
+/**
+ * Tool integration type — categorizes what kind of external tool the
+ * integration provides. Stored in `tool_integrations.integration_type`.
+ */
+export type IntegrationType = "web_search" | "fetch_url";
+
+/**
+ * Tool integration provider — identifies the specific service within
+ * an integration type. E.g., for web_search: tavily, brave, jina.
+ */
+export type IntegrationProvider = "tavily" | "brave" | "jina" | "singlefetch";
+
+/**
+ * Tool integration configuration. Mirrors the server-side
+ * `tool_integrations` table shape. Secrets in `config` (e.g., api_key)
+ * are masked to "***masked***" on read; updates that pass the mask value
+ * back preserve the existing encrypted value.
+ */
+export interface ToolIntegration {
+  id: string;
+  name: string;
+  integration_type: IntegrationType;
+  provider: IntegrationProvider;
+  /** Provider-specific config. api_key is masked on read. */
+  config: Record<string, string>;
+  enabled: boolean;
+  is_default: boolean;
+  /** True when configured via env/YAML (read-only in the UI). */
+  from_config?: boolean;
+  read_only?: boolean;
+  /** Result of the most recent test-connection call, if any. */
+  last_tested_at?: string;
+  last_test_status?: "ok" | "failed";
+  last_test_error?: string;
+  created_at: string;
+  updated_at: string;
+  created_by?: string;
+}
+
+/**
+ * Request shape for creating a tool integration.
+ */
+export interface CreateToolIntegrationRequest {
+  name: string;
+  integration_type: IntegrationType;
+  provider: IntegrationProvider;
+  config?: Record<string, string>;
+  enabled?: boolean;
+  is_default?: boolean;
+}
+
+/**
+ * Request shape for updating a tool integration. All fields optional.
+ * Updates that pass config.api_key = "***masked***" preserve the
+ * existing encrypted value rather than overwriting it.
+ */
+export interface UpdateToolIntegrationRequest {
+  name?: string;
+  config?: Record<string, string>;
+  enabled?: boolean;
+  is_default?: boolean;
+}
+
+/**
+ * Response from POST /api/v1/admin/ai/integrations/:id/test
+ */
+export interface TestToolIntegrationResult {
+  status: "ok" | "failed";
+  last_tested_at: string;
+  error?: string;
+}
 
 /**
  * AI provider configuration


### PR DESCRIPTION
## Summary

Adds a new **Tool Integrations** framework for non-LLM external services that chatbot specialists can call. First integration: **Tavily web search**. The supervisor's new Web Agent specialist uses it to answer current-info questions ("what's the latest X", "what time does Y close today").

## Why a new abstraction (not shoved into ai.providers)

Tool integrations are a NEW concept, NOT jammed into \`ai.providers\`:

- \`ai.providers\` → LLM completion services (OpenAI, Anthropic, …)
- \`ai.tool_integrations\` → non-LLM tool services (Tavily, future Brave/Jina, code runner)

Forcing Tavily into \`ai.providers\` would be a category error — it doesn't do chat completions, doesn't take a model, isn't selected per-chatbot via \`chatbot.provider_id\`. The new table keeps the abstraction clean and sets up for future integrations without polluting the provider enum.

## Configuration parity (the explicit ask)

Mirrors the existing AI provider config paths exactly:

| Path | How |
|---|---|
| Env vars | \`FLUXBASE_AI_TAVILY_API_KEY\` (+ optional \`DEFAULT_DEPTH\`, \`BASE_URL\`) |
| YAML | \`ai.tavily_api_key\` in \`fluxbase.yaml\` |
| Admin UI | **AI → Tool Integrations** (new tab with full CRUD + Test button) |
| REST API | \`/api/v1/admin/ai/integrations\` (full CRUD + \`/test\`) |

When env/YAML is set, the server constructs a synthetic read-only \`FROM_CONFIG\` row so instance-level deployments work the same as multi-tenant dashboard deployments — same pattern as AI providers.

## Secrets handling

API keys in \`tool_integrations.config.api_key\` are encrypted at the application layer with AES-256-GCM, keyed by the master \`FLUXBASE_ENCRYPTION_KEY\`.

- Read paths auto-detect the \`enc:\` prefix and decrypt; values without the prefix pass through unchanged (**lazy migration path** — forward-compatible with existing plaintext conventions).
- API responses mask secrets to \`\"***masked***\"\`; update handlers preserve masked values so admins can change non-secret fields without re-entering the key.
- Test-connection endpoint runs a real \"hello world\" Tavily search and stores \`last_tested_at\` + status + error on the row.

## Web Agent specialist

New \`internal/ai/agent_web.go\` mirrors the SQL/KB specialist pattern: focused prompt, two tools (\`web_search\` + \`fetch_url\`), bounded internal loop.

Supervisor routes to \`\"web\"\` when the chatbot opts in via:

\`\`\`typescript
/**
 * @fluxbase:web-search enabled
 * @fluxbase:web-search-domains wikipedia.org,mdn.dev  // optional allowlist
 */
export default \`You are a helpful assistant.\`;
\`\`\`

…and a default \`web_search\` integration is configured at the tenant/instance level.

The agent runs Tavily search, optionally fetches the top result for full content (capped at 8KB), then streams the final answer in the user's language. \`agent_thought\` events fire for each step (search query, fetch URL, result summary) so clients render the thought process.

Supervisor routing excludes \`\"web\"\` when either condition is missing — chatbots without the annotation are unchanged.

## Cost

Tavily pricing:
- Free: 1,000 searches/month
- Pro: $30/month, 4,000 searches, then $0.01/search

Per chatbot turn routed to Web Agent: ~$0.01-0.03 Tavily + 1-3 extra LLM calls (~$0.005-0.02). Typical chatbot: $5-20/month additional. Disable per chatbot by removing the annotation.

## What changed

### New files
- \`internal/ai/integrations/{storage,handler,crypto,env_config,tavily}.go\` — framework
- \`internal/ai/integrations/{crypto,tavily}_test.go\` — unit tests
- \`internal/ai/agent_web.go\` (+ \`agent_web_test.go\`) — Web Agent specialist
- \`admin/src/components/ai-integrations/{tool-integrations-tab,create-integration-dialog,edit-integration-dialog}.tsx\`
- \`admin/src/routes/_authenticated/ai-integrations/index.tsx\`
- \`docs/src/content/docs/guides/ai-integrations.md\`

### Modified
- \`internal/ai/{chatbot,agent_deps,agent_prompts,agent_supervisor,supervisor_graph,chat_handler,chat_handler_supervisor}.go\`
- \`internal/ai/page_context_test.go\` — added \`@fluxbase:web-search\` annotation tests
- \`internal/api/{handler_groups,module_ai,routes_admin}.go\` + \`routes/ai_admin.go\` — wire routes + handler groups
- \`internal/config/{config_ai,config_defaults}.go\` — Tavily config fields
- \`internal/database/schema/schemas/ai.sql\` — new \`tool_integrations\` table
- \`internal/settings/unified_service.go\` — Tavily config exposed via settings API
- \`sdk/src/{types,admin-ai,index}.ts\` — types + methods; also fixed pre-existing \`AIProviderType\` bug (missing \`\"anthropic\"\`)
- \`fluxbase.yaml.example\`, \`deploy/helm/fluxbase/{values,deployment}.yaml\` — env var plumbing
- \`CLAUDE.md\`, \`docs/src/content/docs/guides/ai-chatbots.md\`

## Encryption migration note

The lazy-encryption pattern (\`enc:\` prefix detection) means existing \`ai.providers\` plaintext keys continue to work after deploy. A future PR will migrate those rows to encrypted form using the same helper. This PR keeps the blast radius small by only encrypting new integration keys.

## Tests

- \`integrations/crypto_test.go\`: encrypt/decrypt round-trip, lazy migration path, masking helpers
- \`integrations/tavily_test.go\`: real HTTP test server, verifies request body shape + error handling + domain filters
- \`ai/page_context_test.go\` additions: \`@fluxbase:web-search\` parsing variants + \`@fluxbase:web-search-domains\` parsing (including scheme stripping)
- \`ai/agent_web_test.go\`: nil-safe contract — Web Agent returns error (not panic) when integrations storage is missing; supervisor router graph correctly includes/excludes Web Agent per chatbot annotation

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`gofumpt -l .\` — 0 files
- [x] \`golangci-lint run ./internal/... ./cli/...\` — 0 issues
- [x] \`go test ./internal/ai/... ./internal/ai/integrations/... ./cli/...\` — all pass
- [x] \`cd sdk && bun run type-check\` — clean
- [x] \`cd sdk-react && bun run type-check\` — clean
- [x] \`cd admin && bun run type-check\` — clean
- [ ] Manual: set \`FLUXBASE_AI_TAVILY_API_KEY\`, verify synthetic FROM_CONFIG row appears read-only in UI
- [ ] Manual: create integration via UI, click Test, verify status pill updates
- [ ] Manual: chatbot with \`@fluxbase:web-search enabled\`, ask \"what's the latest X\" — verify Web Agent runs and returns current info
- [ ] Manual: verify existing AI provider keys still work (lazy migration doesn't break reads)