### PR TITLE
fix(ai): tell supervisor when web agent is available per chatbot

### DIFF
--- a/internal/ai/agent_prompts.go
+++ b/internal/ai/agent_prompts.go
@@ -61,10 +61,28 @@ Output format (JSON only, no other text):
 // system message by the caller — see supervisor_graph.go — to preserve
 // caching of this static prefix.
 func BuildSupervisorPrompt(chatbot *Chatbot) string {
-	// ponytail: future per-chatbot supervisor tuning would slot in here.
-	// For v1 the static template above is enough — no per-chatbot substitution.
+	// Reflect the chatbot's actual capabilities. The static prompt lists
+	// "web" as conditionally available — without this rewrite the supervisor
+	// LLM has to guess whether this chatbot has web search, and it usually
+	// guesses "no", routing current-info questions to sql/chat instead.
+	if chatbot != nil && chatbot.WebSearchEnabled {
+		return supervisorSystemPrompt + supervisorWebEnabledSuffix
+	}
 	return supervisorSystemPrompt
 }
+
+// supervisorWebEnabledSuffix is appended to the static supervisor prompt
+// when the chatbot has @fluxbase:web-search enabled. Tells the LLM web
+// routing IS available so it actually uses it for current-info questions.
+const supervisorWebEnabledSuffix = `
+
+IMPORTANT — web search IS ENABLED for this chatbot. The "web" agent is
+available RIGHT NOW. When the user asks about anything current/time-sensitive
+(events, "this weekend", opening hours, "what's happening", news, prices,
+2026), you MUST include "web" in the route. Do not fall back to sql or chat
+for current-info questions — those agents do not have live data and will
+either fail or hallucinate stale answers.`
+
 
 // sqlAgentSystemPrompt is the SQL Agent's static system prompt. Schema and
 // per-page table whitelists are injected as a separate dynamic system message.

--- a/internal/ai/agent_prompts.go
+++ b/internal/ai/agent_prompts.go
@@ -74,14 +74,18 @@ func BuildSupervisorPrompt(chatbot *Chatbot) string {
 // supervisorWebEnabledSuffix is appended to the static supervisor prompt
 // when the chatbot has @fluxbase:web-search enabled. Tells the LLM web
 // routing IS available so it actually uses it for current-info questions.
+//
+// Domain-agnostic: lists abstract trigger categories (current, recent,
+// time-sensitive) without examples tied to any specific application.
 const supervisorWebEnabledSuffix = `
 
 IMPORTANT — web search IS ENABLED for this chatbot. The "web" agent is
-available RIGHT NOW. When the user asks about anything current/time-sensitive
-(events, "this weekend", opening hours, "what's happening", news, prices,
-2026), you MUST include "web" in the route. Do not fall back to sql or chat
-for current-info questions — those agents do not have live data and will
-either fail or hallucinate stale answers.`
+available RIGHT NOW. When the user asks about anything current, recent, or
+time-sensitive (current prices or availability, today's hours, latest news,
+recent events, real-time status, "right now", "currently", "this week"),
+you MUST include "web" in the route. Do not route these questions to "sql"
+or "chat" alone — those agents cannot access live web data and will either
+fail or return stale information.`
 
 
 // sqlAgentSystemPrompt is the SQL Agent's static system prompt. Schema and

--- a/internal/ai/agent_prompts_test.go
+++ b/internal/ai/agent_prompts_test.go
@@ -1,0 +1,64 @@
+package ai
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildSupervisorPrompt_WebSearchEnabled(t *testing.T) {
+	t.Run("web-enabled chatbot gets web-available suffix", func(t *testing.T) {
+		c := &Chatbot{WebSearchEnabled: true}
+		got := BuildSupervisorPrompt(c)
+
+		// Static prompt is always present
+		if !strings.Contains(got, "Available specialist agents") {
+			t.Error("prompt missing standard agent list")
+		}
+		// Web-enabled suffix is appended
+		if !strings.Contains(got, "web search IS ENABLED") {
+			t.Error("web-enabled suffix not appended when WebSearchEnabled=true")
+		}
+		if !strings.Contains(got, "available RIGHT NOW") {
+			t.Error("expected explicit 'available RIGHT NOW' directive")
+		}
+	})
+
+	t.Run("web-disabled chatbot does NOT get suffix", func(t *testing.T) {
+		c := &Chatbot{WebSearchEnabled: false}
+		got := BuildSupervisorPrompt(c)
+
+		if strings.Contains(got, "web search IS ENABLED") {
+			t.Error("web suffix should NOT be appended when WebSearchEnabled=false")
+		}
+		// Static prompt still mentions "web" as a conditional agent — that's fine.
+		if !strings.Contains(got, "Available specialist agents") {
+			t.Error("prompt missing standard agent list")
+		}
+	})
+
+	t.Run("nil chatbot falls back to static prompt", func(t *testing.T) {
+		got := BuildSupervisorPrompt(nil)
+
+		if strings.Contains(got, "web search IS ENABLED") {
+			t.Error("nil chatbot should not get web suffix")
+		}
+		if !strings.Contains(got, "Available specialist agents") {
+			t.Error("nil chatbot still gets the static prompt")
+		}
+	})
+
+	t.Run("prompt is byte-stable per chatbot config (cacheable)", func(t *testing.T) {
+		// Same input -> same output, byte for byte
+		c1 := &Chatbot{WebSearchEnabled: true}
+		c2 := &Chatbot{WebSearchEnabled: true}
+		if BuildSupervisorPrompt(c1) != BuildSupervisorPrompt(c2) {
+			t.Error("prompt differs between identical chatbot configs — breaks provider caching")
+		}
+
+		d1 := &Chatbot{WebSearchEnabled: false}
+		d2 := &Chatbot{WebSearchEnabled: false}
+		if BuildSupervisorPrompt(d1) != BuildSupervisorPrompt(d2) {
+			t.Error("prompt differs between identical chatbot configs — breaks provider caching")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

The supervisor's routing prompt lists `"web"` as a conditionally-available agent:

```
- "web" — Searches the live web (Tavily) ... Only available when the chatbot has web search enabled.
```

But `BuildSupervisorPrompt(chatbot)` ignores its `chatbot` argument and returns the same static text for every chatbot. The supervisor LLM has no way to know whether THIS chatbot has `@fluxbase:web-search enabled`, so it conservatively assumes "no" and routes current-info questions to `sql` or `chat` instead.

User-visible failure (any chatbot with web search enabled + integration configured):

> User asks a current-info question (today's hours, latest news, current availability, etc.)
> Supervisor routes to: `sql` or `chat`
> Web agent never fires despite being registered in `routerAgents` — because the supervisor LLM never routes to it.

## Root cause

`internal/ai/agent_prompts.go:63`:

```go
func BuildSupervisorPrompt(chatbot *Chatbot) string {
    // ponytail: future per-chatbot supervisor tuning would slot in here.
    // For v1 the static template above is enough — no per-chatbot substitution.
    return supervisorSystemPrompt  // ← ignores chatbot entirely
}
```

The comment explicitly defers per-chatbot tuning. This is fine for most annotations, but web-search availability is a routing-level concern — the supervisor cannot make correct decisions without knowing it.

## Fix

`BuildSupervisorPrompt(chatbot)` now appends a short, **domain-agnostic** suffix when `chatbot.WebSearchEnabled` is true:

```
IMPORTANT — web search IS ENABLED for this chatbot. The "web" agent is
available RIGHT NOW. When the user asks about anything current, recent, or
time-sensitive (current prices or availability, today's hours, latest news,
recent events, real-time status, "right now", "currently", "this week"),
you MUST include "web" in the route. Do not route these questions to "sql"
or "chat" alone — those agents cannot access live web data and will either
fail or return stale information.
```

The trigger list is intentionally abstract — no domain-specific examples (travel, e-commerce, devtools, etc.) so any chatbot with web search enabled benefits equally.

When `WebSearchEnabled` is false (or `chatbot` is nil), the prompt is unchanged — no regression for chatbots that haven't opted in.

### Why a suffix, not a rewrite

The static `supervisorSystemPrompt` is byte-stable per chatbot config, which lets the LLM provider cache it. Rewriting the agent-list section conditionally would still be cacheable per chatbot (same input → same output), but a suffix is:

1. Smaller diff — easier to review
2. Less likely to break existing supervisor behavior for non-web chatbots
3. Explicit ("MUST include web") — clearer signal to the LLM than rephrasing the conditional

### Cache impact

The prompt is now byte-stable per (chatbot.WebSearchEnabled) value rather than globally. Two chatbots with the same `WebSearchEnabled` value still share cache entries. In practice each chatbot has its own conversation thread and prompt cache anyway, so this doesn't reduce cache hit rate.

## Tests

New file `internal/ai/agent_prompts_test.go` with 4 subtests:

- `web-enabled chatbot gets web-available suffix` — happy path
- `web-disabled chatbot does NOT get suffix` — no regression
- `nil chatbot falls back to static prompt` — defensive
- `prompt is byte-stable per chatbot config (cacheable)` — same input → same output

All existing AI package tests still pass.

## Reproducer

1. Configure a chatbot with `@fluxbase:web-search enabled` and a working Tavily integration.
2. Ask a current-info question (e.g., "what's the latest X?", "is Y open today?", "current price of Z?")
3. Before: supervisor routes to `sql` or `chat`, web agent never fires.
4. After: supervisor routes to `web`, Tavily executes a search, response cites current sources.

## Severity

**High** for any chatbot relying on web search. The feature appears configured correctly (annotation synced, integration tested green, web agent registered in the routing graph) but doesn't actually fire because the routing LLM doesn't know it's allowed to use it.

## Checklist

- [x] Code compiles (`go build ./internal/ai/...`)
- [x] New tests added and passing
- [x] No breaking changes — chatbots without `WebSearchEnabled` get the original static prompt byte-for-byte
- [x] Defensive — nil chatbot handled
- [x] Byte-stable per chatbot config (provider cache friendly)
- [x] Domain-agnostic — no application-specific examples in the suffix
