### PR TITLE
fix(cli): show migration error details on sync failures

### DIFF
--- a/cli/cmd/migrations.go
+++ b/cli/cmd/migrations.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -376,9 +377,19 @@ func runMigrationsSync(cmd *cobra.Command, args []string) error {
 	}
 
 	var result map[string]interface{}
-	if err := apiClient.DoPost(ctx, "/api/v1/admin/migrations/sync", body, &result); err != nil {
+	resp, err := apiClient.Post(ctx, "/api/v1/admin/migrations/sync", body)
+	if err != nil {
 		return err
 	}
+
+	// The server returns 422 when migrations have partial errors.
+	// We need to decode the body regardless of status code to get
+	// the detailed error list (which migrations failed and why).
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		resp.Body.Close()
+		return fmt.Errorf("failed to parse sync response: %w", err)
+	}
+	resp.Body.Close()
 
 	// Parse the nested summary response
 	summary, ok := result["summary"].(map[string]interface{})


### PR DESCRIPTION
## Problem

When migration sync has errors, the CLI only prints a generic error message and exits. The user has to dig through Fluxbase server logs to find which migration failed and why.

## Root cause

The server returns HTTP 422 (Unprocessable Entity) when migrations have partial errors. The response body contains the full error list with per-migration failure reasons. The CLI used `apiClient.DoPost()` which calls `decodeBody()`. That function checks `if resp.StatusCode >= 400` and calls `parseErrorBody()` instead of decoding into the target. So the `result` map was never populated — the existing error-printing logic never ran.

## Fix

Replaced `DoPost` with a raw `Post` + manual `json.Decode`. This reads the body regardless of status code, so the existing error-printing logic can display the per-migration failure reasons:

```
Synced migrations: 0 created, 0 updated.
Warning: 1 errors occurred during sync.
  - 075_fix_public_trip_media_view: ERROR: cannot drop columns from view (SQLSTATE 42P16)
```

## Checklist

- [x] Code compiles
- [x] CLI tests pass
- [x] gofumpt clean
