### PR TITLE
fix(admin): AI Providers duplicate header + sidebar reorg + remove API Reference

### DIFF
--- a/admin/src/components/layout/data/sidebar-data.ts
+++ b/admin/src/components/layout/data/sidebar-data.ts
@@ -259,7 +259,6 @@ export const sidebarData: SidebarDataWithVisibility = {
           visibility: "all",
           requiresTenant: false, // Override: works at both levels
         },
-        },
         {
           title: "Realtime",
           url: "/realtime",

--- a/admin/src/components/layout/data/sidebar-data.ts
+++ b/admin/src/components/layout/data/sidebar-data.ts
@@ -216,6 +216,18 @@ export const sidebarData: SidebarDataWithVisibility = {
       requiresTenant: true,
       items: [
         {
+          title: "AI Providers",
+          url: "/ai-providers",
+          icon: Bot,
+          visibility: "all",
+        },
+        {
+          title: "Tool Integrations",
+          url: "/ai-integrations",
+          icon: Globe,
+          visibility: "all",
+        },
+        {
           title: "Knowledge Bases",
           url: "/knowledge-bases",
           icon: BookOpen,
@@ -247,13 +259,6 @@ export const sidebarData: SidebarDataWithVisibility = {
           visibility: "all",
           requiresTenant: false, // Override: works at both levels
         },
-        {
-          title: "API Reference",
-          url: "/api-docs",
-          icon: ScrollText,
-          visibility: "all",
-          requiresTenant: false,
-          external: true,
         },
         {
           title: "Realtime",
@@ -291,18 +296,6 @@ export const sidebarData: SidebarDataWithVisibility = {
           icon: Mail,
           visibility: "all",
           requiresTenant: false, // Both instance and tenant admins can access
-        },
-        {
-          title: "AI Providers",
-          url: "/ai-providers",
-          icon: Bot,
-          visibility: "all",
-        },
-        {
-          title: "Tool Integrations",
-          url: "/ai-integrations",
-          icon: Globe,
-          visibility: "all",
         },
       ],
     },

--- a/admin/src/routes/_authenticated/ai-providers/index.tsx
+++ b/admin/src/routes/_authenticated/ai-providers/index.tsx
@@ -1,17 +1,9 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { Bot } from 'lucide-react'
 import { AIProvidersTab } from '@/components/ai-providers/ai-providers-tab'
-import { PageHeader } from '@/components/layout/page-header'
 
 const AIProvidersPage = () => {
   return (
     <div className='flex h-full flex-col'>
-      <PageHeader
-        icon={<Bot />}
-        title="AI Providers"
-        description="Configure AI providers for chatbots and intelligent features"
-      />
-
       <div className='flex-1 overflow-auto p-6'>
         <AIProvidersTab />
       </div>


### PR DESCRIPTION
Three fixes for the admin panel:

1. **AI Providers duplicate header** — same bug as ai-integrations: removed PageHeader from index.tsx. The tab component already has a CardTitle + CardDescription.

2. **Sidebar reorganization** — moved AI Providers and Tool Integrations from API & Services to the AI category. The AI section now contains: Providers, Tool Integrations, Knowledge Bases, AI Chatbots, MCP Tools.

3. **Removed API Reference link** — pointed to non-existent /api-docs page.

Only 3 files changed (the previous PR had 22 accidental prettier formatting changes that are now discarded).