### PR TITLE
fix(release): copy all workspaces in Dockerfile + revert js-yaml to v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ WORKDIR /build
 COPY package.json bun.lock ./
 COPY sdk/ ./sdk/
 COPY sdk-react/ ./sdk-react/
+COPY sdk-svelte/ ./sdk-svelte/
+COPY sdk-next/ ./sdk-next/
+COPY sdk-vue/ ./sdk-vue/
 COPY admin/ ./admin/
 COPY docs/ ./docs/
 

--- a/bun.lock
+++ b/bun.lock
@@ -222,7 +222,7 @@
     "esbuild": "^0.28.1",
     "form-data": "^4.0.6",
     "h3": "^1.15.11",
-    "js-yaml": "^5.2.2",
+    "js-yaml": "^4.3.0",
     "picomatch": "^4.0.5",
     "postcss": "^8.5.19",
     "smol-toml": "^1.7.0",
@@ -1582,7 +1582,7 @@
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
-    "js-yaml": ["js-yaml@5.2.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.mjs" } }, "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw=="],
+    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "jsdom": ["jsdom@29.1.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "smol-toml": "^1.7.0",
     "picomatch": "^4.0.5",
     "form-data": "^4.0.6",
-    "js-yaml": "^5.2.2",
+    "js-yaml": "^4.3.0",
     "postcss": "^8.5.19"
   }
 }


### PR DESCRIPTION
Fixes two issues that broke the release pipeline ([run 30488381777](https://github.com/nimbleflux/fluxbase/actions/runs/30488381777)).

## 1. Docker images: `Workspace not found "sdk-svelte" / "sdk-next" / "sdk-vue"`

PR #288 added `sdk-svelte`, `sdk-next`, `sdk-vue` to the root `package.json` workspaces array but **never updated the root `Dockerfile`**. The `admin-builder` stage only COPYs 4 of the 7 workspaces, so `bun install` failed mid-image-build (both ARM64 and AMD64).

Fix: add the three missing `COPY` lines so all 7 workspaces are present. These new SDKs don't need to be built in the server image — they only need to exist so the workspaces declaration resolves. (`Dockerfile.docs` was already updated in #288.)

## 2. Docs build: `The requested module 'js-yaml' does not provide an export named 'default'`

PR #285 bumped the root `overrides.js-yaml` from `^4.3.0` → `^5.2.1`. js-yaml v5 is ESM-only with named exports and **no `export default`**. The entire Astro 7 / Starlight / markdown-remark stack uses `import yaml from "js-yaml"` (default import), which breaks under v5. The fluxbase codebase doesn't import js-yaml directly — this is purely transitive-via-override.

Fix: revert the override to `^4.3.0`. Verified the docs build passes locally (733 pages built).

## Not fixed here (needs manual action)
The **Svelte SDK publish** fails with `E404 Not Found` on `@nimbleflux/fluxbase-sdk-svelte`. These are brand-new packages from #288 that have never been published to npm. A 404 on first publish of a scoped package means the **`@nimbleflux` npm org doesn't exist or the publish token lacks permission to create new packages under the scope**. This is an npm account/permission setup step, not a code change.

## Verification
- `bun run build` in `docs/` → ✓ (was failing)
- `bun install` with all workspaces → ✓
- js-yaml resolves to 4.3.0, zero v5 references in lockfile