### PR TITLE
fix(schema): use direct-apply fallback as PRIMARY apply path for app schemas

### DIFF
--- a/internal/migrations/app_declarative.go
+++ b/internal/migrations/app_declarative.go
@@ -534,13 +534,19 @@ func stripLeadingComma(s string) string {
 	return strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(s), ","))
 }
 
-// ApplyFromContent stores the content and applies it via pgschema. This is the
-// entry point used by `fluxbase schema sync` (store + apply) and by ApplyAllPending
-// (startup) against already-stored content.
+// ApplyFromContent stores the content and applies it. This is the entry point
+// used by `fluxbase schema sync` (store + apply) and by ApplyAllPending (startup)
+// against already-stored content.
 //
-// If the stored fingerprint already matches the last-applied fingerprint, the
-// plan is still computed (cheap no-op) so drift outside Fluxbase is detected and
-// reconciled on every apply — consistent with the internal declarative engine.
+// Apply uses the DIRECT-APPLY FALLBACK as the primary path, not pgschema's plan.
+// Rationale: pgschema's plan is a whole-schema diff that includes Fluxbase's
+// infrastructure grants (service_role, tenant roles, default privileges) which
+// the app's schema file doesn't (and shouldn't) declare — producing destructive
+// REVOKEs that would break Fluxbase if applied. The fallback applies only the
+// app's declared DDL idempotently (CREATE IF NOT EXISTS + ensureMissingColumns +
+// MakeSQLIdempotent for policies/triggers/indexes/constraints), which is the
+// correct model for a Fluxbase app. pgschema's plan remains available for
+// plan/validate (drift detection) via the Plan() method.
 func (s *AppDeclarativeService) ApplyFromContent(ctx context.Context, namespace, schemaName, schemaContent, ignoreContent string) (*ApplyResult, error) {
 	if schemaName == "" {
 		schemaName = "public"
@@ -558,117 +564,23 @@ func (s *AppDeclarativeService) ApplyFromContent(ctx context.Context, namespace,
 		Str("fingerprint", fingerprint[:12]).
 		Msg("Applying declarative app schema")
 
-	plan, err := s.planFromContent(ctx, schemaName, schemaContent, ignoreContent)
+	res, err := s.applyDirectFallback(ctx, schemaName, schemaContent)
 	if err != nil {
-		// pgschema plan can fail when the desired-state SQL references objects or
-		// operators from extensions (e.g. pgvector's <=> operator) or other schemas,
-		// because plan validation applies the SQL to a temporary schema where those
-		// aren't available. This mirrors the internal declarative engine: fall back
-		// to applying the idempotent SQL directly. Since pgschema-dump content uses
-		// CREATE ... IF NOT EXISTS throughout, direct application is safe and a
-		// re-apply against a matching DB is a no-op.
-		log.Warn().Err(err).
-			Str("namespace", namespace).
-			Str("schema", schemaName).
-			Msg("pgschema plan failed, applying app schema via direct fallback")
-		res, ferr := s.applyDirectFallback(ctx, schemaName, schemaContent)
-		if ferr != nil {
-			return nil, fmt.Errorf("failed to plan app schema for namespace=%s schema=%s: %w (and direct fallback failed: %w)", namespace, schemaName, err, ferr)
-		}
-		// If the fallback blocked destructive changes, surface that result.
-		if res != nil && res.Error != nil {
-			return res, nil
-		}
-		if err := s.recordApply(ctx, namespace, schemaName, fingerprint); err != nil {
-			log.Warn().Err(err).Msg("Failed to record app schema state")
-		}
-		log.Info().
-			Str("namespace", namespace).
-			Str("schema", schemaName).
-			Int("statements", len(res.Applied)).
-			Msg("App schema applied via direct fallback")
+		return nil, fmt.Errorf("failed to apply app schema for namespace=%s schema=%s: %w", namespace, schemaName, err)
+	}
+	// If the fallback blocked destructive changes, surface that result without recording apply.
+	if res != nil && res.Error != nil {
 		return res, nil
 	}
-
-	if len(plan.Changes) == 0 {
-		if err := s.recordApply(ctx, namespace, schemaName, fingerprint); err != nil {
-			log.Warn().Err(err).Msg("Failed to record app schema state")
-		}
-		log.Info().Str("namespace", namespace).Str("schema", schemaName).Msg("No app schema changes to apply")
-		return &ApplyResult{Applied: []Change{}, Duration: 0}, nil
-	}
-
-	// Block destructive changes unless explicitly allowed.
-	if !s.allowDestructive {
-		destructive := 0
-		for _, c := range plan.Changes {
-			if c.Destructive {
-				destructive++
-			}
-		}
-		if destructive > 0 {
-			if err := s.recordApply(ctx, namespace, schemaName, fingerprint); err != nil {
-				log.Warn().Err(err).Msg("Failed to record app schema state")
-			}
-			return &ApplyResult{
-				Applied:  []Change{},
-				Duration: 0,
-				Error:    fmt.Errorf("app schema plan for namespace=%s schema=%s contains %d destructive change(s); blocked (set allow_destructive=true to permit)", namespace, schemaName, destructive),
-			}, nil
-		}
-	}
-
-	// Apply using pgschema (plan + auto-approve), same as the tenant path.
-	applyContent, err := s.substituteAppUserForContent(schemaContent)
-	if err != nil {
-		return nil, fmt.Errorf("invalid app user placeholder: %w", err)
-	}
-	tmpFile, err := writeContentToTemp("app-schema-*.sql", applyContent)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = os.Remove(tmpFile) }()
-
-	planFile, err := writePlanToTempFile(plan)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = os.Remove(planFile) }()
-
-	applyArgs := []string{
-		"apply",
-		"--host", s.dbHost,
-		"--port", fmt.Sprintf("%d", s.dbPort),
-		"--user", s.dbUser,
-		"--db", s.dbName,
-		"--file", tmpFile,
-		"--schema", schemaName,
-		"--plan", planFile,
-		"--auto-approve",
-	}
-	applyCmd := exec.CommandContext(ctx, s.pgschemaPath, applyArgs...)
-	applyCmd.Env = append(os.Environ(), fmt.Sprintf("PGPASSWORD=%s", s.dbPassword))
-
-	start := time.Now()
-	if _, err := applyCmd.Output(); err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("pgschema apply failed: %w: %s", err, string(exitErr.Stderr))
-		}
-		return nil, fmt.Errorf("pgschema apply failed: %w", err)
-	}
-
 	if err := s.recordApply(ctx, namespace, schemaName, fingerprint); err != nil {
 		log.Warn().Err(err).Msg("Failed to record app schema state")
 	}
-
 	log.Info().
 		Str("namespace", namespace).
 		Str("schema", schemaName).
-		Int("changes", len(plan.Changes)).
-		Str("duration", time.Since(start).String()).
-		Msg("App declarative schema applied successfully")
-
-	return &ApplyResult{Applied: plan.Changes, Duration: time.Since(start)}, nil
+		Int("statements", len(res.Applied)).
+		Msg("App schema applied via direct fallback")
+	return res, nil
 }
 
 // ApplyStored applies the already-stored content for a (namespace, schema).


### PR DESCRIPTION
## Summary

Fixes a regression introduced by the pgschema 1.12.1 bump (#297 / rc.5).

With pgschema 1.12.1, plan no longer crashes on extension operators — so it now runs for Fluxbase apps and produces a whole-schema diff that includes Fluxbase's infrastructure grants (`service_role`, tenant roles, default privileges). Those grants aren't declared in the app's schema file (and shouldn't be), so the plan generates destructive REVOKEs. The destructive guard then **silently blocks the entire apply** — `fluxbase schema sync` does nothing.

On rc.4 (pgschema 1.7.4), plan crashed and the fallback ran, so applies worked. Bumping pgschema "fixed" the crash but broke the working path.

## Fix

Make the direct-apply fallback the **primary** apply path for app schemas (`ApplyFromContent`), instead of trying pgschema plan first. The fallback applies only the app's declared DDL idempotently and never touches Fluxbase's infrastructure grants — the correct model for a Fluxbase app.

This is the same apply path that rc.4 used effectively (because the fallback was the de-facto path when plan crashed). The fallback already has the robust capabilities from #297: trigger/index idempotency (MakeSQLIdempotent), destructive-change blocking, additive columns (ensureMissingColumns), and accurate reporting.

pgschema's plan remains available for `plan`/`validate` (drift detection), where destructive output is informational, not applied.

## What changed
- `ApplyFromContent`: calls `applyDirectFallback` directly instead of `planFromContent` → fallback-on-failure. Removes the now-unused plan-apply branch + its destructive guard (the fallback enforces `allowDestructive` itself). Net: **−108 lines, +20**.

## Testing
- `go build ./...` ✅ · `go test ./internal/migrations/ ./internal/database/schema/` ✅ · `golangci-lint` 0 issues ✅
- The fallback path's capabilities were verified end-to-end on rc.4 (zero-diff baseline, additive columns, function/policy changes, idempotent re-apply).
- Pending: full verification on rc.6 (this PR) — zero-diff, additive, triggers, destructive block, reporting in one pass.

## Why not fix the plan path instead
Investigated thoroughly: pgschema's whole-schema diffing is **fundamentally mismatched** with Fluxbase's grant model. Fluxbase grants full DML to `service_role`/tenant roles on base tables (multi-tenancy); an app's schema file manages structure + RLS grants to `authenticated`/`anon`, not those infra roles. No amount of `.pgschemaignore` cleanly separates them (same role names across object types). The fallback's "apply only declared DDL" model is architecturally correct; the plan path's "diff everything" model isn't, for this use case.