### PR TITLE
fix(integrations): COALESCE nullable string columns to prevent NULL scan crash

### DIFF
--- a/internal/ai/integrations/storage.go
+++ b/internal/ai/integrations/storage.go
@@ -180,10 +180,14 @@ func scanIntegration(row pgx.Row) (*Integration, error) {
 
 // standardColumns is the SELECT column list used by all read queries.
 // Keep in sync with scanIntegration.
+// COALESCE on nullable string columns to avoid "cannot scan NULL into *string"
+// crashes when last_test_status / last_test_error / created_by haven't been
+// populated yet (e.g., a freshly-created integration that was never tested).
 const standardColumns = `
 	id, name, integration_type, provider, config,
-	enabled, is_default, last_tested_at, last_test_status, last_test_error,
-	created_at, updated_at, created_by, tenant_id
+	enabled, is_default, last_tested_at,
+	COALESCE(last_test_status, ''), COALESCE(last_test_error, ''),
+	created_at, updated_at, COALESCE(created_by, ''), tenant_id
 `
 
 // GetIntegration returns a single integration by ID. Decrypts secrets in


### PR DESCRIPTION
## Problem

`GetDefaultIntegration` crashes when `last_test_status` or `last_test_error` is NULL in the database:

```
web agent: resolve integration: GetDefaultIntegration:
can't scan into dest[8] (col: last_test_status): cannot scan NULL into *string
```

This is the default state for any freshly-created integration that hasn't been tested via the "Test connection" button yet. The crash causes the supervisor graph to fail, falling back to the ReAct loop — the web agent never runs, and current-info questions get generic training-data answers instead of Tavily search results.

## Root cause

`internal/ai/integrations/storage.go` line 94:

```go
type Integration struct {
    // ...
    LastTestStatus  string  `json:"last_test_status,omitempty"`   // NOT *string
    LastTestError   string  `json:"last_test_error,omitempty"`    // NOT *string
    CreatedBy       string  `json:"created_by,omitempty"`         // NOT *string
}
```

These are plain `string` fields, but the DB columns are nullable. When `row.Scan(&i.LastTestStatus)` encounters a NULL value, pgx rejects it: `cannot scan NULL into *string`.

The `standardColumns` constant (line 183) selects the raw column names without COALESCE:

```go
const standardColumns = `
    id, name, integration_type, provider, config,
    enabled, is_default, last_tested_at, last_test_status, last_test_error,
    created_at, updated_at, created_by, tenant_id
`
```

## Fix

COALESCE the nullable string columns at the SELECT level:

```go
const standardColumns = `
    id, name, integration_type, provider, config,
    enabled, is_default, last_tested_at,
    COALESCE(last_test_status, ''), COALESCE(last_test_error, ''),
    created_at, updated_at, COALESCE(created_by, ''), tenant_id
`
```

No struct changes needed — NULL becomes empty string before pgx sees it.

## Why COALESCE instead of changing struct types

Options considered:
1. **Change `LastTestStatus` to `*string`** — clean, but invasive. Every caller needs nil checks. The JSON serialization also changes (empty string → `""`, nil → omitted with `omitempty`).
2. **Use `sql.NullString`** — clean, but callers need `.String` accessor. Even more invasive.
3. **COALESCE in SELECT** — one-line change per column. No struct change. No caller change. Existing `omitempty` JSON tag still works (empty string is omitted). **This is the smallest correct fix.**

Same pattern as the `created_by` fix in PR #255 (which used a Go-side `var createdBy interface{}` check). COALESCE is cleaner because it handles the problem at the SQL level where it belongs.

## Reproducer

1. Create a Tavily integration via the admin API/UI
2. Do NOT click "Test connection"
3. Ask a chatbot (with `@fluxbase:web-search enabled`) a current-info question
4. Before: supervisor routes to web → web agent tries to resolve integration → crash on NULL `last_test_status` → fallback to ReAct → generic answer
5. After: supervisor routes to web → web agent resolves integration (NULL becomes `""`) → Tavily search executes → current answer with sources

## Severity

**High.** Blocks the entire web-search feature for any integration that hasn't been tested yet. Since "Test connection" is optional and many users will skip it, this affects every new Tavily setup.

## Checklist

- [x] Code compiles (`go build ./internal/ai/integrations/...`)
- [x] All existing integration tests pass (`go test ./internal/ai/integrations/...`)
- [x] No struct changes — purely SQL-level fix
- [x] Same pattern as PR #255 (created_by NULL handling)
