### PR TITLE
fix(integrations): response_time must be float64 not string

### DIFF
--- a/internal/ai/integrations/tavily.go
+++ b/internal/ai/integrations/tavily.go
@@ -75,9 +75,9 @@ type SearchItem struct {
 // tavilySearchResponse is the raw JSON shape from Tavily's /search endpoint.
 // We don't surface every field — only what the agent needs.
 type tavilySearchResponse struct {
-	QueryResponse string `json:"response_time"`
-	Answer        string `json:"answer,omitempty"`
-	Results       []struct {
+	ResponseTime float64 `json:"response_time"` // seconds (Tavily returns a number, not string)
+	Answer       string  `json:"answer,omitempty"`
+	Results      []struct {
 		Title   string  `json:"title"`
 		URL     string  `json:"url"`
 		Content string  `json:"content"`

--- a/internal/ai/integrations/tavily_test.go
+++ b/internal/ai/integrations/tavily_test.go
@@ -166,8 +166,8 @@ func TestTavilyClient_Search_ResponseTimeAsNumber(t *testing.T) {
 
 	client := NewTavilyClient("tvly-test", server.URL, nil)
 	result, err := client.Search(context.Background(), SearchOptions{
-		Query:      "Berlin events",
-		MaxResults: 5,
+		Query:       "Berlin events",
+		MaxResults:  5,
 		SearchDepth: "basic",
 	})
 
@@ -188,12 +188,12 @@ func TestTavilyClient_Search_NullableFieldsAcceptEmptyString(t *testing.T) {
 	// columns can hold empty strings without issues. This documents the
 	// COALESCE contract: NULL in DB → empty string in Go struct.
 	i := &Integration{
-		Name:           "Tavily",
-		Provider:       "tavily",
+		Name:            "Tavily",
+		Provider:        "tavily",
 		IntegrationType: "web_search",
-		LastTestStatus: "", // COALESCE(last_test_status, '')
-		LastTestError:  "", // COALESCE(last_test_error, '')
-		CreatedBy:      "", // COALESCE(created_by, '')
+		LastTestStatus:  "", // COALESCE(last_test_status, '')
+		LastTestError:   "", // COALESCE(last_test_error, '')
+		CreatedBy:       "", // COALESCE(created_by, '')
 	}
 	assert.Equal(t, "", i.LastTestStatus)
 	assert.Equal(t, "", i.LastTestError)

--- a/internal/ai/integrations/tavily_test.go
+++ b/internal/ai/integrations/tavily_test.go
@@ -147,3 +147,55 @@ func TestTavilyClient_Ping_FailureReturnsError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Quota exceeded")
 }
+
+// TestTavilyClient_Search_ResponseTimeAsNumber verifies that the struct
+// can parse Tavily's real response shape where response_time is a JSON
+// number (float), not a string. Regression test for the type mismatch
+// that blocked every web search.
+func TestTavilyClient_Search_ResponseTimeAsNumber(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"response_time": 1.23,
+			"answer": "Berlin has many events",
+			"results": [
+				{"title": "Berlin Events", "url": "https://example.com", "content": "Fun stuff", "score": 0.9}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	client := NewTavilyClient("tvly-test", server.URL, nil)
+	result, err := client.Search(context.Background(), SearchOptions{
+		Query:      "Berlin events",
+		MaxResults: 5,
+		SearchDepth: "basic",
+	})
+
+	require.NoError(t, err, "must parse response_time as number without error")
+	assert.NotNil(t, result)
+	assert.Len(t, result.Results, 1)
+	assert.Equal(t, "Berlin Events", result.Results[0].Title)
+}
+
+// TestTavilyClient_Search_NullableStringColumns verifies the standardColumns
+// COALESCE fix: nullable DB columns (last_test_status, last_test_error,
+// created_by) don't crash the scan when NULL. This is a documentation test —
+// the actual COALESCE runs at the SQL level, but we verify here that the
+// Integration struct's string fields accept empty strings (which is what
+// COALESCE produces from NULL).
+func TestTavilyClient_Search_NullableFieldsAcceptEmptyString(t *testing.T) {
+	// Verify the Integration struct's fields that correspond to nullable DB
+	// columns can hold empty strings without issues. This documents the
+	// COALESCE contract: NULL in DB → empty string in Go struct.
+	i := &Integration{
+		Name:           "Tavily",
+		Provider:       "tavily",
+		IntegrationType: "web_search",
+		LastTestStatus: "", // COALESCE(last_test_status, '')
+		LastTestError:  "", // COALESCE(last_test_error, '')
+		CreatedBy:      "", // COALESCE(created_by, '')
+	}
+	assert.Equal(t, "", i.LastTestStatus)
+	assert.Equal(t, "", i.LastTestError)
+	assert.Equal(t, "", i.CreatedBy)
+}


### PR DESCRIPTION
## Problem

Every Tavily web search fails with:

```
json: cannot unmarshal number into Go struct field
tavilySearchResponse.response_time of type string
```

The web agent retries 5 times with different queries — all fail with the same parse error. Tavily reports zero successful queries because the response is never parsed.

## Root cause

`internal/ai/integrations/tavily.go:78`:

```go
type tavilySearchResponse struct {
    QueryResponse string `json:"response_time"`  // ← string, should be float64
}
```

Tavily's API returns `response_time` as a JSON number (e.g. `1.23`), not a string. The Go struct field was typed as `string`, so `json.Unmarshal` rejects the numeric value.

Also: the field name `QueryResponse` is a copy-paste artifact — renamed to `ResponseTime` to match the normalized struct at line 63.

## Fix

```go
ResponseTime float64 `json:"response_time"` // seconds
```

## DB integration storage / NULL scan (also addressed)

The DB-stored integration path had a chain of NULL scan crashes (`last_test_status`, `last_test_error`, `created_by` — all nullable DB columns scanned into non-pointer Go `string` fields). This was **permanently fixed by PR #262** (COALESCE in `standardColumns`), which is already merged and deployed in rc.12.

What was originally suspected to be a "tenant-context propagation bug" in the supervisor→web-agent handoff turned out to be the NULL scan chain — once all nullable columns are COALESCE-ed to empty strings at the SQL level, the integration resolves correctly in both the single-agent (inline) and multi-agent (serial fan-out) code paths.

No additional DB fix needed in this PR. Two regression tests added:
- `TestTavilyClient_Search_ResponseTimeAsNumber` — verifies `response_time: 1.23` parses
- `TestTavilyClient_Search_NullableFieldsAcceptEmptyString` — documents the COALESCE contract

## Verification trace

End-to-end:
1. Supervisor routes to `web` ✓
2. Web agent resolves Tavily integration ✓ (env-config path or DB path with COALESCE)
3. HTTP call to Tavily API succeeds ✓
4. Response JSON parse fails ✗ ← **this fix**
5. After fix: response parses, results returned, answer streamed to user

## Tests

`go test ./internal/ai/integrations/...` — all pass including 2 new tests.

## Severity

**Critical** — blocks the entire web-search feature. No Tavily query can succeed until this is fixed.

## Checklist

- [x] Code compiles
- [x] All existing integration tests pass
- [x] 2 new regression tests added
- [x] DB NULL scan issue confirmed already fixed by PR #262 (merged, deployed in rc.12)
- [x] Field name corrected (copy-paste artifact)