### PR TITLE
fix(ai): make web-enabled suffix principle-based, not phrase-based

### DIFF
--- a/internal/ai/agent_prompts.go
+++ b/internal/ai/agent_prompts.go
@@ -75,17 +75,39 @@ func BuildSupervisorPrompt(chatbot *Chatbot) string {
 // when the chatbot has @fluxbase:web-search enabled. Tells the LLM web
 // routing IS available so it actually uses it for current-info questions.
 //
-// Domain-agnostic: lists abstract trigger categories (current, recent,
-// time-sensitive) without examples tied to any specific application.
+// Domain-agnostic and principle-based: focuses on the abstract category
+// (anything needing fresh/live data) rather than enumerating trigger
+// phrases, which the LLM might take too literally.
 const supervisorWebEnabledSuffix = `
 
 IMPORTANT — web search IS ENABLED for this chatbot. The "web" agent is
-available RIGHT NOW. When the user asks about anything current, recent, or
-time-sensitive (current prices or availability, today's hours, latest news,
-recent events, real-time status, "right now", "currently", "this week"),
-you MUST include "web" in the route. Do not route these questions to "sql"
-or "chat" alone — those agents cannot access live web data and will either
-fail or return stale information.`
+available RIGHT NOW.
+
+ROUTE TO "web" whenever the user's question needs fresh, live, or
+time-bound information that is NOT already in the database or knowledge
+base. This includes:
+
+- Any question about a specific timeframe (today, this week, this weekend,
+  this month, this year, next week, next weekend, next month, in <year>,
+  on <date>, "right now", "currently", "lately", "recently", "still")
+- Any question about current state (current prices, today's hours, current
+  availability, latest version, who currently holds <role>, recent changes)
+- Any question about events, news, releases, or happenings — past or future
+- Any "what's new" / "what's changed" / "is X still <adjective>" framing
+
+When in doubt, include "web" in the route — over-routing is cheap,
+under-routing produces stale or hallucinated answers.
+
+Do NOT route these questions to "sql" or "chat" alone. Those agents
+cannot access live web data and will either fail or return stale
+information. If the question has a database/static component too (e.g.,
+"compare my past visits to what's currently open"), route to BOTH "sql"
+and "web". If the question is ambiguous about dates, route to "web"
+anyway — the web agent can search broadly and refine.
+
+Never ask the user to clarify a current-info question before routing —
+route first, then the web agent's answer will surface relevant specifics.`
+
 
 
 // sqlAgentSystemPrompt is the SQL Agent's static system prompt. Schema and


### PR DESCRIPTION
Follow-up to PR #257. Same fix, stronger prompt.

## What changed

PR #257 made `BuildSupervisorPrompt(chatbot)` append a suffix when `chatbot.WebSearchEnabled`. The suffix told the supervisor LLM that web routing is available and listed trigger phrases: `"right now"`, `"currently"`, `"this week"`.

**Problem:** the supervisor LLM took the phrase list literally. A user asked "What are some fun activities happening **next weekend** in Berlin?" — `next weekend` was not in the trigger list, so the supervisor routed to `chat` (asking the user to clarify the dates) instead of `web`. Tavily never fired.

## Root cause

Phrase-list framing has two failure modes:

1. **Brittle:** any temporal phrase NOT in the list gets missed. There are dozens of valid temporal references (`next month`, `in 2026`, `lately`, `still`, `on <date>`, etc.) — enumerating all of them is futile.
2. **Conservative interpretation:** the LLM treats the enumerated list as exhaustive, defaulting to non-web routing for anything outside it.

## Fix

Rewrote the suffix as **principle-based**:

> Route to "web" whenever the user's question needs fresh, live, or time-bound information that is NOT already in the database or knowledge base.

The principle is domain-agnostic (applies to any chatbot — travel, devtools, e-commerce, news). Examples follow but are explicitly non-exhaustive:

- Any question about a specific timeframe (today, this week, this weekend, this month, this year, next week, next weekend, next month, in \<year\>, on \<date\>, "right now", "currently", "lately", "recently", "still")
- Any question about current state (current prices, today's hours, current availability, latest version, who currently holds \<role\>, recent changes)
- Any question about events, news, releases, or happenings — past or future
- Any "what's new" / "what's changed" / "is X still \<adjective\>" framing

Two directives the previous version missed:

- **"When in doubt, include web"** — over-routing is cheap, under-routing produces stale or hallucinated answers. This flips the default from conservative to liberal for web-enabled chatbots.
- **"Never ask the user to clarify a current-info question before routing"** — directly fixes the failure mode we saw. The supervisor was asking "did you mean Aug 1-2 or Jul 25-26?" instead of just searching. The web agent can search broadly and refine.

## Why principle-based, not list-based

LLMs are good at categorizing abstract concepts ("is this question about current information?") and bad at exhaustive string matching against a list. The principle-based prompt leverages the model's strength.

This also means the prompt ages well — new temporal phrases (`next quarter`, `in 2027`, etc.) don't require prompt updates because they fit the abstract category.

## Tests

Existing tests in `internal/ai/agent_prompts_test.go` still pass — they assert:
- Suffix is appended when `WebSearchEnabled=true`
- Not appended when `false` or `nil`
- Byte-stable per chatbot config

The new suffix still contains the assertions' key phrases (`"available RIGHT NOW"`, `"web search IS ENABLED"`).

## Reproducer

Same as before — chatbot with `@fluxbase:web-search enabled` + Tavily integration. User asks "what's happening next weekend in [city]?"

- Before (PR #257): supervisor routes to `chat`, asks for clarification, Tavily never fires
- After (this PR): supervisor routes to `web`, Tavily executes, response cites current sources

## Severity

High — PR #257 was necessary but not sufficient. Without this follow-up, web search still doesn't fire for many valid current-info questions, just different ones.

## Checklist

- [x] Code compiles
- [x] Existing tests pass unchanged
- [x] Domain-agnostic — no application-specific examples
- [x] Principle-based framing (not exhaustive phrase list)
