### PR TITLE
feat(admin): add Anthropic (Claude) to provider type dropdown

### DIFF
--- a/admin/src/components/ai-providers/create-provider-dialog.tsx
+++ b/admin/src/components/ai-providers/create-provider-dialog.tsx
@@ -127,6 +127,7 @@ export function CreateProviderDialog({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="openai">OpenAI</SelectItem>
+                <SelectItem value="anthropic">Anthropic (Claude)</SelectItem>
                 <SelectItem value="azure">Azure OpenAI</SelectItem>
                 <SelectItem value="ollama">Ollama</SelectItem>
               </SelectContent>


### PR DESCRIPTION
## What

Added `Anthropic (Claude)` to the AI provider type dropdown in the create-provider dialog.

The backend already fully supports Anthropic:
- `provider_anthropic.go` — streaming, embeddings, prompt caching
- `NewAnthropicProvider` in `provider.go`
- Model config, rate limiting, token counting

The admin UI was the only gap — the dropdown only showed OpenAI, Azure OpenAI, Ollama.

## Files changed

- `admin/src/components/ai-providers/create-provider-dialog.tsx` — added `<SelectItem value="anthropic">Anthropic (Claude)</SelectItem>`

That's it. One line.