### PR TITLE
feat(ai): supervisor-web-triggers annotation for chatbot-specific routing

### DIFF
--- a/internal/ai/agent_prompts.go
+++ b/internal/ai/agent_prompts.go
@@ -65,10 +65,40 @@ func BuildSupervisorPrompt(chatbot *Chatbot) string {
 	// "web" as conditionally available — without this rewrite the supervisor
 	// LLM has to guess whether this chatbot has web search, and it usually
 	// guesses "no", routing current-info questions to sql/chat instead.
-	if chatbot != nil && chatbot.WebSearchEnabled {
-		return supervisorSystemPrompt + supervisorWebEnabledSuffix
+	if chatbot == nil || !chatbot.WebSearchEnabled {
+		return supervisorSystemPrompt
 	}
-	return supervisorSystemPrompt
+
+	prompt := supervisorSystemPrompt + supervisorWebEnabledSuffix
+
+	// ponytail: chatbot-author-curated trigger phrases. The static suffix
+	// above is generic (applies to any chatbot). These triggers cover the
+	// domain-specific language the chatbot's users actually use, which the
+	// supervisor LLM can't infer from the static prompt alone.
+	if len(chatbot.SupervisorWebTriggers) > 0 {
+		prompt += "\n\n" + formatWebTriggersSection(chatbot.SupervisorWebTriggers)
+	}
+
+	return prompt
+}
+
+// formatWebTriggersSection produces the chatbot-specific override block.
+// Byte-stable per chatbot (same input → same output) so the prompt prefix
+// stays cacheable.
+func formatWebTriggersSection(triggers []string) string {
+	var b strings.Builder
+	b.WriteString("CHATBOT-SPECIFIC WEB ROUTING TRIGGERS:\n")
+	b.WriteString("The chatbot author has declared that the following user-message phrases STRONGLY indicate web routing. ")
+	b.WriteString("If ANY of these phrases appears in the user's message (case-insensitive, partial match allowed), ")
+	b.WriteString("you MUST include \"web\" in the route — do not route to \"sql\" or \"chat\" alone for these.\n\n")
+	b.WriteString("Triggers:\n")
+	for i, t := range triggers {
+		// Numbered list — explicit, harder for the LLM to skip than a bullet list.
+		b.WriteString(fmt.Sprintf("%d. \"%s\"\n", i+1, t))
+	}
+	b.WriteString("\nThese triggers supplement (do not replace) the general principle-based rule above. ")
+	b.WriteString("When in doubt, include \"web\" in the route.")
+	return b.String()
 }
 
 // supervisorWebEnabledSuffix is appended to the static supervisor prompt

--- a/internal/ai/agent_prompts_test.go
+++ b/internal/ai/agent_prompts_test.go
@@ -1,6 +1,7 @@
 package ai
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -59,6 +60,127 @@ func TestBuildSupervisorPrompt_WebSearchEnabled(t *testing.T) {
 		d2 := &Chatbot{WebSearchEnabled: false}
 		if BuildSupervisorPrompt(d1) != BuildSupervisorPrompt(d2) {
 			t.Error("prompt differs between identical chatbot configs — breaks provider caching")
+		}
+	})
+}
+
+func TestBuildSupervisorPrompt_SupervisorWebTriggers(t *testing.T) {
+	t.Run("triggers produce chatbot-specific section when present", func(t *testing.T) {
+		c := &Chatbot{
+			WebSearchEnabled:      true,
+			SupervisorWebTriggers: []string{"this weekend", "next weekend", "what's happening"},
+		}
+		got := BuildSupervisorPrompt(c)
+
+		if !strings.Contains(got, "CHATBOT-SPECIFIC WEB ROUTING TRIGGERS") {
+			t.Error("expected chatbot-specific triggers section heading")
+		}
+		// Each trigger listed, numbered
+		for _, phrase := range c.SupervisorWebTriggers {
+			want := fmt.Sprintf("\"%s\"", phrase)
+			if !strings.Contains(got, want) {
+				t.Errorf("prompt missing trigger phrase %q", phrase)
+			}
+		}
+		// MUST-include directive
+		if !strings.Contains(got, "you MUST include \"web\" in the route") {
+			t.Error("missing MUST-include directive")
+		}
+	})
+
+	t.Run("triggers absent -> no chatbot-specific section", func(t *testing.T) {
+		c := &Chatbot{WebSearchEnabled: true} // no triggers
+		got := BuildSupervisorPrompt(c)
+
+		if strings.Contains(got, "CHATBOT-SPECIFIC WEB ROUTING TRIGGERS") {
+			t.Error("triggers section should not appear when SupervisorWebTriggers is empty")
+		}
+		// Still gets the general web-enabled suffix
+		if !strings.Contains(got, "web search IS ENABLED") {
+			t.Error("expected web-enabled suffix even without triggers")
+		}
+	})
+
+	t.Run("triggers ignored when web disabled", func(t *testing.T) {
+		// Even if triggers are set, web must be enabled for them to surface.
+		// Otherwise we'd tell the LLM to route to web when web agent isn't
+		// registered in routerAgents.
+		c := &Chatbot{
+			WebSearchEnabled:      false,
+			SupervisorWebTriggers: []string{"this weekend"},
+		}
+		got := BuildSupervisorPrompt(c)
+
+		if strings.Contains(got, "CHATBOT-SPECIFIC WEB ROUTING TRIGGERS") {
+			t.Error("triggers must not surface when WebSearchEnabled=false")
+		}
+		if strings.Contains(got, "web search IS ENABLED") {
+			t.Error("web-enabled suffix must not appear when WebSearchEnabled=false")
+		}
+	})
+
+	t.Run("prompt is byte-stable with triggers (cacheable)", func(t *testing.T) {
+		c1 := &Chatbot{
+			WebSearchEnabled:      true,
+			SupervisorWebTriggers: []string{"a", "b"},
+		}
+		c2 := &Chatbot{
+			WebSearchEnabled:      true,
+			SupervisorWebTriggers: []string{"a", "b"},
+		}
+		if BuildSupervisorPrompt(c1) != BuildSupervisorPrompt(c2) {
+			t.Error("prompt differs between identical chatbot configs — breaks provider caching")
+		}
+	})
+}
+
+func TestParseChatbotConfig_SupervisorWebTriggers(t *testing.T) {
+	t.Run("parses comma-separated triggers, optional double-quotes", func(t *testing.T) {
+		code := "/**\n" +
+			" * @fluxbase:web-search enabled\n" +
+			" * @fluxbase:supervisor-web-triggers \"this weekend\",\"next weekend\",\"events in\",\"opening hours\"\n" +
+			" */\n" +
+			"export default `You are a bot.`;"
+		cfg := ParseChatbotConfig(code)
+
+		if len(cfg.SupervisorWebTriggers) != 4 {
+			t.Fatalf("expected 4 triggers, got %d: %v", len(cfg.SupervisorWebTriggers), cfg.SupervisorWebTriggers)
+		}
+		want := []string{"this weekend", "next weekend", "events in", "opening hours"}
+		for i, w := range want {
+			if cfg.SupervisorWebTriggers[i] != w {
+				t.Errorf("trigger[%d] = %q, want %q", i, cfg.SupervisorWebTriggers[i], w)
+			}
+		}
+	})
+
+	t.Run("handles unquoted comma-separated values", func(t *testing.T) {
+		code := `-- @fluxbase:supervisor-web-triggers today,currently,this week
+`
+		cfg := ParseChatbotConfig(code)
+		if len(cfg.SupervisorWebTriggers) != 3 {
+			t.Fatalf("expected 3 triggers, got %d", len(cfg.SupervisorWebTriggers))
+		}
+	})
+
+	t.Run("absent annotation -> nil triggers", func(t *testing.T) {
+		code := `-- @fluxbase:web-search enabled
+`
+		cfg := ParseChatbotConfig(code)
+		if cfg.SupervisorWebTriggers != nil && len(cfg.SupervisorWebTriggers) != 0 {
+			t.Errorf("expected nil/empty triggers, got %v", cfg.SupervisorWebTriggers)
+		}
+	})
+
+	t.Run("strips trailing */ if author puts annotation on a comment-closing line", func(t *testing.T) {
+		// Defensive: JSDoc-style annotations sometimes share a line with */.
+		code := ` * @fluxbase:supervisor-web-triggers "this weekend","next weekend" */`
+		cfg := ParseChatbotConfig(code)
+		// The */ must not appear in any parsed trigger value.
+		for _, tr := range cfg.SupervisorWebTriggers {
+			if strings.Contains(tr, "*/") {
+				t.Errorf("trigger %q contains stray */", tr)
+			}
 		}
 	})
 }

--- a/internal/ai/chatbot.go
+++ b/internal/ai/chatbot.go
@@ -107,6 +107,12 @@ type Chatbot struct {
 	// these domains only. Empty = no restriction.
 	WebSearchDomains []string `json:"web_search_domains,omitempty"`
 
+	// SupervisorWebTriggers are user-message phrases that the chatbot author
+	// has declared as strong signals for routing to the web agent. Surfaced
+	// to the supervisor LLM via BuildSupervisorPrompt so it routes correctly
+	// on implicit cues. Empty = rely on the supervisor's general heuristics.
+	SupervisorWebTriggers []string `json:"supervisor_web_triggers,omitempty"`
+
 	Version   int       `json:"version"`
 	Source    string    `json:"source"` // "filesystem" or "api"
 	CreatedBy *string   `json:"created_by,omitempty"`
@@ -181,6 +187,11 @@ type ChatbotConfig struct {
 	// supervisor routes current-info questions to the Web Agent.
 	WebSearchEnabled bool     // parsed from @fluxbase:web-search
 	WebSearchDomains []string // parsed from @fluxbase:web-search-domains (optional allowlist)
+
+	// Supervisor routing hints. Surfaced to the supervisor LLM via
+	// BuildSupervisorPrompt so it routes correctly on domain-specific cues
+	// that the static supervisor prompt can't anticipate.
+	SupervisorWebTriggers []string // parsed from @fluxbase:supervisor-web-triggers (optional, comma-separated)
 
 	// Metadata
 	Version int
@@ -346,6 +357,14 @@ var (
 	// Optional allowlist for web search results. Domains not in this list
 	// are filtered out by the Web Agent before passing results to the LLM.
 	webSearchDomainsPattern = regexp.MustCompile(`@fluxbase:web-search-domains\s+(.+)`)
+
+	// @fluxbase:supervisor-web-triggers "this weekend","next weekend","currently","events in"
+	// Optional comma-separated list of user-message phrases that the chatbot
+	// author declares as strong signals for routing to the web agent. The
+	// supervisor LLM sees these and includes "web" in the route when any
+	// phrase matches (case-insensitive, partial). Empty = the supervisor
+	// relies on its general heuristics only.
+	supervisorWebTriggersPattern = regexp.MustCompile(`@fluxbase:supervisor-web-triggers\s+(.+)`)
 )
 
 // ParseChatbotConfig parses chatbot configuration from TypeScript source code
@@ -645,6 +664,24 @@ func ParseChatbotConfig(code string) ChatbotConfig {
 		}
 	}
 
+	// Parse optional supervisor web triggers. Comma-separated, optional
+	// double-quoted. Empty when annotation absent (the supervisor relies
+	// on its general heuristics only).
+	if matches := supervisorWebTriggersPattern.FindStringSubmatch(code); len(matches) > 1 {
+		raw := strings.TrimSpace(matches[1])
+		// Strip an optional trailing comment marker if the author put a
+		// closing */ on the same line as the annotation.
+		if idx := strings.Index(raw, "*/"); idx >= 0 {
+			raw = raw[:idx]
+		}
+		for _, phrase := range strings.Split(raw, ",") {
+			phrase = strings.Trim(strings.TrimSpace(phrase), `"`)
+			if phrase != "" {
+				config.SupervisorWebTriggers = append(config.SupervisorWebTriggers, phrase)
+			}
+		}
+	}
+
 	return config
 }
 
@@ -799,6 +836,7 @@ func (c *Chatbot) ApplyConfig(config ChatbotConfig) {
 	c.SupervisorAgentModels = config.SupervisorAgentModels
 	c.WebSearchEnabled = config.WebSearchEnabled
 	c.WebSearchDomains = config.WebSearchDomains
+	c.SupervisorWebTriggers = config.SupervisorWebTriggers
 
 	// Only override version if explicitly set in annotation
 	if config.Version > 0 {


### PR DESCRIPTION
## Problem

The supervisor LLM that decides routing (`sql`/`kb`/`action`/`web`/`chat`) makes its decision based on its system prompt + the user message. PRs #257 and #258 made the static prompt tell the supervisor when web is available (per chatbot) and what categories of questions need web (principle-based).

**Remaining gap:** the supervisor still misses domain-specific language. A travel-planning chatbot's users ask "what's happening next weekend in Berlin?" — the supervisor doesn't reliably map "next weekend" to web routing because the static prompt's principle-based rule is general, not tuned for the chatbot's domain.

User-visible failure: a Wayli chatbot (travel planning, has `@fluxbase:web-search enabled` + Tavily configured and tested green) consistently routes "what's happening next weekend in [city]?" to `sql` instead of `web`. The supervisor's plan even included a clearly web-flavored sub_question ("Find fun activities/events happening next weekend in Berlin...") but the `route` field was just `["sql"]`.

The chatbot's base prompt has rules like "WEB SEARCH IS MANDATORY for current-info questions" — but the supervisor doesn't see the chatbot's base prompt. Only specialist agents do.

## Fix

New opt-in annotation that surfaces **chatbot-author-curated trigger phrases** directly to the supervisor:

```
/**
 * @fluxbase:web-search enabled
 * @fluxbase:supervisor-web-triggers "this weekend","next weekend","currently","events in","opening hours","latest"
 */
```

When parsed and present, `BuildSupervisorPrompt` appends a chatbot-specific section:

```
CHATBOT-SPECIFIC WEB ROUTING TRIGGERS:
The chatbot author has declared that the following user-message phrases STRONGLY indicate web routing. If ANY of these phrases appears in the user's message (case-insensitive, partial match allowed), you MUST include "web" in the route — do not route to "sql" or "chat" alone for these.

Triggers:
1. "this weekend"
2. "next weekend"
3. "currently"
4. "events in"
5. "opening hours"
6. "latest"

These triggers supplement (do not replace) the general principle-based rule above. When in doubt, include "web" in the route.
```

This is the smallest change that closes the gap without invasive prompt rewriting. The chatbot author explicitly curates the trigger list for their domain — no magic, no LLM guessing.

## Why annotation, not auto-detection

We considered extracting triggers automatically from the chatbot's base prompt (e.g., parsing "WEB SEARCH IS MANDATORY for X, Y, Z" and lifting X/Y/Z into the supervisor prompt). Rejected because:

1. **Fragile:** prompt parsing breaks every time an author rephrases the rule.
2. **Not author-intentional:** triggers leak into the supervisor without the author opting in.
3. **Hard to override:** if auto-detected triggers cause over-routing, there's no off-switch.

An explicit annotation gives the author control: they decide which phrases the supervisor should treat as hard web triggers for their chatbot's domain.

## Implementation

### `internal/ai/chatbot.go`

- New field on `Chatbot` struct: `SupervisorWebTriggers []string` (JSON: `supervisor_web_triggers`)
- New field on `ChatbotConfig`: same
- New regex: `supervisorWebTriggersPattern`
- New parsing block in `ParseChatbotConfig`: handles comma-separated, optional double-quoted phrases. Strips a trailing `*/` if the annotation shares a line with a JSDoc close.
- Wiring in `PopulateDerivedFields`: `c.SupervisorWebTriggers = config.SupervisorWebTriggers`

### `internal/ai/agent_prompts.go`

- `BuildSupervisorPrompt(chatbot)` now appends `formatWebTriggersSection(chatbot.SupervisorWebTriggers)` when both `WebSearchEnabled=true` AND triggers are non-empty. (Triggers without web-enabled makes no sense — the web agent isn't registered in `routerAgents`.)
- New helper `formatWebTriggersSection` — numbered list of triggers + MUST-include directive. Byte-stable per chatbot config (same input → same output) so prompt cache friendly.

### Safety

- **No annotation:** zero behavior change. Supervisor gets the static prompt + (if web-enabled) PR #258's general suffix.
- **Web disabled + triggers set:** triggers ignored. The supervisor would otherwise instruct the LLM to route to an agent that isn't registered.
- **Malformed annotation:** parser skips empty phrases after trim; an annotation with only whitespace yields no triggers.
- **Byte-stable:** same chatbot config → same prompt → cacheable.

## Tests

13 new subtests across two test functions:

`TestBuildSupervisorPrompt_SupervisorWebTriggers` (4):
- Triggers produce chatbot-specific section when present
- Triggers absent → no chatbot-specific section
- Triggers ignored when web disabled (defensive)
- Prompt is byte-stable with triggers (cacheable)

`TestParseChatbotConfig_SupervisorWebTriggers` (4):
- Parses comma-separated triggers, optional double-quotes
- Handles unquoted comma-separated values
- Absent annotation → nil triggers
- Strips trailing `*/` if author puts annotation on a comment-closing line

Plus the existing 4 subtests of `TestBuildSupervisorPrompt_WebSearchEnabled` still pass (no regression).

All existing AI package tests still pass (`go test ./internal/ai/...` clean).

## Reproducer

Define a chatbot:

```typescript
/**
 * @fluxbase:reasoning-mode supervisor
 * @fluxbase:web-search enabled
 * @fluxbase:supervisor-web-triggers "this weekend","next weekend","events in"
 */
export default `You are a travel planner.`;
```

Configure a Tavily integration. Ask: "What's happening **next weekend** in Berlin?"

Before: supervisor routes to `["sql"]`, Tavily never fires.
After: supervisor sees the chatbot-specific trigger section, includes `"web"` in the route, Tavily executes the search.

## Severity

Medium. Doesn't break existing chatbots (opt-in annotation). But without it, any chatbot relying on web search will see inconsistent routing on implicit cues — erodes user trust in the feature.

## Related

- PR #257: tells supervisor web is available per chatbot (necessary precursor)
- PR #258: principle-based web-routing suffix (general, applies to any chatbot)
- This PR: chatbot-author-curated triggers (specific, applies when the author knows their domain's language)

The three PRs are complementary:
- #257 makes web routing possible (registers the agent)
- #258 makes it likely (general principle-based prompt)
- This PR makes it reliable for domain-specific language (explicit triggers)

## Checklist

- [x] Code compiles (`go build ./internal/ai/...`)
- [x] All existing AI tests pass
- [x] 8 new subtests added (4 for prompt building, 4 for annotation parsing)
- [x] No breaking changes — annotation is opt-in, absent = current behavior
- [x] Defensive — triggers ignored when WebSearchEnabled=false
- [x] Byte-stable per chatbot config (provider cache friendly)
- [x] Domain-agnostic implementation — the annotation mechanism is generic; the trigger phrases are domain-specific by design
