### PR TITLE
fix(integrations): cast created_by to text before COALESCE

### DIFF
--- a/internal/ai/integrations/storage.go
+++ b/internal/ai/integrations/storage.go
@@ -180,14 +180,17 @@ func scanIntegration(row pgx.Row) (*Integration, error) {
 
 // standardColumns is the SELECT column list used by all read queries.
 // Keep in sync with scanIntegration.
-// COALESCE on nullable string columns to avoid "cannot scan NULL into *string"
+// COALESCE on nullable columns to avoid "cannot scan NULL into *string"
 // crashes when last_test_status / last_test_error / created_by haven't been
 // populated yet (e.g., a freshly-created integration that was never tested).
+// created_by is a UUID column — must cast to text before COALESCE with ”,
+// otherwise PostgreSQL tries to cast ” to UUID and fails with
+// "invalid input syntax for type uuid".
 const standardColumns = `
 	id, name, integration_type, provider, config,
 	enabled, is_default, last_tested_at,
 	COALESCE(last_test_status, ''), COALESCE(last_test_error, ''),
-	created_at, updated_at, COALESCE(created_by, ''), tenant_id
+	created_at, updated_at, COALESCE(created_by::text, ''), tenant_id
 `
 
 // GetIntegration returns a single integration by ID. Decrypts secrets in


### PR DESCRIPTION
## Problem

`ListIntegrations` fails with:

```
ERROR: invalid input syntax for type uuid: "" (SQLSTATE 22P02)
```

This blocks the admin UI from loading existing integrations — `CreateIntegration` works but `UpdateIntegration` fails because it calls `ListIntegrations` to load the existing row.

## Root cause

PR #262 added `COALESCE(created_by, '')` to `standardColumns` to prevent NULL scan crashes. But `created_by` is a **UUID column** — PostgreSQL's COALESCE tries to find a common type between UUID (first arg) and text (second arg `''`), attempts to cast `''` to UUID, and fails.

The error is NOT a scan error — it's a **query execution error** from PostgreSQL itself. The query never returns rows because it fails during column resolution.

## Fix

`COALESCE(created_by::text, '')` — cast the UUID column to text BEFORE COALESCE so both arguments are text. The Go struct field `CreatedBy` is already `string`, so scanning text into string works correctly.

The other two COALESCE columns (`last_test_status`, `last_test_error`) are already `text` type, so they don't need the cast.

## Test plan

1. Create a Tavily integration via the admin UI
2. Verify `ListIntegrations` returns the row without error
3. Click Save again (update path) — should succeed
4. Click Test connection — should work

## Severity

**High** — blocks all integration updates from the admin UI.

## Checklist

- [x] Code compiles
- [x] Existing tests pass
- [x] One-line fix (`::text` cast)
- [x] Only UUID column needs the cast; text columns are fine