### PR TITLE
feat(ai): provider config fallback for max_tokens and temperature

### DIFF
--- a/internal/ai/chat_handler_message.go
+++ b/internal/ai/chat_handler_message.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -295,12 +296,37 @@ func (h *ChatHandler) handleMessage(ctx context.Context, chatCtx *ChatContext, m
 			Bool("has_used_think", hasUsedThink).
 			Msg("Tools available for chatbot")
 
+		// Resolve max_tokens and temperature: chatbot annotation takes precedence,
+		// then provider config (admin UI), then hardcoded defaults from
+		// DefaultChatbotConfig (already in chatbot.MaxTokens / chatbot.Temperature).
+		maxTokens := chatbot.MaxTokens
+		temperature := chatbot.Temperature
+		if !chatbot.HasMaxTokens || !chatbot.HasTemperature {
+			if rc, ok := provider.(interface{ RawConfig() map[string]string }); ok {
+				rawCfg := rc.RawConfig()
+				if !chatbot.HasMaxTokens {
+					if v := rawCfg["max_tokens"]; v != "" {
+						if n, err := strconv.Atoi(v); err == nil && n > 0 {
+							maxTokens = n
+						}
+					}
+				}
+				if !chatbot.HasTemperature {
+					if v := rawCfg["temperature"]; v != "" {
+						if t, err := strconv.ParseFloat(v, 64); err == nil {
+							temperature = t
+						}
+					}
+				}
+			}
+		}
+
 		// Create chat request
 		chatReq := &ChatRequest{
 			Messages:    messages,
 			Model:       chatbot.Model,
-			MaxTokens:   chatbot.MaxTokens,
-			Temperature: chatbot.Temperature,
+			MaxTokens:   maxTokens,
+			Temperature: temperature,
 			Tools:       tools,
 			Stream:      true,
 		}

--- a/internal/ai/chatbot.go
+++ b/internal/ai/chatbot.go
@@ -46,11 +46,13 @@ type Chatbot struct {
 	DefaultTable    string             `json:"default_table,omitempty"`
 
 	// Runtime config
-	Enabled     bool    `json:"enabled"`
-	MaxTokens   int     `json:"max_tokens"`
-	Temperature float64 `json:"temperature"`
-	Model       string  `json:"model,omitempty"` // Model name from @fluxbase:model annotation
-	ProviderID  *string `json:"provider_id,omitempty"`
+	Enabled        bool    `json:"enabled"`
+	MaxTokens      int     `json:"max_tokens"`
+	Temperature    float64 `json:"temperature"`
+	HasMaxTokens   bool    `json:"has_max_tokens,omitempty"`  // true when @fluxbase:max-tokens was explicitly set
+	HasTemperature bool    `json:"has_temperature,omitempty"` // true when @fluxbase:temperature was explicitly set
+	Model          string  `json:"model,omitempty"`           // Model name from @fluxbase:model annotation
+	ProviderID     *string `json:"provider_id,omitempty"`
 
 	// Conversation config
 	PersistConversations bool `json:"persist_conversations"`
@@ -134,9 +136,11 @@ type ChatbotConfig struct {
 	DefaultTable    string
 
 	// Model settings
-	MaxTokens   int
-	Temperature float64
-	Model       string
+	MaxTokens      int
+	Temperature    float64
+	HasMaxTokens   bool // true when @fluxbase:max-tokens was explicitly set
+	HasTemperature bool // true when @fluxbase:temperature was explicitly set
+	Model          string
 
 	// Conversation settings
 	PersistConversations bool
@@ -395,6 +399,7 @@ func ParseChatbotConfig(code string) ChatbotConfig {
 	if matches := maxTokensPattern.FindStringSubmatch(code); len(matches) > 1 {
 		if v, err := strconv.Atoi(matches[1]); err == nil {
 			config.MaxTokens = v
+			config.HasMaxTokens = true
 		}
 	}
 
@@ -402,6 +407,7 @@ func ParseChatbotConfig(code string) ChatbotConfig {
 	if matches := temperaturePattern.FindStringSubmatch(code); len(matches) > 1 {
 		if v, err := strconv.ParseFloat(matches[1], 64); err == nil {
 			config.Temperature = v
+			config.HasTemperature = true
 		}
 	}
 
@@ -804,6 +810,8 @@ func (c *Chatbot) ApplyConfig(config ChatbotConfig) {
 	c.DefaultTable = config.DefaultTable
 	c.MaxTokens = config.MaxTokens
 	c.Temperature = config.Temperature
+	c.HasMaxTokens = config.HasMaxTokens
+	c.HasTemperature = config.HasTemperature
 	c.Model = config.Model
 	c.PersistConversations = config.PersistConversations
 	c.ConversationTTLHours = int(config.ConversationTTL.Hours())

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -241,7 +241,12 @@ func NewOpenAIProvider(config ProviderConfig) (Provider, error) {
 		openaiConfig.Model = "gpt-4-turbo"
 	}
 
-	return newOpenAIProviderInternal(config.Name, openaiConfig)
+	p, err := newOpenAIProviderInternal(config.Name, openaiConfig)
+	if err != nil {
+		return nil, err
+	}
+	p.rawConfig = config.Config
+	return p, nil
 }
 
 // NewAzureProvider creates a new Azure OpenAI provider (implemented in provider_azure.go)
@@ -270,7 +275,12 @@ func NewAzureProvider(config ProviderConfig) (Provider, error) {
 		azureConfig.APIVersion = "2024-02-15-preview"
 	}
 
-	return newAzureProviderInternal(config.Name, azureConfig)
+	p, err := newAzureProviderInternal(config.Name, azureConfig)
+	if err != nil {
+		return nil, err
+	}
+	p.rawConfig = config.Config
+	return p, nil
 }
 
 // NewOllamaProvider creates a new Ollama provider (implemented in provider_ollama.go)
@@ -289,7 +299,12 @@ func NewOllamaProvider(config ProviderConfig) (Provider, error) {
 		return nil, fmt.Errorf("ollama: model is required")
 	}
 
-	return newOllamaProviderInternal(config.Name, ollamaConfig)
+	p, err := newOllamaProviderInternal(config.Name, ollamaConfig)
+	if err != nil {
+		return nil, err
+	}
+	p.rawConfig = config.Config
+	return p, nil
 }
 
 // NewAnthropicProvider creates a new Anthropic Claude provider (implemented in provider_anthropic.go)
@@ -317,7 +332,12 @@ func NewAnthropicProvider(config ProviderConfig) (Provider, error) {
 		anthropicConfig.APIVersion = "2023-06-01"
 	}
 
-	return newAnthropicProviderInternal(config.Name, anthropicConfig)
+	p, err := newAnthropicProviderInternal(config.Name, anthropicConfig)
+	if err != nil {
+		return nil, err
+	}
+	p.rawConfig = config.Config
+	return p, nil
 }
 
 // ExecuteSQLTool is the standard tool definition for SQL execution.

--- a/internal/ai/provider_anthropic.go
+++ b/internal/ai/provider_anthropic.go
@@ -37,8 +37,11 @@ const (
 type anthropicProvider struct {
 	name       string
 	config     AnthropicConfig
+	rawConfig  map[string]string
 	httpClient *http.Client
 }
+
+func (p *anthropicProvider) RawConfig() map[string]string { return p.rawConfig }
 
 func newAnthropicProviderInternal(name string, config AnthropicConfig) (*anthropicProvider, error) {
 	config.BaseURL = strings.TrimSuffix(config.BaseURL, "/")

--- a/internal/ai/provider_azure.go
+++ b/internal/ai/provider_azure.go
@@ -22,8 +22,11 @@ const (
 type azureProvider struct {
 	name       string
 	config     AzureConfig
+	rawConfig  map[string]string
 	httpClient *http.Client
 }
+
+func (p *azureProvider) RawConfig() map[string]string { return p.rawConfig }
 
 // newAzureProviderInternal creates a new Azure OpenAI provider instance
 func newAzureProviderInternal(name string, config AzureConfig) (*azureProvider, error) {

--- a/internal/ai/provider_ollama.go
+++ b/internal/ai/provider_ollama.go
@@ -22,8 +22,11 @@ const (
 type ollamaProvider struct {
 	name       string
 	config     OllamaConfig
+	rawConfig  map[string]string
 	httpClient *http.Client
 }
+
+func (p *ollamaProvider) RawConfig() map[string]string { return p.rawConfig }
 
 // newOllamaProviderInternal creates a new Ollama provider instance
 func newOllamaProviderInternal(name string, config OllamaConfig) (*ollamaProvider, error) {

--- a/internal/ai/provider_openai.go
+++ b/internal/ai/provider_openai.go
@@ -23,8 +23,11 @@ const (
 type openAIProvider struct {
 	name       string
 	config     OpenAIConfig
+	rawConfig  map[string]string
 	httpClient *http.Client
 }
+
+func (p *openAIProvider) RawConfig() map[string]string { return p.rawConfig }
 
 // newOpenAIProviderInternal creates a new OpenAI provider instance
 func newOpenAIProviderInternal(name string, config OpenAIConfig) (*openAIProvider, error) {


### PR DESCRIPTION
## Problem

The admin UI's AI Settings card has `max_tokens` and `temperature` fields. These are stored on the provider record but **never read** by the chat handler. Changing them in the admin UI has zero effect on the chatbot's behavior.

The chat handler always uses `chatbot.MaxTokens` / `chatbot.Temperature`, which come from either the `@fluxbase:max-tokens` / `@fluxbase:temperature` annotations (when present) or `DefaultChatbotConfig()` hardcoded values (4096 / 0.7). The provider's config is ignored for these fields.

## Fix

Add a 3-tier resolution chain:

1. **Chatbot annotation** (`@fluxbase:max-tokens` / `@fluxbase:temperature`) — highest priority, used when present
2. **Provider config** (admin UI) — used when the chatbot annotation is absent
3. **Hardcoded default** (`DefaultChatbotConfig`: 4096 / 0.7) — ultimate fallback

### Implementation

**Tracking whether annotations are present:**

`ChatbotConfig` and `Chatbot` gain `HasMaxTokens bool` / `HasTemperature bool` fields. The parser sets these to `true` only when the annotation is explicitly found in the source code. When absent, they stay `false`, signaling "use provider config or default".

**Exposing provider config to the handler:**

Each provider struct (`openAIProvider`, `anthropicProvider`, `azureProvider`, `ollamaProvider`) gains a `rawConfig map[string]string` field storing the original `ProviderConfig.Config` map. The `New*Provider` constructors populate it from the `ProviderConfig` they receive.

Each provider gains a `RawConfig() map[string]string` method.

**Not on the Provider interface** — accessed via anonymous interface type assertion in the handler:

```go
if rc, ok := provider.(interface{ RawConfig() map[string]string }); ok {
    // use rc.RawConfig() for fallback
}
```

This means any future Provider implementation that doesn't have `RawConfig()` is simply skipped — no build break, no interface satisfaction requirement.

**Handler resolution logic:**

```go
maxTokens := chatbot.MaxTokens     // starts with default (4096)
temperature := chatbot.Temperature  // starts with default (0.7)

if !chatbot.HasMaxTokens || !chatbot.HasTemperature {
    if rc, ok := provider.(interface{ RawConfig() map[string]string }); ok {
        rawCfg := rc.RawConfig()
        if !chatbot.HasMaxTokens {
            // parse rawCfg["max_tokens"], override if valid
        }
        if !chatbot.HasTemperature {
            // parse rawCfg["temperature"], override if valid
        }
    }
}
```

## Backwards compatibility

| Scenario | Before | After |
|---|---|---|
| Chatbot has `@fluxbase:max-tokens` | Annotation value | Annotation value (unchanged) |
| Chatbot has `@fluxbase:temperature` | Annotation value | Annotation value (unchanged) |
| No annotation, provider has config | Hardcoded default (4096/0.7) | **Provider config** (NEW) |
| No annotation, no provider config | Hardcoded default | Hardcoded default (unchanged) |

No breaking changes. Existing chatbots with annotations are completely unaffected.

## Why anonymous interface assertion instead of adding to Provider interface

Adding `RawConfig()` to the `Provider` interface would require every implementation (including mocks, test fakes, third-party providers) to implement it. The anonymous interface assertion (`provider.(interface{ RawConfig() map[string]string })`) is a Go idiom that:
- Doesn't change the Provider interface
- Gracefully skips providers that don't expose config
- Still type-checks at compile time (unlike reflection)
- Is the same pattern used by `io.Closer`, `fmt.Stringer`, etc.

## Tests

All existing tests pass (`go test ./internal/ai/...`). The change is additive — existing annotation-present behavior is byte-for-byte identical.

## Files changed

- `internal/ai/chatbot.go` — `HasMaxTokens`/`HasTemperature` fields on `ChatbotConfig` + `Chatbot`; parser sets them; `PopulateDerivedFields` wires through
- `internal/ai/provider.go` — `New*Provider` constructors store `config.Config` on the provider struct
- `internal/ai/provider_openai.go` — `rawConfig` field + `RawConfig()` method
- `internal/ai/provider_anthropic.go` — same
- `internal/ai/provider_azure.go` — same
- `internal/ai/provider_ollama.go` — same
- `internal/ai/chat_handler_message.go` — resolution logic before building `ChatRequest`

## Checklist

- [x] Code compiles (`go build ./internal/ai/...`)
- [x] All existing tests pass (`go test ./internal/ai/...`)
- [x] gofumpt clean
- [x] No breaking changes — chatbots with annotations unaffected
- [x] Provider interface unchanged (anonymous assertion used)
- [x] All 4 provider types updated (OpenAI, Anthropic, Azure, Ollama)
