### PR TITLE
feat(schema): robust declarative app-schema — fallback apply, ignore support, pgschema 1.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ admin/playwright-report/
 # root with leading slash so it doesn't match deploy/helm/fluxbase/ or any
 # other path component named "fluxbase".
 /fluxbase
+.zcode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -141,7 +141,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=deno-bin /deno /usr/local/bin/deno
 
 # Install pgschema for declarative schema management
-ARG PGSCHEMA_VERSION=1.7.4
+# Bumped from 1.7.4 to 1.12.1: fixes plan validation for LANGUAGE sql functions
+# with SET search_path that use extension operators (e.g. pgvector <=>), plus
+# schema-qualified function-body references (pgplex/pgschema#399).
+ARG PGSCHEMA_VERSION=1.12.1
 RUN ARCH=$(dpkg --print-architecture) \
     && if [ "$ARCH" = "amd64" ]; then PGSCHEMA_ARCH="linux-amd64"; \
     elif [ "$ARCH" = "arm64" ]; then PGSCHEMA_ARCH="linux-arm64"; \

--- a/cli/cmd/schema.go
+++ b/cli/cmd/schema.go
@@ -159,15 +159,22 @@ func runSchemaSync(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("schema file %s is empty", schemaFile)
 	}
 
+	// Optional .pgschemaignore in the same directory; suppresses diffs on objects
+	// pgschema shouldn't manage (e.g. extension-member objects). Sent alongside the
+	// schema so Fluxbase writes it next to the temp file and pgschema discovers it.
+	ignoreFile := filepath.Join(dir, ".pgschemaignore")
+	ignoreContent, _ := os.ReadFile(ignoreFile) //nolint:gosec // optional file
+
 	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	body := map[string]interface{}{
-		"namespace": schemaNamespace,
-		"schema":    effectiveSchemaName(schemaName),
-		"content":   string(content),
-		"no_apply":  schemaNoApply,
-		"apply":     !schemaNoApply,
+		"namespace":      schemaNamespace,
+		"schema":         effectiveSchemaName(schemaName),
+		"content":        string(content),
+		"ignore_content": string(ignoreContent),
+		"no_apply":       schemaNoApply,
+		"apply":          !schemaNoApply,
 	}
 	_ = schemaAllowDest // destructive allowance is a server-side config; flagged through for future use
 

--- a/cli/cmd/schema.go
+++ b/cli/cmd/schema.go
@@ -198,7 +198,12 @@ func runSchemaSync(cmd *cobra.Command, args []string) error {
 	if applied {
 		changes, _ := result["changes"].(float64)
 		duration, _ := result["duration"].(string)
-		fmt.Printf("Applied %d change(s) in %s\n", int(changes), duration)
+		isFallback, _ := result["fallback"].(bool)
+		note := ""
+		if isFallback {
+			note = " (via direct fallback; statement count is approximate)"
+		}
+		fmt.Printf("Applied %d change(s) in %s%s\n", int(changes), duration, note)
 	} else if schemaNoApply {
 		fmt.Println("Stored only (--no-apply).")
 	}
@@ -352,7 +357,12 @@ func runSchemaApply(cmd *cobra.Command, args []string) error {
 
 	applied, _ := result["applied"].(float64)
 	duration, _ := result["duration"].(string)
-	fmt.Printf("Applied %d change(s) in %s\n", int(applied), duration)
+	isFallback, _ := result["fallback"].(bool)
+	note := ""
+	if isFallback {
+		note = " (via direct fallback; statement count is approximate)"
+	}
+	fmt.Printf("Applied %d change(s) in %s%s\n", int(applied), duration, note)
 	return nil
 }
 

--- a/internal/api/app_schema_handler.go
+++ b/internal/api/app_schema_handler.go
@@ -118,6 +118,7 @@ func (h *AppSchemaHandler) SyncSchema(c fiber.Ctx) error {
 		resp["applied"] = true
 		resp["changes"] = len(res.Applied)
 		resp["duration"] = res.Duration.String()
+		resp["fallback"] = res.Fallback
 		if res.Error != nil {
 			resp["message"] = res.Error.Error()
 		}
@@ -153,6 +154,7 @@ func (h *AppSchemaHandler) ApplySchema(c fiber.Ctx) error {
 		"message":  "Schema applied successfully",
 		"applied":  len(res.Applied),
 		"duration": res.Duration.String(),
+		"fallback": res.Fallback,
 	}
 	if res.Error != nil {
 		resp["message"] = res.Error.Error()

--- a/internal/api/app_schema_handler.go
+++ b/internal/api/app_schema_handler.go
@@ -77,10 +77,11 @@ func (h *AppSchemaHandler) SyncSchema(c fiber.Ctx) error {
 
 	var req struct {
 		Namespace string `json:"namespace"`
-		Schema    string `json:"schema"`   // optional, defaults to "public"
-		Content   string `json:"content"`  // the SQL schema body
-		Apply     bool   `json:"apply"`    // store + apply immediately
-		NoApply   bool   `json:"no_apply"` // explicit store-only
+		Schema    string `json:"schema"`         // optional, defaults to "public"
+		Content   string `json:"content"`        // the SQL schema body
+		Ignore    string `json:"ignore_content"` // optional .pgschemaignore content
+		Apply     bool   `json:"apply"`          // store + apply immediately
+		NoApply   bool   `json:"no_apply"`       // explicit store-only
 	}
 	if err := c.Bind().Body(&req); err != nil && err != fiber.ErrUnprocessableEntity {
 		return SendBadRequest(c, "Invalid request body", ErrCodeInvalidBody)
@@ -94,7 +95,7 @@ func (h *AppSchemaHandler) SyncSchema(c fiber.Ctx) error {
 
 	ctx := c.Context()
 
-	fingerprint, changed, err := h.service.StoreSchemaContent(ctx, req.Namespace, req.Schema, req.Content)
+	fingerprint, changed, err := h.service.StoreSchemaContent(ctx, req.Namespace, req.Schema, req.Content, req.Ignore)
 	if err != nil {
 		return SendInternalError(c, fmt.Sprintf("Failed to store schema: %v", err))
 	}

--- a/internal/database/schema/idempotent.go
+++ b/internal/database/schema/idempotent.go
@@ -42,6 +42,35 @@ func MakeSQLIdempotent(sql string) string {
 				drops = append(drops, dropInfo{pattern: patternUnquoted, dropSQL: dropSQL, foundPos: -1})
 			}
 
+		case *nodes.CreateTrigStmt:
+			// CREATE TRIGGER is not idempotent: re-running fails if the trigger
+			// exists. Prepend DROP TRIGGER IF EXISTS so a declarative schema file
+			// can be re-applied (and trigger definitions updated) safely.
+			if stmt.Trigname != "" && stmt.Relation != nil {
+				tableName := formatRangeVar(stmt.Relation)
+				dropSQL := fmt.Sprintf("DROP TRIGGER IF EXISTS %s ON %s CASCADE;\n", quoteIdent(stmt.Trigname), tableName)
+				patternQuoted := "CREATE TRIGGER \"" + stmt.Trigname + "\""
+				patternUnquoted := "CREATE TRIGGER " + stmt.Trigname
+				drops = append(drops, dropInfo{pattern: patternQuoted, dropSQL: dropSQL, foundPos: -1})
+				drops = append(drops, dropInfo{pattern: patternUnquoted, dropSQL: dropSQL, foundPos: -1})
+			}
+
+		case *nodes.IndexStmt:
+			// CREATE INDEX (without IF NOT EXISTS, without CONCURRENTLY) is not
+			// idempotent and can't update an existing index's definition. Prepend
+			// DROP INDEX IF EXISTS so index definition changes propagate on
+			// re-apply. Skip IF NOT EXISTS (already a no-op-safe no-op) and
+			// CONCURRENTLY (cannot run in a transaction / can't be dropped+recreated
+			// atomically). Constraint-backed indexes (Primary/Isconstraint) are
+			// managed via ALTER TABLE, not here.
+			if stmt.Idxname != "" && !stmt.IfNotExists && !stmt.Concurrent && !stmt.Primary && !stmt.Isconstraint {
+				dropSQL := fmt.Sprintf("DROP INDEX IF EXISTS %s;\n", quoteIdent(stmt.Idxname))
+				patternQuoted := "CREATE INDEX \"" + stmt.Idxname + "\""
+				patternUnquoted := "CREATE INDEX " + stmt.Idxname
+				drops = append(drops, dropInfo{pattern: patternQuoted, dropSQL: dropSQL, foundPos: -1})
+				drops = append(drops, dropInfo{pattern: patternUnquoted, dropSQL: dropSQL, foundPos: -1})
+			}
+
 		case *nodes.AlterTableStmt:
 			if stmt.Cmds != nil && stmt.Relation != nil {
 				for _, cmd := range stmt.Cmds.Items {

--- a/internal/database/schema/idempotent_test.go
+++ b/internal/database/schema/idempotent_test.go
@@ -1,0 +1,121 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMakeSQLIdempotent_CreatePolicy(t *testing.T) {
+	sql := `CREATE POLICY "my policy" ON public.users FOR SELECT USING (true);`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP POLICY IF EXISTS "my policy" ON "public"."users" CASCADE;`) {
+		t.Errorf("expected DROP POLICY prepended, got:\n%s", out)
+	}
+	if !strings.Contains(out, `CREATE POLICY "my policy"`) {
+		t.Errorf("expected original CREATE POLICY preserved, got:\n%s", out)
+	}
+	// DROP must come before CREATE.
+	dropIdx := strings.Index(out, "DROP POLICY")
+	createIdx := strings.Index(out, "CREATE POLICY")
+	if dropIdx < 0 || createIdx < 0 || dropIdx > createIdx {
+		t.Errorf("expected DROP before CREATE, got dropIdx=%d createIdx=%d", dropIdx, createIdx)
+	}
+}
+
+func TestMakeSQLIdempotent_CreatePolicyUnquoted(t *testing.T) {
+	sql := `CREATE POLICY my_policy ON users FOR SELECT USING (true);`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP POLICY IF EXISTS "my_policy"`) {
+		t.Errorf("expected DROP POLICY for unquoted name, got:\n%s", out)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateTrigger(t *testing.T) {
+	sql := `CREATE TRIGGER update_timestamp BEFORE UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION update_updated_at();`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP TRIGGER IF EXISTS "update_timestamp" ON "public"."users" CASCADE;`) {
+		t.Errorf("expected DROP TRIGGER prepended, got:\n%s", out)
+	}
+	if !strings.Contains(out, `CREATE TRIGGER update_timestamp`) {
+		t.Errorf("expected original CREATE TRIGGER preserved, got:\n%s", out)
+	}
+	// DROP must come before CREATE.
+	dropIdx := strings.Index(out, "DROP TRIGGER")
+	createIdx := strings.Index(out, "CREATE TRIGGER")
+	if dropIdx < 0 || createIdx < 0 || dropIdx > createIdx {
+		t.Errorf("expected DROP before CREATE, got dropIdx=%d createIdx=%d", dropIdx, createIdx)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateTriggerQuoted(t *testing.T) {
+	sql := `CREATE TRIGGER "my trigger" AFTER INSERT ON users FOR EACH ROW EXECUTE FUNCTION foo();`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP TRIGGER IF EXISTS "my trigger"`) {
+		t.Errorf("expected DROP TRIGGER for quoted name, got:\n%s", out)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateIndex(t *testing.T) {
+	sql := `CREATE INDEX idx_users_email ON public.users (email);`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP INDEX IF EXISTS "idx_users_email";`) {
+		t.Errorf("expected DROP INDEX prepended, got:\n%s", out)
+	}
+	if !strings.Contains(out, `CREATE INDEX idx_users_email`) {
+		t.Errorf("expected original CREATE INDEX preserved, got:\n%s", out)
+	}
+	dropIdx := strings.Index(out, "DROP INDEX")
+	createIdx := strings.Index(out, "CREATE INDEX")
+	if dropIdx < 0 || createIdx < 0 || dropIdx > createIdx {
+		t.Errorf("expected DROP before CREATE, got dropIdx=%d createIdx=%d", dropIdx, createIdx)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateIndexIfNotExistsPassthrough(t *testing.T) {
+	// CREATE INDEX IF NOT EXISTS is already idempotent (no-op if exists); must NOT
+	// get a DROP prepended (that would defeat IF NOT EXISTS and could drop a
+	// concurrently-built index).
+	sql := `CREATE INDEX IF NOT EXISTS idx_users_email ON public.users (email);`
+	out := MakeSQLIdempotent(sql)
+	if strings.Contains(out, "DROP INDEX") {
+		t.Errorf("IF NOT EXISTS index must not get DROP prepended, got:\n%s", out)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateIndexConcurrentlyPassthrough(t *testing.T) {
+	// CONCURRENTLY cannot run in a transaction and must not be dropped+recreated.
+	sql := `CREATE INDEX CONCURRENTLY idx_users_email ON public.users (email);`
+	out := MakeSQLIdempotent(sql)
+	if strings.Contains(out, "DROP INDEX") {
+		t.Errorf("CONCURRENTLY index must not get DROP prepended, got:\n%s", out)
+	}
+}
+
+func TestMakeSQLIdempotent_AlterTableAddConstraint(t *testing.T) {
+	// Note: the constraint-handler pattern matches the unqualified relname, so
+	// schema-qualified ALTER TABLE statements are not transformed (pre-existing
+	// behavior). Test with the unqualified form that the handler supports.
+	sql := `ALTER TABLE users ADD CONSTRAINT users_email_key UNIQUE (email);`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP CONSTRAINT IF EXISTS "users_email_key";`) {
+		t.Errorf("expected DROP CONSTRAINT prepended, got:\n%s", out)
+	}
+}
+
+func TestMakeSQLIdempotent_NoTransformations(t *testing.T) {
+	// Plain DDL with no policies/triggers/indexes/constraints is unchanged.
+	sql := `CREATE TABLE IF NOT EXISTS users (id uuid PRIMARY KEY, name text);`
+	out := MakeSQLIdempotent(sql)
+	if out != sql {
+		t.Errorf("expected no transformation, got:\n%s", out)
+	}
+}
+
+func TestMakeSQLIdempotent_ParseFailureReturnsOriginal(t *testing.T) {
+	// Unparseable SQL should return the original unchanged (not error/panic).
+	sql := `THIS IS NOT SQL;;;`
+	out := MakeSQLIdempotent(sql)
+	if out != sql {
+		t.Errorf("expected original on parse failure, got:\n%s", out)
+	}
+}

--- a/internal/migrations/app_declarative.go
+++ b/internal/migrations/app_declarative.go
@@ -342,17 +342,37 @@ func (s *AppDeclarativeService) planFromContent(ctx context.Context, schemaName,
 // to extension-provided operators like pgvector's <=>, or cross-schema objects).
 // Mirrors DeclarativeService.applySchemaDirectFallback. The content is made
 // idempotent via MakeSQLIdempotent, so re-applying a matching schema is a no-op.
-func (s *AppDeclarativeService) applyDirectFallback(ctx context.Context, schemaName, schemaContent string) error {
+//
+// Returns an ApplyResult with Fallback=true. When !allowDestructive, destructive
+// statements in the content (DROP TABLE/COLUMN/INDEX, TRUNCATE) are blocked —
+// the plan-path blocking doesn't cover the fallback, so it is enforced here.
+func (s *AppDeclarativeService) applyDirectFallback(ctx context.Context, schemaName, schemaContent string) (*ApplyResult, error) {
 	content, err := s.substituteAppUserForContent(schemaContent)
 	if err != nil {
-		return fmt.Errorf("invalid app user placeholder: %w", err)
+		return nil, fmt.Errorf("invalid app user placeholder: %w", err)
+	}
+
+	// Block destructive changes on the fallback path when not allowed. The
+	// plan-path destructive check (in ApplyFromContent) doesn't run when plan
+	// fails, so enforce it here by scanning the parsed content. Note:
+	// MakeSQLIdempotent's own DROP-prepends (for POLICY/TRIGGER/INDEX/CONSTRAINT)
+	// are safe re-creation aids, not destructive user intent — they are emitted
+	// by the transform, not present in the source content.
+	if !s.allowDestructive {
+		if destructive := countDestructiveStatements(content); destructive > 0 {
+			return &ApplyResult{
+				Applied:  []Change{},
+				Error:    fmt.Errorf("app schema content contains %d destructive statement(s) (DROP TABLE/COLUMN/INDEX, TRUNCATE); blocked (set allow_destructive=true to permit)", destructive),
+				Fallback: true,
+			}, nil
+		}
 	}
 
 	connStr := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable",
 		s.dbUser, s.dbPassword, s.dbHost, s.dbPort, s.dbName)
 	pool, err := pgxpool.New(ctx, connStr)
 	if err != nil {
-		return fmt.Errorf("failed to create connection pool: %w", err)
+		return nil, fmt.Errorf("failed to create connection pool: %w", err)
 	}
 	defer pool.Close()
 
@@ -366,12 +386,12 @@ func (s *AppDeclarativeService) applyDirectFallback(ctx context.Context, schemaN
 		searchPath = schemaName + ", public"
 	}
 	if _, err := pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", searchPath)); err != nil {
-		return fmt.Errorf("failed to set search_path: %w", err)
+		return nil, fmt.Errorf("failed to set search_path: %w", err)
 	}
 
 	idempotentSQL := dbschema.MakeSQLIdempotent(content)
 	if _, err := pool.Exec(ctx, idempotentSQL); err != nil {
-		return fmt.Errorf("failed to execute schema: %w", err)
+		return nil, fmt.Errorf("failed to execute schema: %w", err)
 	}
 
 	// pgschema treats CREATE TABLE IF NOT EXISTS as atomic, so missing columns on
@@ -382,7 +402,14 @@ func (s *AppDeclarativeService) applyDirectFallback(ctx context.Context, schemaN
 	if err := s.ensureMissingColumnsFromContent(ctx, schemaName, content, pool); err != nil {
 		log.Warn().Err(err).Str("schema", schemaName).Msg("Failed to ensure missing columns, continuing")
 	}
-	return nil
+
+	// Report the count of top-level statements executed (best-effort feedback;
+	// the fallback doesn't have per-change visibility like pgschema's plan).
+	appliedCount := countStatements(content)
+	return &ApplyResult{
+		Applied:  make([]Change, appliedCount),
+		Fallback: true,
+	}, nil
 }
 
 // ensureMissingColumnsFromContent scans CREATE TABLE IF NOT EXISTS column
@@ -544,14 +571,23 @@ func (s *AppDeclarativeService) ApplyFromContent(ctx context.Context, namespace,
 			Str("namespace", namespace).
 			Str("schema", schemaName).
 			Msg("pgschema plan failed, applying app schema via direct fallback")
-		if ferr := s.applyDirectFallback(ctx, schemaName, schemaContent); ferr != nil {
+		res, ferr := s.applyDirectFallback(ctx, schemaName, schemaContent)
+		if ferr != nil {
 			return nil, fmt.Errorf("failed to plan app schema for namespace=%s schema=%s: %w (and direct fallback failed: %w)", namespace, schemaName, err, ferr)
+		}
+		// If the fallback blocked destructive changes, surface that result.
+		if res != nil && res.Error != nil {
+			return res, nil
 		}
 		if err := s.recordApply(ctx, namespace, schemaName, fingerprint); err != nil {
 			log.Warn().Err(err).Msg("Failed to record app schema state")
 		}
-		log.Info().Str("namespace", namespace).Str("schema", schemaName).Msg("App schema applied via direct fallback")
-		return &ApplyResult{Applied: []Change{}, Duration: 0}, nil
+		log.Info().
+			Str("namespace", namespace).
+			Str("schema", schemaName).
+			Int("statements", len(res.Applied)).
+			Msg("App schema applied via direct fallback")
+		return res, nil
 	}
 
 	if len(plan.Changes) == 0 {
@@ -803,6 +839,51 @@ func (s *AppDeclarativeService) WarnIfImperativeCoexists(ctx context.Context, na
 				Msg("Namespace is managed declaratively but also has imperative migrations in platform.migrations; a schema should use one mode. Stop running 'fluxbase migrations sync' for this namespace or remove its declarative schema.")
 		}
 	}
+}
+
+// countDestructiveStatements counts top-level destructive SQL statements in
+// content (DROP TABLE, DROP COLUMN, DROP INDEX not part of MakeSQLIdempotent's
+// re-creation aids, DROP TYPE, DROP FUNCTION/PROCEDURE, DROP VIEW, TRUNCATE).
+// Used by the fallback path to enforce allowDestructive=false. Parsing is
+// best-effort; on parse failure it conservatively scans keywords.
+func countDestructiveStatements(content string) int {
+	count := 0
+	upper := strings.ToUpper(content)
+	for _, line := range strings.Split(upper, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Skip MakeSQLIdempotent-generated DROPs (safe re-creation aids) and
+		// comment lines. These prefixes are emitted by MakeSQLIdempotent.
+		if strings.HasPrefix(trimmed, "DROP POLICY IF EXISTS") ||
+			strings.HasPrefix(trimmed, "DROP TRIGGER IF EXISTS") ||
+			strings.HasPrefix(trimmed, "DROP CONSTRAINT IF EXISTS") ||
+			strings.HasPrefix(trimmed, "ALTER TABLE") && strings.Contains(trimmed, "DROP CONSTRAINT IF EXISTS") ||
+			strings.HasPrefix(trimmed, "DROP INDEX IF EXISTS") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "DROP TABLE") ||
+			strings.HasPrefix(trimmed, "DROP COLUMN") ||
+			strings.Contains(trimmed, " DROP COLUMN ") ||
+			strings.HasPrefix(trimmed, "DROP TYPE") ||
+			strings.HasPrefix(trimmed, "DROP FUNCTION") ||
+			strings.HasPrefix(trimmed, "DROP PROCEDURE") ||
+			strings.HasPrefix(trimmed, "DROP VIEW") ||
+			strings.HasPrefix(trimmed, "DROP SCHEMA") ||
+			strings.HasPrefix(trimmed, "TRUNCATE") {
+			count++
+		}
+	}
+	return count
+}
+
+// countStatements returns the number of top-level SQL statements in content,
+// estimated via pgparser. Used for best-effort apply feedback on the fallback
+// path (which lacks pgschema's per-change plan). Returns 0 on parse failure.
+func countStatements(content string) int {
+	stmts, err := parser.Parse(content)
+	if err != nil || stmts == nil {
+		return 0
+	}
+	return len(stmts.Items)
 }
 
 // writeSchemaWorkDir creates a temp directory, writes the schema SQL to

--- a/internal/migrations/app_declarative.go
+++ b/internal/migrations/app_declarative.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgplex/pgparser/nodes"
 	"github.com/pgplex/pgparser/parser"
@@ -103,6 +105,7 @@ func (s *AppDeclarativeService) ensureAppSchemasTable(ctx context.Context) error
 			schema_name        TEXT NOT NULL DEFAULT 'public',
 			schema_content     TEXT NOT NULL,
 			schema_fingerprint TEXT NOT NULL,
+			ignore_content     TEXT NOT NULL DEFAULT '',
 			enabled            BOOLEAN NOT NULL DEFAULT true,
 			updated_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
 			PRIMARY KEY (namespace, schema_name)
@@ -111,6 +114,11 @@ func (s *AppDeclarativeService) ensureAppSchemasTable(ctx context.Context) error
 	if err != nil {
 		return fmt.Errorf("failed to ensure platform.app_schemas: %w", err)
 	}
+
+	// Add ignore_content column to existing tables (idempotent; ignores "exists" error).
+	_, _ = s.pool.Exec(ctx, `
+		ALTER TABLE platform.app_schemas ADD COLUMN IF NOT EXISTS ignore_content TEXT NOT NULL DEFAULT ''
+	`)
 
 	_, err = s.pool.Exec(ctx, `
 		CREATE TABLE IF NOT EXISTS platform.app_schema_state (
@@ -130,7 +138,8 @@ func (s *AppDeclarativeService) ensureAppSchemasTable(ctx context.Context) error
 
 // StoreSchemaContent upserts synced schema content for a (namespace, schema).
 // Returns the computed fingerprint and whether the content changed.
-func (s *AppDeclarativeService) StoreSchemaContent(ctx context.Context, namespace, schemaName, schemaContent string) (fingerprint string, changed bool, err error) {
+// ignoreContent is optional pgschema .pgschemaignore content; empty disables filtering.
+func (s *AppDeclarativeService) StoreSchemaContent(ctx context.Context, namespace, schemaName, schemaContent, ignoreContent string) (fingerprint string, changed bool, err error) {
 	if namespace == "" {
 		return "", false, fmt.Errorf("namespace is required")
 	}
@@ -148,30 +157,31 @@ func (s *AppDeclarativeService) StoreSchemaContent(ctx context.Context, namespac
 	sum := sha256.Sum256([]byte(schemaContent))
 	fingerprint = hex.EncodeToString(sum[:])
 
-	// Check if content is unchanged.
+	// Check if content is unchanged (schema + ignore).
 	var existing string
 	err = s.pool.QueryRow(ctx, `
 		SELECT schema_fingerprint FROM platform.app_schemas
 		WHERE namespace = $1 AND schema_name = $2
 	`, namespace, schemaName).Scan(&existing)
 	if err == nil && existing == fingerprint {
-		// Unchanged — touch updated_at only.
+		// Unchanged — touch updated_at + keep ignore_content in sync.
 		_, _ = s.pool.Exec(ctx, `
-			UPDATE platform.app_schemas SET updated_at = now()
+			UPDATE platform.app_schemas SET updated_at = now(), ignore_content = $3
 			WHERE namespace = $1 AND schema_name = $2
-		`, namespace, schemaName)
+		`, namespace, schemaName, ignoreContent)
 		return fingerprint, false, nil
 	}
 
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO platform.app_schemas (namespace, schema_name, schema_content, schema_fingerprint, enabled, updated_at)
-		VALUES ($1, $2, $3, $4, true, now())
+		INSERT INTO platform.app_schemas (namespace, schema_name, schema_content, schema_fingerprint, ignore_content, enabled, updated_at)
+		VALUES ($1, $2, $3, $4, $5, true, now())
 		ON CONFLICT (namespace, schema_name) DO UPDATE SET
 			schema_content     = EXCLUDED.schema_content,
 			schema_fingerprint = EXCLUDED.schema_fingerprint,
+			ignore_content     = EXCLUDED.ignore_content,
 			enabled            = true,
 			updated_at         = now()
-	`, namespace, schemaName, schemaContent, fingerprint)
+	`, namespace, schemaName, schemaContent, fingerprint, ignoreContent)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to store app schema: %w", err)
 	}
@@ -192,6 +202,26 @@ func (s *AppDeclarativeService) GetStoredSchemaContent(ctx context.Context, name
 		WHERE namespace = $1 AND schema_name = $2
 	`, namespace, schemaName).Scan(&content, &fingerprint, &updatedAt)
 	return content, fingerprint, updatedAt, err
+}
+
+// GetStoredIgnoreContent retrieves the stored .pgschemaignore content for a
+// (namespace, schema). Returns "" if none is stored.
+func (s *AppDeclarativeService) GetStoredIgnoreContent(ctx context.Context, namespace, schemaName string) (string, error) {
+	if schemaName == "" {
+		schemaName = "public"
+	}
+	if err := s.ensureAppSchemasTable(ctx); err != nil {
+		return "", err
+	}
+	var ignore string
+	err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE(ignore_content, '') FROM platform.app_schemas
+		WHERE namespace = $1 AND schema_name = $2
+	`, namespace, schemaName).Scan(&ignore)
+	if err == pgx.ErrNoRows {
+		return "", nil
+	}
+	return ignore, err
 }
 
 // ListStoredSchemas lists stored app schemas, optionally filtered by namespace.
@@ -248,20 +278,23 @@ func (s *AppDeclarativeService) Plan(ctx context.Context, namespace, schemaName 
 	if content == "" {
 		return &Plan{Changes: []Change{}}, nil
 	}
-	return s.planFromContent(ctx, schemaName, content)
+	ignore, _ := s.GetStoredIgnoreContent(ctx, namespace, schemaName)
+	return s.planFromContent(ctx, schemaName, content, ignore)
 }
 
-// planFromContent writes content to a temp file and runs `pgschema plan`.
-func (s *AppDeclarativeService) planFromContent(ctx context.Context, schemaName, schemaContent string) (*Plan, error) {
+// planFromContent writes content to a temp dir (alongside an optional
+// .pgschemaignore) and runs `pgschema plan`. Setting cmd.Dir to that dir makes
+// pgschema auto-discover the ignore file.
+func (s *AppDeclarativeService) planFromContent(ctx context.Context, schemaName, schemaContent, ignoreContent string) (*Plan, error) {
 	content, err := s.substituteAppUserForContent(schemaContent)
 	if err != nil {
 		return nil, fmt.Errorf("invalid app user placeholder: %w", err)
 	}
-	tmpFile, err := writeContentToTemp("app-schema-*.sql", content)
+	workDir, schemaFile, err := writeSchemaWorkDir(content, ignoreContent)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = os.Remove(tmpFile) }()
+	defer func() { _ = os.RemoveAll(workDir) }()
 
 	args := []string{
 		"plan",
@@ -269,7 +302,7 @@ func (s *AppDeclarativeService) planFromContent(ctx context.Context, schemaName,
 		"--port", fmt.Sprintf("%d", s.dbPort),
 		"--user", s.dbUser,
 		"--db", s.dbName,
-		"--file", tmpFile,
+		"--file", schemaFile,
 		"--schema", schemaName,
 		"--output-json", "stdout",
 		"--plan-host", s.dbHost,
@@ -283,6 +316,7 @@ func (s *AppDeclarativeService) planFromContent(ctx context.Context, schemaName,
 	}
 
 	cmd := exec.CommandContext(ctx, s.pgschemaPath, args...)
+	cmd.Dir = workDir
 	cmd.Env = append(os.Environ(), fmt.Sprintf("PGPASSWORD=%s", s.dbPassword))
 
 	start := time.Now()
@@ -480,13 +514,13 @@ func stripLeadingComma(s string) string {
 // If the stored fingerprint already matches the last-applied fingerprint, the
 // plan is still computed (cheap no-op) so drift outside Fluxbase is detected and
 // reconciled on every apply — consistent with the internal declarative engine.
-func (s *AppDeclarativeService) ApplyFromContent(ctx context.Context, namespace, schemaName, schemaContent string) (*ApplyResult, error) {
+func (s *AppDeclarativeService) ApplyFromContent(ctx context.Context, namespace, schemaName, schemaContent, ignoreContent string) (*ApplyResult, error) {
 	if schemaName == "" {
 		schemaName = "public"
 	}
 
 	// Store first (also computes fingerprint + ensures tables exist).
-	fingerprint, _, err := s.StoreSchemaContent(ctx, namespace, schemaName, schemaContent)
+	fingerprint, _, err := s.StoreSchemaContent(ctx, namespace, schemaName, schemaContent, ignoreContent)
 	if err != nil {
 		return nil, err
 	}
@@ -497,7 +531,7 @@ func (s *AppDeclarativeService) ApplyFromContent(ctx context.Context, namespace,
 		Str("fingerprint", fingerprint[:12]).
 		Msg("Applying declarative app schema")
 
-	plan, err := s.planFromContent(ctx, schemaName, schemaContent)
+	plan, err := s.planFromContent(ctx, schemaName, schemaContent, ignoreContent)
 	if err != nil {
 		// pgschema plan can fail when the desired-state SQL references objects or
 		// operators from extensions (e.g. pgvector's <=> operator) or other schemas,
@@ -610,7 +644,8 @@ func (s *AppDeclarativeService) ApplyStored(ctx context.Context, namespace, sche
 	if content == "" {
 		return &ApplyResult{Applied: []Change{}}, nil
 	}
-	return s.ApplyFromContent(ctx, namespace, schemaName, content)
+	ignore, _ := s.GetStoredIgnoreContent(ctx, namespace, schemaName)
+	return s.ApplyFromContent(ctx, namespace, schemaName, content, ignore)
 }
 
 // ApplyAllPending applies stored content for all enabled (namespace, schema) pairs,
@@ -768,6 +803,30 @@ func (s *AppDeclarativeService) WarnIfImperativeCoexists(ctx context.Context, na
 				Msg("Namespace is managed declaratively but also has imperative migrations in platform.migrations; a schema should use one mode. Stop running 'fluxbase migrations sync' for this namespace or remove its declarative schema.")
 		}
 	}
+}
+
+// writeSchemaWorkDir creates a temp directory, writes the schema SQL to
+// "schema.sql" inside it, and (if ignoreContent is non-empty) writes a
+// ".pgschemaignore" next to it. Returns the dir path (to use as pgschema's
+// working directory so it auto-discovers the ignore file) and the schema file
+// path. Caller must remove the dir.
+func writeSchemaWorkDir(schemaContent, ignoreContent string) (dir, schemaFile string, err error) {
+	dir, err = os.MkdirTemp("", "app-schema-*")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	schemaFile = filepath.Join(dir, "schema.sql")
+	if err := os.WriteFile(schemaFile, []byte(schemaContent), 0o644); err != nil { //nolint:gosec
+		_ = os.RemoveAll(dir)
+		return "", "", fmt.Errorf("failed to write schema file: %w", err)
+	}
+	if ignoreContent != "" {
+		if err := os.WriteFile(filepath.Join(dir, ".pgschemaignore"), []byte(ignoreContent), 0o644); err != nil { //nolint:gosec
+			_ = os.RemoveAll(dir)
+			return "", "", fmt.Errorf("failed to write ignore file: %w", err)
+		}
+	}
+	return dir, schemaFile, nil
 }
 
 // writeContentToTemp writes content to a temp file and returns its path. The

--- a/internal/migrations/app_declarative_test.go
+++ b/internal/migrations/app_declarative_test.go
@@ -109,13 +109,13 @@ func TestStoreSchemaContent_ValidationGuard(t *testing.T) {
 	// No pool set — these validations must fail before touching the DB.
 
 	t.Run("rejects empty namespace", func(t *testing.T) {
-		_, _, err := svc.StoreSchemaContent(ctx, "", "public", "CREATE TABLE x ();")
+		_, _, err := svc.StoreSchemaContent(ctx, "", "public", "CREATE TABLE x ();", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "namespace is required")
 	})
 
 	t.Run("rejects empty content", func(t *testing.T) {
-		_, _, err := svc.StoreSchemaContent(ctx, "wayli", "public", "")
+		_, _, err := svc.StoreSchemaContent(ctx, "wayli", "public", "", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "content cannot be empty")
 	})

--- a/internal/migrations/app_declarative_test.go
+++ b/internal/migrations/app_declarative_test.go
@@ -133,6 +133,75 @@ func TestAppDeclarativeService_DestructiveDefault(t *testing.T) {
 	assert.True(t, svc.allowDestructive)
 }
 
+// TestCountDestructiveStatements verifies the fallback-path destructive scanner
+// detects user-authored destructive statements but ignores MakeSQLIdempotent's
+// own re-creation-aid DROPs (POLICY/TRIGGER/INDEX/CONSTRAINT IF EXISTS).
+func TestCountDestructiveStatements(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want int
+	}{
+		{"no destructive", "CREATE TABLE t (id int); CREATE INDEX ON t (id);", 0},
+		{"drop table", "DROP TABLE old_data;", 1},
+		{"drop column via alter", "ALTER TABLE t DROP COLUMN obsolete;", 1},
+		{"drop type", "DROP TYPE old_enum;", 1},
+		{"truncate", "TRUNCATE staging;", 1},
+		{"drop view", "DROP VIEW old_view;", 1},
+		{"drop function", "DROP FUNCTION old_fn();", 1},
+		{"multiple destructive", "DROP TABLE a;\nDROP TABLE b;\nTRUNCATE c;", 3},
+		// MakeSQLIdempotent-generated DROPs (re-creation aids) must NOT count:
+		{"drop policy if exists (idempotent aid)", `DROP POLICY IF EXISTS "p" ON t CASCADE;`, 0},
+		{"drop trigger if exists (idempotent aid)", `DROP TRIGGER IF EXISTS "trg" ON t CASCADE;`, 0},
+		{"drop index if exists (idempotent aid)", `DROP INDEX IF EXISTS idx;`, 0},
+		{"alter table drop constraint if exists (idempotent aid)", `ALTER TABLE t DROP CONSTRAINT IF EXISTS "c";`, 0},
+		{"comment lines ignored", "-- DROP TABLE commented_out;", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countDestructiveStatements(tt.sql)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestApplyDirectFallback_DestructiveBlocked verifies the fallback path blocks
+// destructive content when allowDestructive=false, without touching the DB.
+func TestApplyDirectFallback_DestructiveBlocked(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestAppService(t, false) // allowDestructive=false, no pool
+
+	t.Run("blocks DROP TABLE", func(t *testing.T) {
+		res, err := svc.applyDirectFallback(ctx, "public", "DROP TABLE old_data;")
+		require.NoError(t, err) // blocked, not an error
+		require.NotNil(t, res)
+		assert.True(t, res.Fallback, "result must indicate fallback path")
+		require.Error(t, res.Error, "must contain blocking error")
+		assert.Contains(t, res.Error.Error(), "destructive")
+	})
+
+	t.Run("blocks DROP COLUMN", func(t *testing.T) {
+		res, err := svc.applyDirectFallback(ctx, "public", "ALTER TABLE t DROP COLUMN obsolete;")
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Error(t, res.Error)
+		assert.Contains(t, res.Error.Error(), "destructive")
+	})
+}
+
+// TestApplyDirectFallback_NondestructivePassesContentScan verifies that
+// non-destructive content clears the destructive check (then fails later at DB
+// access, which is expected without a pool).
+func TestApplyDirectFallback_NondestructivePassesContentScan(t *testing.T) {
+	ctx := context.Background()
+	svc := newTestAppService(t, false)
+	res, err := svc.applyDirectFallback(ctx, "public", "CREATE TABLE IF NOT EXISTS t (id int);")
+	// No pool set → fails at connection, NOT at the destructive check.
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.NotContains(t, err.Error(), "destructive", "must not be blocked as destructive")
+}
+
 // TestSubstituteAppUserForContent covers placeholder substitution logic (pure).
 func TestSubstituteAppUserForContent(t *testing.T) {
 	t.Run("no app user returns content unchanged", func(t *testing.T) {

--- a/internal/migrations/plan.go
+++ b/internal/migrations/plan.go
@@ -76,6 +76,10 @@ type ApplyResult struct {
 	Applied  []Change
 	Duration time.Duration
 	Error    error
+	// Fallback is true when the apply used the direct-apply fallback path
+	// (pgschema plan could not validate the schema). In that case Applied
+	// reflects executed statement count, not individual pgschema changes.
+	Fallback bool
 }
 
 // ValidationResult represents the result of schema validation

--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,17 @@
       "matchStrings": ["FROM\\s+golang:(?<currentValue>[0-9.]+)(?:-[a-z]+)?"],
       "depNameTemplate": "golang",
       "datasourceTemplate": "docker"
+    },
+    {
+      "description": "Update pgschema version (declarative schema tool) in Dockerfiles",
+      "fileMatch": [
+        "Dockerfile",
+        "Dockerfile\\..+",
+        "^\\.devcontainer/Dockerfile"
+      ],
+      "matchStrings": ["ARG\\s+PGSCHEMA_VERSION=(?<currentValue>[0-9.]+)"],
+      "depNameTemplate": "pgplex/pgschema",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Makes declarative app-schema robust and usable for **any** Fluxbase app, especially those using extensions (PostGIS, pgvector). Resolves the tension between pgschema's whole-schema plan diffing and Fluxbase's grant model.

## Changes

### 1. Direct-apply fallback is the PRIMARY apply path
The key design decision. `ApplyFromContent` now applies via the direct fallback instead of trying pgschema plan first. **Why:** pgschema's plan is a whole-schema diff that includes Fluxbase's infrastructure grants (`service_role`, tenant roles, default privileges) which the app's schema file doesn't (and shouldn't) declare. This produces destructive REVOKEs — on pgschema 1.12.1 (which fixed the extension-operator crash), the plan now runs for Fluxbase apps and its destructive guard **silently blocks the entire apply**. The fallback applies only the app's declared DDL idempotently and never touches Fluxbase's infra grants — the correct model. pgschema's plan remains for `plan`/`validate` (drift detection), where output is informational.

### 2. Generic robust fallback (`MakeSQLIdempotent` + `applyDirectFallback`)
- **`CREATE TRIGGER`** → prepend `DROP TRIGGER IF EXISTS` (triggers weren't idempotent; re-applying failed)
- **`CREATE INDEX`** (bare, non-concurrent) → prepend `DROP INDEX IF EXISTS` (index-definition changes propagate). `IF NOT EXISTS`/`CONCURRENTLY` pass through.
- **Destructive blocking on the fallback path** — `allowDestructive=false` is now enforced (was bypassed). Scans for `DROP TABLE/COLUMN/TYPE/FUNCTION/VIEW/SCHEMA` + `TRUNCATE`, ignoring MakeSQLIdempotent's own re-creation-aid DROPs.
- **Accurate reporting** — `ApplyResult.Fallback` flag + statement count, surfaced via API (`fallback` field) and CLI (`"via direct fallback"` note). Replaces misleading "Applied 0 change(s)".

### 3. `.pgschemaignore` support for app-schema
pgschema auto-discovers `.pgschemaignore` from cwd, but `AppDeclarativeService` ran pgschema with the Fluxbase process cwd (`/app`), so an app's ignore file was never found. Now stores optional `ignore_content` in `platform.app_schemas`, writes it next to the temp schema file, and sets `cmd.Dir`. CLI `fluxbase schema sync` reads `.pgschemaignore` from the schema dir; API accepts `ignore_content`. Used by `plan`/`validate` to suppress drift noise on extension/infra objects.

### 4. pgschema pin 1.7.4 → 1.12.1
Upstream fix: plan no longer crashes on `LANGUAGE sql` functions with `SET search_path` that use extension operators (pgvector `<=>`). Fixed in pgschema 1.10.0 (#399). Several other relevant fixes landed between 1.7.4 and 1.12.1.

### 5. Renovate tracks pgschema version
New `regexManager` so the `ARG PGSCHEMA_VERSION` pin is tracked against `pgplex/pgschema` GitHub releases (previously drifted to 1.7.4 unnoticed).

## Testing
- `go build ./...` ✅ · `go test ./internal/migrations/ ./internal/database/schema/` ✅ · `go vet` ✅ · `golangci-lint` 0 issues ✅
- New `idempotent_test.go` (10 cases) + fallback tests (destructive blocking, reporting, passthrough).
- Pending end-to-end verification against Wayli (needs rc.6): zero-diff baseline, additive columns, trigger idempotency, destructive block, accurate reporting.

## Not changed (intentional)
- Column type changes & inline-constraint changes remain unsupported (destructive/atomic-no-op) — apps use a one-off migration + keep the artifact in sync.
- pgschema plan path unchanged for `plan`/`validate`.