### PR TITLE
fix(storage): add tenant_id to INSERT statements across functions + jobs storage

### DIFF
--- a/internal/functions/handler_sync.go
+++ b/internal/functions/handler_sync.go
@@ -533,10 +533,15 @@ func (h *Handler) CreateSharedModule(c fiber.Ctx) error {
 		return apperrors.SendBadRequest(c, "Module path must start with '_shared/'", apperrors.ErrCodeInvalidInput)
 	}
 
-	// Get user ID from context (if authenticated)
+	// Get user ID from context (if authenticated). JWT locals store strings,
+	// not uuid.UUID — so parse manually like the SyncFunctions handler does.
 	var userID *uuid.UUID
 	if uid := c.Locals("user_id"); uid != nil {
-		if parsedUID, ok := uid.(uuid.UUID); ok {
+		if uidStr, ok := uid.(string); ok {
+			if parsed, err := uuid.Parse(uidStr); err == nil {
+				userID = &parsed
+			}
+		} else if parsedUID, ok := uid.(uuid.UUID); ok {
 			userID = &parsedUID
 		}
 	}

--- a/internal/functions/storage_files.go
+++ b/internal/functions/storage_files.go
@@ -12,10 +12,12 @@ import (
 
 // CreateSharedModule creates a new shared module or updates it if it already exists (upsert)
 func (s *Storage) CreateSharedModule(ctx context.Context, module *SharedModule) error {
+	tenantID := database.TenantFromContext(ctx)
+
 	query := `
 		INSERT INTO functions.shared_modules (
-			module_path, content, description, created_by
-		) VALUES ($1, $2, $3, $4)
+			module_path, content, description, created_by, tenant_id
+		) VALUES ($1, $2, $3, $4, $5)
 		ON CONFLICT (module_path) DO UPDATE SET
 			content = EXCLUDED.content,
 			description = EXCLUDED.description,
@@ -28,6 +30,7 @@ func (s *Storage) CreateSharedModule(ctx context.Context, module *SharedModule) 
 		return tx.QueryRow(
 			ctx, query,
 			module.ModulePath, module.Content, module.Description, module.CreatedBy,
+			database.TenantOrNil(tenantID),
 		).Scan(&module.ID, &module.Version, &module.CreatedAt, &module.UpdatedAt)
 	})
 	if err != nil {

--- a/internal/jobs/storage_function_files.go
+++ b/internal/jobs/storage_function_files.go
@@ -5,15 +5,19 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+
+	"github.com/nimbleflux/fluxbase/internal/database"
 )
 
 // ========== Job Function Files ==========
 
 // CreateJobFunctionFile creates a supporting file for a job function
 func (s *Storage) CreateJobFunctionFile(ctx context.Context, file *JobFunctionFile) error {
+	tenantID := database.TenantFromContext(ctx)
+
 	query := `
-		INSERT INTO jobs.function_files (id, function_id, file_path, content)
-		VALUES ($1, $2, $3, $4)
+		INSERT INTO jobs.function_files (id, function_id, file_path, content, tenant_id)
+		VALUES ($1, $2, $3, $4, $5)
 		ON CONFLICT (function_id, file_path) DO UPDATE SET content = EXCLUDED.content
 		RETURNING created_at
 	`
@@ -21,7 +25,7 @@ func (s *Storage) CreateJobFunctionFile(ctx context.Context, file *JobFunctionFi
 	return s.WithTenant(ctx, func(tx pgx.Tx) error {
 		return tx.QueryRow(
 			ctx, query,
-			file.ID, file.JobFunctionID, file.FilePath, file.Content,
+			file.ID, file.JobFunctionID, file.FilePath, file.Content, database.TenantOrNil(tenantID),
 		).Scan(&file.CreatedAt)
 	})
 }

--- a/internal/jobs/storage_functions.go
+++ b/internal/jobs/storage_functions.go
@@ -27,9 +27,9 @@ func (s *Storage) CreateJobFunctionWithTenant(ctx context.Context, tenantID stri
 			id, name, namespace, description, code, original_code, is_bundled, bundle_error,
 			enabled, schedule, timeout_seconds, memory_limit_mb, max_retries,
 			progress_timeout_seconds, allow_net, allow_env, allow_read, allow_write,
-			require_roles, disable_execution_logs, version, created_by, source
+			require_roles, disable_execution_logs, version, created_by, source, tenant_id
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24
 		)
 		RETURNING created_at, updated_at
 	`
@@ -42,6 +42,7 @@ func (s *Storage) CreateJobFunctionWithTenant(ctx context.Context, tenantID stri
 			fn.MemoryLimitMB, fn.MaxRetries, fn.ProgressTimeoutSeconds,
 			fn.AllowNet, fn.AllowEnv, fn.AllowRead, fn.AllowWrite,
 			fn.RequireRoles, fn.DisableExecutionLogs, fn.Version, fn.CreatedBy, fn.Source,
+			database.TenantOrNil(tenantID),
 		).Scan(&fn.CreatedAt, &fn.UpdatedAt)
 	})
 }
@@ -110,9 +111,9 @@ func (s *Storage) UpsertJobFunctionWithTenant(ctx context.Context, tenantID stri
 			id, name, namespace, description, code, original_code, is_bundled, bundle_error,
 			enabled, schedule, timeout_seconds, memory_limit_mb, max_retries,
 			progress_timeout_seconds, allow_net, allow_env, allow_read, allow_write,
-			require_roles, disable_execution_logs, version, created_by, source
+			require_roles, disable_execution_logs, version, created_by, source, tenant_id
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, 1, $21, $22
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, 1, $21, $22, $23
 		)
 		ON CONFLICT (name, namespace) DO UPDATE SET
 			description = EXCLUDED.description,
@@ -145,6 +146,7 @@ func (s *Storage) UpsertJobFunctionWithTenant(ctx context.Context, tenantID stri
 			fn.MemoryLimitMB, fn.MaxRetries, fn.ProgressTimeoutSeconds,
 			fn.AllowNet, fn.AllowEnv, fn.AllowRead, fn.AllowWrite,
 			fn.RequireRoles, fn.DisableExecutionLogs, fn.CreatedBy, fn.Source,
+			database.TenantOrNil(tenantID),
 		).Scan(&fn.ID, &fn.Version, &fn.CreatedAt, &fn.UpdatedAt)
 	})
 }


### PR DESCRIPTION
## Problem

`fluxbase functions sync` fails to upload shared modules with "Failed to create shared module". The error is a 500 INTERNAL_ERROR from the server.

## Root cause

Same bug class as commit `eefe04ac` (which fixed chatbots and RPC procedures): INSERT statements on RLS-enabled tables **omit `tenant_id`** from the column list. They rely on a BEFORE INSERT trigger to set it from the session GUC.

When an existing row has a different `tenant_id` (e.g., NULL from a sync that ran without tenant context), RLS makes it invisible. The `ON CONFLICT DO UPDATE` then fails because PostgreSQL cannot update a row hidden by RLS, even though the unique constraint detects the conflict.

The fix from `eefe04ac` was applied to chatbots and RPC procedures but was **never propagated** to these sibling storage methods.

## Tables fixed

| Table | Storage method | Has ON CONFLICT? | Bug present? |
|---|---|---|---|
| `functions.shared_modules` | `CreateSharedModule` | Yes (module_path) | **Yes — reported bug** |
| `jobs.functions` | `UpsertJobFunctionWithTenant` | Yes (name, namespace) | **Yes** |
| `jobs.function_files` | `CreateJobFunctionFile` | Yes (function_id, file_path) | **Yes** |
| `jobs.functions` | `CreateJobFunctionWithTenant` | No | Preventive fix |

## Secondary fix: `created_by` type assertion

`CreateSharedModule` handler (`handler_sync.go:539`) asserted `c.Locals("user_id").(uuid.UUID)` — but JWT locals store strings, not `uuid.UUID`. The assertion silently fails, leaving `created_by` as NULL. Now uses `uuid.Parse` like the sibling `SyncFunctions` handler.

## Fix pattern (mirrors commit eefe04ac)

1. Resolve `tenantID := database.TenantFromContext(ctx)` at function entry
2. Add `tenant_id` to INSERT column list
3. Pass `database.TenantOrNil(tenantID)` as the value
4. For ON CONFLICT: existing rows become RLS-visible because `tenant_id` matches → UPDATE path works

## Tests

- `go test ./internal/functions/...` — pass
- `go test ./internal/jobs/...` — pass
- gofumpt clean

## Checklist

- [x] Code compiles
- [x] All existing tests pass
- [x] gofumpt clean
- [x] Same fix pattern as the already-merged commit eefe04ac
- [x] All 4 affected storage methods fixed
- [x] Secondary fix: created_by type assertion
