### PR TITLE
fix(api): service_role bypasses max_total_results pagination caps

### DIFF
--- a/internal/api/rest_crud.go
+++ b/internal/api/rest_crud.go
@@ -17,7 +17,7 @@ import (
 // isAdminUser checks if the request is from an admin or instance_admin user
 func isAdminUser(c fiber.Ctx) bool {
 	role, ok := c.Locals("user_role").(string)
-	return ok && (role == "admin" || role == "instance_admin" || role == "tenant_service")
+	return ok && (role == "admin" || role == "instance_admin" || role == "tenant_service" || role == "service_role")
 }
 
 // injectTenantID adds tenant_id from the current tenant context into the

--- a/internal/api/rest_crud_test.go
+++ b/internal/api/rest_crud_test.go
@@ -46,9 +46,9 @@ func TestIsAdminUser(t *testing.T) {
 			expected: false,
 		},
 		{
-			name:     "service_role",
+			name:     "service_role bypasses caps (BYPASSRLS, no security purpose in capping)",
 			role:     "service_role",
-			expected: false,
+			expected: true,
 		},
 		{
 			name:     "empty string",


### PR DESCRIPTION
## Summary

The `isAdminUser()` function in `internal/api/rest_crud.go` bypasses `max_total_results` pagination caps for admin, instance_admin, and tenant_service — but **not for service_role**. Jobs that use the service-role client (`fluxbaseService`) are silently capped at `max_total_results` (default 10,000 rows total across all offset+limit), truncating batch operations.

This was the root cause of Wayli's `refresh-daily-activity` job only processing ~74 days instead of 4,449: the offset pagination hit `max_total_results` and the limit was silently clamped to 0, terminating the loop early.

## Fix

Add `service_role` to the `isAdminUser` bypass list:

```go
return ok && (role == "admin" || role == "instance_admin" || role == "tenant_service" || role == "service_role")
```

**Rationale**: `service_role` already has BYPASSRLS (full database access). Capping its query results serves no security purpose — it only breaks legitimate batch operations like jobs that iterate all rows. This aligns `service_role` with `tenant_service`, which is already bypassed.

## Test

Updated the existing `TestIsAdminUser/service_role` test case from `expected: false` to `expected: true`.

All 8 sub-tests pass.

🤖 Generated with ZCode