### PR TITLE
fix(jobs): recover stale running jobs on startup

### DIFF
--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -77,6 +77,27 @@ func (m *Manager) Start(ctx context.Context, workerCount int) error {
 		Str("mode", m.Config.WorkerMode).
 		Msg("Starting job worker manager")
 
+	// Recover stale jobs from any previous process. On restart, all
+	// previous workers are dead — their running jobs are orphaned.
+	// Reset them to pending immediately instead of waiting 15-45s for
+	// the staleWorkerCleanupLoop (which only runs from a live worker
+	// and only resets jobs where worker_id IS NULL).
+	recovered, err := m.Storage.RecoverStaleJobs(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to recover stale jobs on startup")
+	} else if recovered > 0 {
+		log.Info().Int64("jobs_recovered", recovered).Msg("Recovered stale running jobs from previous process")
+	}
+
+	// Clean up stale worker registrations. timeout=0 means clean ALL rows
+	// (they're all stale — no previous worker is alive on a fresh start).
+	cleaned, err := m.Storage.CleanupStaleWorkers(ctx, 0)
+	if err != nil {
+		log.Warn().Err(err).Msg("Failed to clean up stale workers on startup")
+	} else if cleaned > 0 {
+		log.Info().Int64("workers_cleaned", cleaned).Msg("Cleaned up stale worker registrations from previous process")
+	}
+
 	m.targetCount = workerCount
 	m.supervisorCtx, m.supervisorStop = context.WithCancel(context.Background())
 

--- a/internal/jobs/storage_queue.go
+++ b/internal/jobs/storage_queue.go
@@ -243,6 +243,34 @@ func (s *Storage) InterruptJob(ctx context.Context, jobID uuid.UUID, reason stri
 	return nil
 }
 
+// RecoverStaleJobs resets ALL running jobs back to pending on startup.
+// Called by Manager.Start before workers register. On restart, all
+// previous workers are dead, so any running job is orphaned regardless
+// of its worker_id. This is immediate — doesn't wait for the 15-second
+// staleWorkerCleanupLoop that only resets jobs where worker_id IS NULL.
+func (s *Storage) RecoverStaleJobs(ctx context.Context) (int64, error) {
+	query := `
+		UPDATE jobs.queue
+		SET status = $1,
+		    worker_id = NULL,
+		    started_at = NULL,
+		    last_progress_at = NULL
+		WHERE status = $2
+	`
+
+	var result pgconn.CommandTag
+	err := database.WrapWithServiceRole(ctx, s.DB, func(tx pgx.Tx) error {
+		var execErr error
+		result, execErr = tx.Exec(ctx, query, JobStatusPending, JobStatusRunning)
+		return execErr
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	return result.RowsAffected(), nil
+}
+
 func (s *Storage) RequeueJob(ctx context.Context, jobID uuid.UUID, errorMsg string) error {
 	return s.requeueJobWithStatus(ctx, jobID, JobStatusRunning, errorMsg)
 }


### PR DESCRIPTION
## Problem

When Fluxbase restarts (e.g. after the machine was off overnight), all previous workers are dead. Their running jobs are orphaned — stuck in `running` status with dead `worker_id` values.

Previously, recovery depended on `staleWorkerCleanupLoop` which:
- Only runs from a **live** worker (none exist at startup)
- Only resets jobs where `worker_id IS NULL` (after the stale worker row is deleted)
- Takes 15-45 seconds to fire its first tick

In practice, jobs that were running at shutdown stayed in `running` status indefinitely if no worker happened to run the cleanup loop. The user observed jobs stuck in `pending`/`running` after a machine restart.

## Fix

Two operations added to `Manager.Start()`, both running **before** any new workers are created:

**1. `Storage.RecoverStaleJobs(ctx)`** — resets ALL `running` jobs to `pending` (regardless of `worker_id`). On a fresh start, every previous worker is dead, so every running job is orphaned.

```sql
UPDATE jobs.queue
SET status = 'pending', worker_id = NULL, started_at = NULL, last_progress_at = NULL
WHERE status = 'running'
```

**2. `Storage.CleanupStaleWorkers(ctx, 0)`** — removes ALL stale worker rows (`timeout=0` = clean everything). This prevents the stale rows from lingering and simplifies the first poll cycle.

Both use `WrapWithServiceRole` (bypasses RLS) since they run before any worker registers.

## Timeline comparison

| Step | Before | After |
|---|---|---|
| Fluxbase starts | t=0 | t=0 |
| Recovery sweep | — | t=0 (immediate) |
| Workers start | t≈0 | t≈0 |
| First poll tick | t≈1s | t≈1s |
| Stale worker cleanup | t≈15-45s | t=0 (done in sweep) |
| Orphaned jobs recovered | t≈15-45s | **t≈1s** |

## Tests

`go test ./internal/jobs/...` passes. The new method is a simple SQL UPDATE using the same pattern as the existing `ResetOrphanedJobs`.

## Checklist

- [x] Code compiles
- [x] All existing jobs tests pass
- [x] gofumpt clean
- [x] Recovery runs before workers start (no race)
- [x] Uses WrapWithServiceRole (no RLS dependency)