### PR TITLE
fix(rpc): honor optional '?' marker in input_schema when building SQL

### DIFF
--- a/internal/rpc/executor.go
+++ b/internal/rpc/executor.go
@@ -337,9 +337,31 @@ func (e *Executor) buildParameterizedSQL(sqlTemplate string, params map[string]i
 	paramPattern := regexp.MustCompile(`\$([a-zA-Z_][a-zA-Z0-9_]*)`)
 	matches := paramPattern.FindAllStringSubmatch(sqlTemplate, -1)
 
+	// Build the set of optional parameters from the procedure's input_schema.
+	// Schema is stored as json.RawMessage; the convention is a flat object whose
+	// keys are param names (with "?" suffix marking optional) and values are
+	// type strings, e.g. {"trip_id?": "uuid", "trip_title?": "text", "name": "text"}.
+	// When the SQL references an optional param the caller omitted, we inject
+	// NULL rather than rejecting the call — matches what RPC authors expect
+	// from the documented `?` convention.
+	optionalParams := make(map[string]bool)
+	if execCtx.Procedure != nil && len(execCtx.Procedure.InputSchema) > 0 {
+		var schema map[string]string
+		if err := json.Unmarshal(execCtx.Procedure.InputSchema, &schema); err == nil {
+			for k := range schema {
+				if strings.HasSuffix(k, "?") {
+					optionalParams[strings.TrimSuffix(k, "?")] = true
+				}
+			}
+		}
+		// If unmarshal fails we silently fall back to "no optional params" —
+		// the executor still rejects missing required params, so this is safe.
+	}
+
 	// Track unique params in order of first appearance for deterministic output
 	seenParams := make(map[string]bool)
 	var orderedParamNames []string
+	missingParamsSet := make(map[string]bool) // dedupe across multiple SQL references
 	var missingParams []string
 
 	for _, match := range matches {
@@ -348,10 +370,19 @@ func (e *Executor) buildParameterizedSQL(sqlTemplate string, params map[string]i
 		}
 		paramName := match[1]
 
-		// Check if parameter exists
+		// Check if parameter exists in the merged caller+user params
 		if _, exists := allParams[paramName]; !exists {
-			missingParams = append(missingParams, paramName)
-			continue
+			// Optional in the schema? Inject NULL so the SQL still resolves.
+			if optionalParams[paramName] {
+				allParams[paramName] = nil
+			} else {
+				// Required + missing — record once, even if referenced N times in SQL.
+				if !missingParamsSet[paramName] {
+					missingParamsSet[paramName] = true
+					missingParams = append(missingParams, paramName)
+				}
+				continue
+			}
 		}
 
 		// Track first occurrence order

--- a/internal/rpc/executor_test.go
+++ b/internal/rpc/executor_test.go
@@ -535,6 +535,128 @@ func TestExecutor_buildParameterizedSQL(t *testing.T) {
 		assert.Contains(t, err.Error(), "param2")
 	})
 
+	t.Run("dedupes missing parameter referenced multiple times in SQL", func(t *testing.T) {
+		// Regression: previously the same missing param was appended once per
+		// SQL reference, producing error text like "[trip_title trip_title]".
+		execCtx := &ExecuteContext{
+			Params: map[string]interface{}{},
+		}
+
+		_, _, err := executor.buildParameterizedSQL(
+			"SELECT * FROM t WHERE a = $dup OR b = $dup",
+			execCtx.Params,
+			execCtx,
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required parameters: [dup]")
+	})
+
+	t.Run("optional param (? marker) injected as NULL when omitted", func(t *testing.T) {
+		// Schema declares trip_title as optional. Caller omits it. SQL references it.
+		// Expected: NULL is injected, call succeeds.
+		execCtx := &ExecuteContext{
+			Procedure: &Procedure{
+				InputSchema: json.RawMessage(`{"trip_id?":"uuid","trip_title?":"text"}`),
+			},
+			Params: map[string]interface{}{
+				"trip_id": "abc-123",
+			},
+		}
+
+		sql, args, err := executor.buildParameterizedSQL(
+			"SELECT * FROM trips WHERE ($trip_id IS NULL OR id = $trip_id) OR ($trip_title IS NOT NULL AND title = $trip_title)",
+			execCtx.Params,
+			execCtx,
+		)
+
+		require.NoError(t, err)
+		// Both params should appear as positional args: trip_id first (first $ ref), trip_title second.
+		assert.Len(t, args, 2)
+		assert.Equal(t, "abc-123", args[0])
+		assert.Nil(t, args[1])
+		assert.Contains(t, sql, "$1")
+		assert.Contains(t, sql, "$2")
+	})
+
+	t.Run("optional param still accepted when provided", func(t *testing.T) {
+		execCtx := &ExecuteContext{
+			Procedure: &Procedure{
+				InputSchema: json.RawMessage(`{"trip_id?":"uuid","trip_title?":"text"}`),
+			},
+			Params: map[string]interface{}{
+				"trip_id":    "abc-123",
+				"trip_title": "Berlin",
+			},
+		}
+
+		_, args, err := executor.buildParameterizedSQL(
+			"SELECT * FROM trips WHERE id = $trip_id OR title = $trip_title",
+			execCtx.Params,
+			execCtx,
+		)
+
+		require.NoError(t, err)
+		assert.Len(t, args, 2)
+		assert.Equal(t, "abc-123", args[0])
+		assert.Equal(t, "Berlin", args[1])
+	})
+
+	t.Run("mixed optional and required: required missing -> error mentions only required", func(t *testing.T) {
+		// trip_title is optional, name is required. Caller omits both.
+		// Error should mention only `name`, not `trip_title`.
+		execCtx := &ExecuteContext{
+			Procedure: &Procedure{
+				InputSchema: json.RawMessage(`{"name":"text","trip_title?":"text"}`),
+			},
+			Params: map[string]interface{}{},
+		}
+
+		_, _, err := executor.buildParameterizedSQL(
+			"SELECT * FROM trips WHERE name = $name AND ($trip_title IS NULL OR title = $trip_title)",
+			execCtx.Params,
+			execCtx,
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name")
+		assert.NotContains(t, err.Error(), "trip_title")
+	})
+
+	t.Run("nil/missing InputSchema falls back to strict (all referenced params required)", func(t *testing.T) {
+		// No InputSchema at all — backward-compat: every SQL-referenced param is required.
+		execCtx := &ExecuteContext{
+			Params: map[string]interface{}{},
+		}
+
+		_, _, err := executor.buildParameterizedSQL(
+			"SELECT * FROM t WHERE id = $any_param",
+			execCtx.Params,
+			execCtx,
+		)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "any_param")
+	})
+
+	t.Run("malformed InputSchema falls back to strict (no panic)", func(t *testing.T) {
+		execCtx := &ExecuteContext{
+			Procedure: &Procedure{
+				InputSchema: json.RawMessage(`not valid json`),
+			},
+			Params: map[string]interface{}{},
+		}
+
+		_, _, err := executor.buildParameterizedSQL(
+			"SELECT * FROM t WHERE id = $any_param",
+			execCtx.Params,
+			execCtx,
+		)
+
+		require.Error(t, err) // strict fallback rejects
+		assert.Contains(t, err.Error(), "any_param")
+	})
+
 	t.Run("empty parameter map works correctly", func(t *testing.T) {
 		execCtx := &ExecuteContext{
 			Params: map[string]interface{}{},


### PR DESCRIPTION
## Problem

The RPC executor's `buildParameterizedSQL` (`internal/rpc/executor.go`) scans the SQL template for `$xxx` placeholders and treats **every referenced param as required**, ignoring the `?` suffix in `@fluxbase:input` that RPC authors use to mark inputs optional.

Callers that omit an optional param get a confusing 400:

```
POST /api/v1/rpc/get_trip_plan
{ "trip_id": "abc-123" }   // trip_title omitted

→ 400 Bad Request
  "missing required parameters: [trip_title trip_title]"
```

Reproduces on any RPC with optional inputs that are referenced in the SQL — e.g. Wayli's `get_trip_plan` (`fluxbase/rpc/get-trip-plan.sql` in the Wayli repo).

## Root cause

`buildParameterizedSQL` at `internal/rpc/executor.go:319-409`:

```go
paramPattern := regexp.MustCompile(`\$([a-zA-Z_][a-zA-Z0-9_]*)`)
matches := paramPattern.FindAllStringSubmatch(sqlTemplate, -1)
// ...
for _, match := range matches {
    paramName := match[1]
    if _, exists := allParams[paramName]; !exists {
        missingParams = append(missingParams, paramName)  // ← always rejects
        continue
    }
    // ...
}
```

The procedure's `InputSchema` (`{"trip_id?": "uuid", "trip_title?": "text"}`) is parsed into `Procedure.InputSchema` but the executor never consults it. The `?` is purely documentation today.

Side bug: the same param referenced twice in the SQL gets appended twice to `missingParams`, producing `[trip_title trip_title]` in the error.

## Fix

Two changes in `buildParameterizedSQL`:

1. **Honor the `?` marker.** Before the missing-params check, build a set of optional param names by unmarshalling `Procedure.InputSchema` and trimming the `?` suffix from each key. When the SQL references a param the caller didn't send:
   - Optional → inject `nil` into the params map (pgx sends NULL) and continue.
   - Required → keep current behavior (add to missing list).

2. **Dedupe missing params.** Use a set so a param referenced N times in the SQL only appears once in the error message.

### Safety

- **Missing `InputSchema` (legacy procedures):** falls through to the existing strict behavior — every SQL-referenced param required. No regression for procedures defined before the `?` convention.
- **Malformed `InputSchema` JSON:** `json.Unmarshal` error is swallowed; we fall back to the strict path. No panic, no behavior change.
- **Required params still enforced:** only the optional case changes. Required params (no `?`) still produce the missing-required error.

## Tests

6 new cases in `TestExecutor_buildParameterizedSQL`:

- `optional param (? marker) injected as NULL when omitted` — the core fix
- `optional param still accepted when provided` — happy path with optional params
- `mixed optional and required: required missing -> error mentions only required` — partial omission
- `dedupes missing parameter referenced multiple times in SQL` — side-fix regression test
- `nil/missing InputSchema falls back to strict` — backward compat
- `malformed InputSchema falls back to strict (no panic)` — defensive

All existing tests still pass (`go test ./internal/rpc/...` clean).

## Reproducer

Define an RPC:
```sql
-- @fluxbase:input { "trip_id?": "uuid", "trip_title?": "text" }
SELECT * FROM trips
WHERE ($trip_id IS NULL OR id = $trip_id)
   OR ($trip_title IS NOT NULL AND title ILIKE '%' || $trip_title || '%');
```

Call with one optional param:
```json
{ "trip_id": "abc-123" }
```

Before: `missing required parameters: [trip_title trip_title]`
After: `200 OK` with results; `trip_title` is NULL in the query (the `OR $trip_title IS NOT NULL` short-circuits).

## Severity

Medium. Not a security or data-loss issue, but makes the `?` convention misleading — RPC authors who follow the documented pattern hit confusing errors in production. Current workaround in Wayli: prompt the AI supervisor to always pass both `trip_id` AND `trip_title` (even as empty string) on every `get_trip_plan` call. Awkward.

## Related

- The `?` convention is documented in the Fluxbase RPC guide
- A separate but related issue (chatbot sync tenant_id race, RPC sync delete-create race) is tracked elsewhere

## Checklist

- [x] Code change compiles (`go build ./internal/rpc/...`)
- [x] All existing RPC tests pass (`go test ./internal/rpc/...`)
- [x] New tests added for optional injection, mixed required/optional, dedupe, fallbacks
- [x] No breaking changes — legacy procedures without `InputSchema` keep strict behavior
- [x] Defensive: malformed JSON doesn't panic
- [x] Commit message follows conventional commits (`fix(rpc):`) and explains the why
