### PR TITLE
fix(rpc): use ON CONFLICT upsert to resolve sync race

### DIFF
--- a/internal/rpc/storage.go
+++ b/internal/rpc/storage.go
@@ -60,6 +60,24 @@ func (s *Storage) CreateProcedureWithTenant(ctx context.Context, tenantID string
 			$11, $12, $13, $14, $15,
 			$16, $17, $18, $19, $20, $21, $22
 		)
+		ON CONFLICT (name, namespace) DO UPDATE SET
+			description = EXCLUDED.description,
+			sql_query = EXCLUDED.sql_query,
+			original_code = EXCLUDED.original_code,
+			input_schema = EXCLUDED.input_schema,
+			output_schema = EXCLUDED.output_schema,
+			allowed_tables = EXCLUDED.allowed_tables,
+			allowed_schemas = EXCLUDED.allowed_schemas,
+			max_execution_time_seconds = EXCLUDED.max_execution_time_seconds,
+			require_roles = EXCLUDED.require_roles,
+			is_public = EXCLUDED.is_public,
+			disable_execution_logs = EXCLUDED.disable_execution_logs,
+			schedule = EXCLUDED.schedule,
+			enabled = EXCLUDED.enabled,
+			source = EXCLUDED.source,
+			created_by = EXCLUDED.created_by,
+			tenant_id = EXCLUDED.tenant_id,
+			updated_at = NOW()
 	`
 
 	if proc.ID == "" {


### PR DESCRIPTION
## Problem

`fluxbase rpc sync` intermittently fails with:

```
duplicate key value violates unique constraint "unique_rpc_procedure_name_namespace" (SQLSTATE 23505)
```

The error is **not** from a delete-then-create race (the sync framework does CREATE → UPDATE → DELETE). It's from a **schema/sync mismatch**:

- **Unique constraint is global:** `UNIQUE (name, namespace)` — no `tenant_id` (rpc.sql:39)
- **Sync existence check is tenant-scoped:** `WHERE namespace = $1 AND (tenant_id = $2 OR tenant_id IS NULL)` (storage.go:404)
- When a row exists with a different `tenant_id` (e.g. NULL from a prior sync without tenant context), the tenant-scoped check doesn't see it → classifies as `toCreate` → INSERT fails on the global unique constraint

## Root cause

The tenant-scoped existence check (`ListProceduresForSync`) filters by `tenant_id`, making rows with different tenant IDs invisible. But the unique constraint is global, so INSERTs from any tenant can collide with rows from other tenants.

This is the same class of bug that was fixed for chatbots and RPC procedures in commit `eefe04ac` (missing `tenant_id` in INSERT), but that fix addressed the INSERT column list — the **unique constraint + tenant-scoped existence check** combination is a separate manifestation of the same underlying design tension.

## Fix

Change `CreateProcedureWithTenant` from plain `INSERT` to:

```sql
INSERT INTO rpc.procedures (name, namespace, ...) VALUES (...)
ON CONFLICT (name, namespace) DO UPDATE SET
    description = EXCLUDED.description,
    sql_query = EXCLUDED.sql_query,
    ...all fields...,
    tenant_id = EXCLUDED.tenant_id,
    updated_at = NOW()
```

When a row exists globally (from any tenant), the conflict resolves as an UPDATE instead of erroring. The `tenant_id = EXCLUDED.tenant_id` claims the row for the syncing tenant.

## Why ON CONFLICT instead of changing the constraint

Changing the constraint to `(name, namespace, tenant_id)` would be more architecturally correct (per-tenant uniqueness) but requires a schema migration, data backfill, and all existing callers to handle the new shape. `ON CONFLICT` is a one-line change that fixes the symptom without touching the schema.

## Tests

`go test ./internal/rpc/...` passes. The change is in the SQL query text, not in any test-covered code path (the tests use mocks for the DB layer).

## Checklist

- [x] Code compiles
- [x] All existing tests pass
- [x] gofumpt clean
- [x] One-query change, minimal diff
- [x] Backwards compatible — first INSERT (no existing row) still works as plain INSERT