### PR TITLE
style(ai): collapse extra blank lines in agent_prompts.go (gofumpt)

### DIFF
--- a/internal/ai/agent_prompts.go
+++ b/internal/ai/agent_prompts.go
@@ -108,8 +108,6 @@ anyway — the web agent can search broadly and refine.
 Never ask the user to clarify a current-info question before routing —
 route first, then the web agent's answer will surface relevant specifics.`
 
-
-
 // sqlAgentSystemPrompt is the SQL Agent's static system prompt. Schema and
 // per-page table whitelists are injected as a separate dynamic system message.
 const sqlAgentSystemPrompt = `You are the SQL Agent in a multi-agent chatbot system. Your job is to investigate factual data questions by running SQL queries against the database.


### PR DESCRIPTION
## Summary

CI's \`golangci-lint run\` was failing:

\`\`\`
internal/ai/agent_prompts.go:111:1: File is not properly formatted (gofumpt)
\`\`\`

Two consecutive blank lines between \`supervisorSystemPrompt\` and \`sqlAgentSystemPrompt\` — gofumpt wants exactly one. Pure whitespace change, no behavior diff.

## Test plan

- [x] \`gofumpt -l .\` — 0 files
- [x] \`golangci-lint run --timeout 10m ./internal/... ./cmd/... ./cli/...\` — 0 issues