### PR TITLE
fix(rpc): parse multi-line @fluxbase:input and @fluxbase:output JSON specs

### DIFF
--- a/internal/rpc/parser.go
+++ b/internal/rpc/parser.go
@@ -43,6 +43,14 @@ func ParseAnnotations(code string) (*Annotations, string, error) {
 	// Parse input schema
 	if matches := inputPattern.FindStringSubmatch(code); len(matches) > 1 {
 		input := strings.TrimSpace(matches[1])
+		// ponytail: multi-line @fluxbase:input blocks. The single-line regex
+		// only captures the first line — for multi-line JSON the first line
+		// is just "{" or "{ "field?":"text",". extractJSONObject scans forward
+		// in the source collecting subsequent "-- ..." lines until braces
+		// balance, then we parse the assembled string as JSON.
+		if input == "{" || (strings.HasPrefix(input, "{") && !strings.HasSuffix(strings.TrimSpace(input), "}")) {
+			input = extractMultilineAnnotationValue(code, inputPattern, input)
+		}
 		if input != "any" && input != "" {
 			schema, err := parseSchemaString(input)
 			if err == nil {
@@ -54,6 +62,9 @@ func ParseAnnotations(code string) (*Annotations, string, error) {
 	// Parse output schema
 	if matches := outputPattern.FindStringSubmatch(code); len(matches) > 1 {
 		output := strings.TrimSpace(matches[1])
+		if output == "{" || (strings.HasPrefix(output, "{") && !strings.HasSuffix(strings.TrimSpace(output), "}")) {
+			output = extractMultilineAnnotationValue(code, outputPattern, output)
+		}
 		if output != "any" && output != "" {
 			schema, err := parseSchemaString(output)
 			if err == nil {
@@ -134,6 +145,118 @@ func ParseAnnotations(code string) (*Annotations, string, error) {
 	sqlQuery := extractSQLQuery(code)
 
 	return annotations, sqlQuery, nil
+}
+
+// extractMultilineAnnotationValue assembles a multi-line JSON annotation value
+// when the single-line regex only captured the opening brace(s).
+//
+// Background: inputPattern/outputPattern use `^(?m)--\s*@fluxbase:input (.+)$`
+// which matches only the first line. For a multi-line spec like:
+//
+//	-- @fluxbase:input {
+//	--   "trip_id?": "uuid",
+//	--   "trip_title?": "text"
+//	-- }
+//
+// the regex captures only "{", which fails JSON parsing. This helper finds
+// the annotation's start position in `code`, then scans forward collecting
+// subsequent `-- ...` lines (stripping the comment prefix) until the JSON
+// braces balance, and returns the assembled single-string JSON.
+//
+// `initial` is the value already captured by the regex; returned as-is when
+// braces already balance (the common single-line case).
+func extractMultilineAnnotationValue(code string, startRe *regexp.Regexp, initial string) string {
+	if balancedBraces(initial) {
+		return initial
+	}
+	loc := startRe.FindStringSubmatchIndex(code)
+	if loc == nil || len(loc) < 4 {
+		return initial
+	}
+	// Submatch index layout: [fullStart, fullEnd, groupStart, groupEnd].
+	// Group 1 is the captured value.
+	groupStart, groupEnd := loc[2], loc[3]
+	if groupStart < 0 || groupEnd < 0 || groupEnd > len(code) {
+		return initial
+	}
+
+	// Scan forward from the end of the captured first line.
+	var sb strings.Builder
+	sb.WriteString(code[groupStart:groupEnd])
+
+	// Walk subsequent lines. Each must start with `--` (after optional
+	// leading whitespace) to count as a continuation of the annotation.
+	// Stop at the first non-comment line or when braces balance.
+	pos := groupEnd
+	for pos < len(code) {
+		// Find the next newline.
+		nl := strings.IndexByte(code[pos:], '\n')
+		var line string
+		if nl < 0 {
+			line = code[pos:]
+			pos = len(code)
+		} else {
+			line = code[pos : pos+nl]
+			pos += nl + 1
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// Must be a SQL comment line (`-- ...`).
+		if !strings.HasPrefix(trimmed, "--") {
+			break
+		}
+		content := strings.TrimSpace(strings.TrimPrefix(trimmed, "--"))
+		// Stop if this is a new annotation (`@fluxbase:`).
+		if strings.HasPrefix(content, "@fluxbase:") {
+			break
+		}
+		sb.WriteString(content)
+		if balancedBraces(sb.String()) {
+			break
+		}
+	}
+	assembled := strings.TrimSpace(sb.String())
+	if balancedBraces(assembled) {
+		return assembled
+	}
+	return initial
+}
+
+// balancedBraces returns true if `s` has balanced `{` and `}` characters,
+// ignoring braces inside double-quoted strings. Good enough for the JSON
+// annotation use case — we don't need a full JSON parser here.
+func balancedBraces(s string) bool {
+	depth := 0
+	inString := false
+	escaped := false
+	for _, r := range s {
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch r {
+		case '\\':
+			if inString {
+				escaped = true
+			}
+		case '"':
+			inString = !inString
+		case '{':
+			if !inString {
+				depth++
+			}
+		case '}':
+			if !inString {
+				depth--
+				if depth < 0 {
+					return false
+				}
+			}
+		}
+	}
+	return depth == 0 && !inString
 }
 
 // parseSchemaString parses a JSON-like schema string into a map

--- a/internal/rpc/parser_test.go
+++ b/internal/rpc/parser_test.go
@@ -116,6 +116,126 @@ ORDER BY u.name;`
 	})
 }
 
+func TestParseAnnotations_MultilineInputSchema(t *testing.T) {
+	t.Run("multi-line @fluxbase:input block parses correctly", func(t *testing.T) {
+		code := `-- @fluxbase:name search_journal_entries
+-- @fluxbase:description Search journal entries.
+-- @fluxbase:require-role authenticated
+-- @fluxbase:input {
+--   "trip_title?": "text",
+--   "search_text?": "text",
+--   "date_range?": "text",
+--   "limit?": "integer"
+-- }
+-- @fluxbase:allowed-tables my_trip_entries
+-- @fluxbase:max-execution-time 30s
+
+SELECT id, title FROM my_trip_entries;
+`
+		annotations, _, err := ParseAnnotations(code)
+		require.NoError(t, err)
+		require.NotNil(t, annotations.InputSchema, "InputSchema must be populated for multi-line input")
+
+		assert.Equal(t, "text", annotations.InputSchema["trip_title?"])
+		assert.Equal(t, "text", annotations.InputSchema["search_text?"])
+		assert.Equal(t, "text", annotations.InputSchema["date_range?"])
+		assert.Equal(t, "integer", annotations.InputSchema["limit?"])
+	})
+
+	t.Run("single-line @fluxbase:input still works (no regression)", func(t *testing.T) {
+		code := `-- @fluxbase:name get_trip_plan
+-- @fluxbase:input { "trip_id?": "uuid", "trip_title?": "text" }
+
+SELECT * FROM trips;
+`
+		annotations, _, err := ParseAnnotations(code)
+		require.NoError(t, err)
+		require.NotNil(t, annotations.InputSchema)
+
+		assert.Equal(t, "uuid", annotations.InputSchema["trip_id?"])
+		assert.Equal(t, "text", annotations.InputSchema["trip_title?"])
+	})
+
+	t.Run("multi-line @fluxbase:output block parses correctly", func(t *testing.T) {
+		code := `-- @fluxbase:name my_proc
+-- @fluxbase:output {
+--   "count": "integer",
+--   "items": "jsonb"
+-- }
+
+SELECT 1;
+`
+		annotations, _, err := ParseAnnotations(code)
+		require.NoError(t, err)
+		require.NotNil(t, annotations.OutputSchema, "OutputSchema must be populated for multi-line output")
+
+		assert.Equal(t, "integer", annotations.OutputSchema["count"])
+		assert.Equal(t, "jsonb", annotations.OutputSchema["items"])
+	})
+
+	t.Run("multi-line annotation stops at the next @fluxbase: annotation", func(t *testing.T) {
+		// If the multi-line collector doesn't stop at the next annotation, it
+		// would consume `-- @fluxbase:allowed-tables ...` as JSON content
+		// and the JSON parse would fail.
+		code := `-- @fluxbase:name my_proc
+-- @fluxbase:input {
+--   "trip_id?": "uuid"
+-- }
+-- @fluxbase:allowed-tables my_trips
+-- @fluxbase:require-role authenticated
+
+SELECT 1;
+`
+		annotations, _, err := ParseAnnotations(code)
+		require.NoError(t, err)
+		require.NotNil(t, annotations.InputSchema)
+		assert.Equal(t, "uuid", annotations.InputSchema["trip_id?"])
+		assert.Equal(t, []string{"my_trips"}, annotations.AllowedTables)
+		assert.Equal(t, []string{"authenticated"}, annotations.RequireRoles)
+	})
+
+	t.Run("input 'any' short-circuit still works", func(t *testing.T) {
+		code := `-- @fluxbase:name my_proc
+-- @fluxbase:input any
+
+SELECT 1;
+`
+		annotations, _, err := ParseAnnotations(code)
+		require.NoError(t, err)
+		// Default schema (empty map or nil depending on DefaultAnnotations impl)
+		// The key assertion: no panic, no error.
+		_ = annotations
+	})
+
+	t.Run("malformed multi-line JSON falls back gracefully", func(t *testing.T) {
+		// No closing brace — extractMultilineAnnotationValue can't balance,
+		// returns the original capture. parseSchemaString then fails, schema
+		// stays empty. No panic.
+		code := `-- @fluxbase:name my_proc
+-- @fluxbase:input {
+--   "trip_id?": "uuid"
+-- whoops no closing brace
+
+SELECT 1;
+`
+		annotations, _, err := ParseAnnotations(code)
+		require.NoError(t, err)
+		// InputSchema is nil/empty because the JSON didn't parse
+		assert.True(t, annotations.InputSchema == nil || len(annotations.InputSchema) == 0)
+	})
+
+	t.Run("balancedBraces helper", func(t *testing.T) {
+		assert.True(t, balancedBraces(`{}`))
+		assert.True(t, balancedBraces(`{"a":"b"}`))
+		assert.True(t, balancedBraces(`{"a":"{not real}"}`)) // braces inside string ignored
+		assert.True(t, balancedBraces(`{}`))
+		assert.False(t, balancedBraces(`{`))
+		assert.False(t, balancedBraces(`}`))
+		assert.False(t, balancedBraces(`{"a": "b"`))
+		assert.False(t, balancedBraces(`{"unterminated": "string`))
+	})
+}
+
 func TestParseSchemaString(t *testing.T) {
 	t.Run("parses JSON format", func(t *testing.T) {
 		input := `{"id": "uuid", "name": "string", "age": "number"}`


### PR DESCRIPTION
## Problem

The RPC parser regex for `@fluxbase:input` and `@fluxbase:output` only captures a single line:

```go
inputPattern = regexp.MustCompile(`(?m)^--\s*@fluxbase:input\s+(.+)$`)
```

For multi-line JSON specs (common when authors indent for readability):

```sql
-- @fluxbase:input {
--   "trip_title?": "text",
--   "search_text?": "text",
--   "date_range?": "text",
--   "limit?": "integer"
-- }
```

The regex captures only `{` → JSON parse fails → `input_schema` ends up **empty in the database**. Verified in production:

```
search_journal_entries | (empty)        ← multi-line spec, broken
search_visits          | (empty)        ← multi-line spec, broken
get_trip_plan          | {"trip_id?": ...}  ← single-line spec, works
```

Downstream impact: the executor's optional-param injection (PR #256) checks `len(procedure.InputSchema) > 0` before injecting NULL for omitted optional params. With empty schema, it falls back to strict mode and rejects calls that omit any SQL-referenced param — even when those params are declared optional:

```
POST /rpc/search_journal_entries { "search_text": "Berlin" }
→ 400 "missing required parameters: [trip_title date_range limit]"
```

## Root cause

`internal/rpc/parser.go:18`:

```go
inputPattern = regexp.MustCompile(`(?m)^--\s*@fluxbase:input\s+(.+)$`)
```

The `.+` is anchored to a single line by `$` in multiline mode. Multi-line JSON has no chance.

## Fix

Two-part change in `internal/rpc/parser.go`:

### 1. Detection

In `ParseAnnotations`, when the single-line regex matches but the captured value is `{` or starts with `{` without a closing `}`, treat it as the start of a multi-line spec and call the new `extractMultilineAnnotationValue` helper.

### 2. Helper

`extractMultilineAnnotationValue(code, startRe, initial)`:

- Returns `initial` unchanged if braces already balance (the common single-line case — fast path).
- Otherwise finds the annotation's position in `code` and walks subsequent lines.
- Each subsequent line must start with `--` to count as a continuation.
- Stops at the first non-comment line OR the next `@fluxbase:` annotation (so it doesn't consume following annotations).
- Stops when `balancedBraces` returns true.
- Returns the assembled single-string JSON.

`balancedBraces(s)` — small helper that counts `{`/`}` ignoring braces inside double-quoted strings. Not a full JSON parser, but enough for the annotation use case.

### Safety

- **Single-line case (the existing common pattern):** `extractMultilineAnnotationValue` short-circuits via `balancedBraces(initial)`. No behavior change.
- **Malformed JSON:** falls back to `initial` (the original capture), `parseSchemaString` then fails as before, schema stays empty. No panic.
- **`@fluxbase:input any`:** short-circuited before the multi-line check.
- **Annotation followed immediately by another annotation** (e.g. `@fluxbase:input {...}` then `@fluxbase:allowed-tables`): the scan stops at `@fluxbase:` so it doesn't consume the next annotation.

## Tests

New `TestParseAnnotations_MultilineInputSchema` with 7 subtests:

- `multi-line @fluxbase:input block parses correctly` — core fix
- `single-line @fluxbase:input still works (no regression)`
- `multi-line @fluxbase:output block parses correctly`
- `multi-line annotation stops at the next @fluxbase: annotation`
- `input 'any' short-circuit still works`
- `malformed multi-line JSON falls back gracefully`
- `balancedBraces helper`

All existing RPC parser tests still pass (`go test ./internal/rpc/...`).

## Reproducer

Define an RPC with a multi-line `@fluxbase:input`:

```sql
-- @fluxbase:name multi_line_test
-- @fluxbase:input {
--   "foo?": "text",
--   "bar?": "integer"
-- }
SELECT $foo::text, $bar::integer;
```

Sync and check the DB row:

```sql
SELECT input_schema FROM rpc.procedures WHERE name='multi_line_test';
```

Before: empty.
After: `{"bar?":"integer","foo?":"text"}`.

And the optional-param injection from PR #256 now fires:

```
POST /rpc/multi_line_test {}
→ 200 OK (both params NULL)
```

## Severity

Medium-high. Silent data corruption: the procedure appears synced but the schema is wrong. Any RPC author following the multi-line pattern (natural for readability with 4+ params) hits confusing "missing required parameters" errors in production.

## Related

- Wayli repo's `fluxbase/rpc/` directory had 3 RPCs affected by this — worked around locally by collapsing to single-line in commit `f45e94f`.
- PR #256 (optional-param injection) is necessary but not sufficient without this fix — the executor can't know which params are optional without `input_schema` populated.

## Checklist

- [x] Code compiles (`go build ./internal/rpc/...`)
- [x] All existing RPC tests pass (`go test ./internal/rpc/...`)
- [x] New tests added: 7 subtests covering multi-line input, multi-line output, no-regression for single-line, edge cases
- [x] No breaking changes — single-line case fast-paths via `balancedBraces(initial)`
- [x] Defensive: malformed JSON doesn't panic, falls back gracefully
- [x] Comment-prefix-aware: scan stops at non-comment lines and `@fluxbase:` annotations
