### PR TITLE
fix(schema): direct-apply fallback for app-schema with extension refs

### DIFF
--- a/internal/migrations/app_declarative.go
+++ b/internal/migrations/app_declarative.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/database/bootstrap"
+	dbschema "github.com/nimbleflux/fluxbase/internal/database/schema"
 )
 
 // AppDeclarativeService manages an application's own schema (e.g. the `public`
@@ -298,6 +299,45 @@ func (s *AppDeclarativeService) planFromContent(ctx context.Context, schemaName,
 	return &plan, nil
 }
 
+// applyDirectFallback applies schema content directly via SQL execution, as a
+// fallback when pgschema plan cannot validate the desired state (e.g. references
+// to extension-provided operators like pgvector's <=>, or cross-schema objects).
+// Mirrors DeclarativeService.applySchemaDirectFallback. The content is made
+// idempotent via MakeSQLIdempotent, so re-applying a matching schema is a no-op.
+func (s *AppDeclarativeService) applyDirectFallback(ctx context.Context, schemaName, schemaContent string) error {
+	content, err := s.substituteAppUserForContent(schemaContent)
+	if err != nil {
+		return fmt.Errorf("invalid app user placeholder: %w", err)
+	}
+
+	connStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
+		s.dbUser, s.dbPassword, s.dbHost, s.dbPort, s.dbName)
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		return fmt.Errorf("failed to create connection pool: %w", err)
+	}
+	defer pool.Close()
+
+	// Set search_path so unqualified names and extension operators resolve. The
+	// target schema comes first; `public` is included for shared types.
+	if schemaName == "" {
+		schemaName = "public"
+	}
+	searchPath := schemaName
+	if schemaName != "public" {
+		searchPath = schemaName + ", public"
+	}
+	if _, err := pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", searchPath)); err != nil {
+		return fmt.Errorf("failed to set search_path: %w", err)
+	}
+
+	idempotentSQL := dbschema.MakeSQLIdempotent(content)
+	if _, err := pool.Exec(ctx, idempotentSQL); err != nil {
+		return fmt.Errorf("failed to execute schema: %w", err)
+	}
+	return nil
+}
+
 // ApplyFromContent stores the content and applies it via pgschema. This is the
 // entry point used by `fluxbase schema sync` (store + apply) and by ApplyAllPending
 // (startup) against already-stored content.
@@ -324,7 +364,25 @@ func (s *AppDeclarativeService) ApplyFromContent(ctx context.Context, namespace,
 
 	plan, err := s.planFromContent(ctx, schemaName, schemaContent)
 	if err != nil {
-		return nil, fmt.Errorf("failed to plan app schema for namespace=%s: %w", namespace, err)
+		// pgschema plan can fail when the desired-state SQL references objects or
+		// operators from extensions (e.g. pgvector's <=> operator) or other schemas,
+		// because plan validation applies the SQL to a temporary schema where those
+		// aren't available. This mirrors the internal declarative engine: fall back
+		// to applying the idempotent SQL directly. Since pgschema-dump content uses
+		// CREATE ... IF NOT EXISTS throughout, direct application is safe and a
+		// re-apply against a matching DB is a no-op.
+		log.Warn().Err(err).
+			Str("namespace", namespace).
+			Str("schema", schemaName).
+			Msg("pgschema plan failed, applying app schema via direct fallback")
+		if ferr := s.applyDirectFallback(ctx, schemaName, schemaContent); ferr != nil {
+			return nil, fmt.Errorf("failed to plan app schema for namespace=%s schema=%s: %w (and direct fallback failed: %v)", namespace, schemaName, err, ferr)
+		}
+		if err := s.recordApply(ctx, namespace, schemaName, fingerprint); err != nil {
+			log.Warn().Err(err).Msg("Failed to record app schema state")
+		}
+		log.Info().Str("namespace", namespace).Str("schema", schemaName).Msg("App schema applied via direct fallback")
+		return &ApplyResult{Applied: []Change{}, Duration: 0}, nil
 	}
 
 	if len(plan.Changes) == 0 {


### PR DESCRIPTION
## Summary

Follow-up to #292 (declarative app-schema), found while testing the Wayli cutover.

`pgschema plan` validates desired-state SQL by applying it to a **temporary schema**. That validation fails when the app schema references objects or operators provided by **extensions** — for example pgvector's `<=>` cosine-distance operator, used by Wayli's `search_similar_*` functions — because those operators aren't visible in the temp schema:

```
Error: failed to apply desired state: ... ERROR: operator does not exist: public.vector <=> public.vector (SQLSTATE 42883)
```

The internal `DeclarativeService` already handles this by falling back to applying the idempotent SQL directly (see `applySchemaDirectFallback`). This PR applies the **same pattern** to `AppDeclarativeService`: when `planFromContent` fails, log a warning and apply the content directly via `MakeSQLIdempotent`.

This is safe because pgschema-dump content uses `CREATE ... IF NOT EXISTS` throughout, so a direct re-apply against a matching DB is a no-op (zero-diff), and additive changes apply cleanly.

## Testing
- `go build ./...` ✅
- `go test ./internal/migrations/` ✅
- `go vet` clean ✅
- Reproduced the pgvector plan failure against a live Wayli DB; this fallback resolves it.

## Notes
Needed before the Wayli declarative-schema cutover can be verified end-to-end. Once merged, cut a new RC (e.g. `v2026.7.4-rc.2`) and Wayli's devcontainer can consume it.