### PR TITLE
fix(release): anchor changelog on last published release, not last tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,16 +393,27 @@ jobs:
 
       - name: Get previous stable tag
         id: prev_tag
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # Get the last stable release tag (excluding release candidates)
-          # This ensures release notes show all changes since the last stable release
-          PREV_TAG=$(git tag -l 'v*' | grep -v '\-rc\.' | sort -V | tail -n1)
+          # Anchor on the last PUBLISHED stable release, not just the last git tag.
+          # A tag-only "skipped" release (e.g. v2026.7.3, created as a tag but never
+          # published as a GitHub Release) would otherwise make the notes start at that
+          # tag and silently drop its commits. Anchoring on published releases rolls
+          # those commits into the next real release's notes.
+          PREV_TAG=$(gh release list --exclude-drafts --exclude-pre-releases -L 100 \
+            --json tagName -q '.[].tagName' | sort -V | tail -n1)
+
+          # Fallback: last non-RC git tag if no published release exists at all
+          if [ -z "$PREV_TAG" ]; then
+            PREV_TAG=$(git tag -l 'v*' | grep -v '\-rc\.' | sort -V | tail -n1)
+          fi
           if [ -z "$PREV_TAG" ]; then
             # If no previous stable tag, use first commit
             PREV_TAG=$(git rev-list --max-parents=0 HEAD)
           fi
           echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
-          echo "Previous stable tag: $PREV_TAG"
+          echo "Previous published stable tag: $PREV_TAG"
 
       - name: Generate changelog from commits and PRs
         id: changelog


### PR DESCRIPTION
## Problem

The `generate-changelog` job derived `PREV_TAG` from the **last git tag** (excluding RCs):

```bash
PREV_TAG=$(git tag -l 'v*' | grep -v '\-rc\.' | sort -V | tail -n1)
```

When a release is created as a **tag but never published as a GitHub Release**, the next stable release's notes anchored on that tag and **silently dropped its commits**.

This happened with **`v2026.7.3`** — the tag exists but `gh release view v2026.7.3` returns `release not found` (tag-only). As a result, the upcoming **`2026.7.4`** notes would have been scoped `v2026.7.3..HEAD` = **only 11 commits** (the schema work), dropping the ~70 commits from the 7.3 window:

- Multi-agent supervisor + page-aware chatbots (#249)
- Tavily web search integration (#254)
- SvelteKit SDK, Next.js/Vue scaffolds (#288)
- `service_role` pagination bypass fix (#287), `QueryBuilder.range()` clone (#286)
- Anthropic (Claude) provider support (#281), and dozens more fixes

## Fix

Anchor `PREV_TAG` on the last **published** stable GitHub Release instead of the last tag:

```yaml
PREV_TAG=$(gh release list --exclude-drafts --exclude-pre-releases -L 100 \
  --json tagName -q '.[].tagName' | sort -V | tail -n1)
```

with fallbacks to the last non-RC tag, then the first commit. Since `v2026.7.3` was never published, the next stable release resolves `PREV_TAG = v2026.7.2` and its notes span the full 81 commits. This is durable — a future tag-only release can't silently drop commits again.

## Verification (against current repo state)

| | Anchor | Commits covered |
|---|---|---|
| Old logic | `v2026.7.3` (tag, no release) | **11** ❌ |
| New logic | `v2026.7.2` (last *published* release) | **81** ✅ |

YAML validated. `prev_tag` is the single source consumed by all downstream steps (changelog, AI summary, commit counts), so no other edits were needed.

## Follow-up

After merging, cut `2026.7.4` stable via `workflow_dispatch` → `release_type: stable`, then verify with `gh release view v2026.7.4`.

## Notes

- Does **not** rewrite the already-published rc.1–rc.4 notes (scoped to `v2026.7.3..HEAD`); RC notes are low-stakes.
- Unrelated to the still-pending `VERSION` / `deploy/docker-compose.yml` (both still read `2026.7.2` because `update-version-files` didn't run without a published 7.3 release) — the 7.4 stable cut should advance those, but worth confirming post-release.