### PR TITLE
feat(extensions): enable out-of-the-box via catalog sync + pg_available fallback

### DIFF
--- a/cmd/fluxbase/main.go
+++ b/cmd/fluxbase/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nimbleflux/fluxbase/internal/database"
 	"github.com/nimbleflux/fluxbase/internal/database/bootstrap"
 	"github.com/nimbleflux/fluxbase/internal/database/schema"
+	"github.com/nimbleflux/fluxbase/internal/extensions"
 	"github.com/nimbleflux/fluxbase/internal/migrations"
 	"github.com/nimbleflux/fluxbase/internal/storage"
 	"github.com/nimbleflux/fluxbase/internal/tenantdb"
@@ -179,6 +180,16 @@ func main() {
 		os.Exit(1)
 	}
 	log.Info().Msg("Database bootstrap completed successfully")
+
+	// Sync the extension catalog from pg_available_extensions so that
+	// `fluxbase extensions enable <name>` works out-of-the-box (the catalog
+	// is empty on fresh installs, which blocked the enable path).
+	extService := extensions.NewService(db)
+	if count, err := extService.SyncExtensionCatalog(context.Background()); err != nil {
+		log.Warn().Err(err).Msg("Failed to sync extension catalog, continuing")
+	} else if count > 0 {
+		log.Info().Int("synced", count).Msg("Extension catalog synced from PostgreSQL")
+	}
 
 	// Apply declarative schema (tables, indexes, functions, policies)
 	// This uses pgschema to apply the internal Fluxbase schema

--- a/internal/extensions/handler.go
+++ b/internal/extensions/handler.go
@@ -1,6 +1,8 @@
 package extensions
 
 import (
+	"fmt"
+
 	"github.com/gofiber/fiber/v3"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
@@ -161,9 +163,17 @@ func (h *Handler) DisableExtension(c fiber.Ctx) error {
 // SyncExtensions syncs the extension catalog with PostgreSQL
 // POST /api/v1/admin/extensions/sync
 func (h *Handler) SyncExtensions(c fiber.Ctx) error {
+	count, err := h.service.SyncExtensionCatalog(c.Context())
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"success": false,
+			"message": fmt.Sprintf("Failed to sync extensions: %v", err),
+		})
+	}
 	return c.JSON(fiber.Map{
 		"success": true,
-		"message": "Extensions synced successfully",
+		"message": fmt.Sprintf("Synced %d extensions from PostgreSQL", count),
+		"count":   count,
 	})
 }
 

--- a/internal/extensions/service.go
+++ b/internal/extensions/service.go
@@ -349,17 +349,28 @@ func (s *Service) enableExtensionRecursive(ctx context.Context, name string, use
 		return nil, fmt.Errorf("extension dependency chain too deep (>%d), possible circular dependency", maxDepth)
 	}
 
-	// Validate extension exists in catalog
+	// Validate extension exists in catalog, falling back to pg_available_extensions.
+	// The catalog (platform.available_extensions) may be empty on fresh installs
+	// (it's populated lazily by SyncExtensions). If the extension isn't in the
+	// catalog, check whether PostgreSQL itself knows about it — if so, allow
+	// enabling it (the CREATE EXTENSION runs as admin regardless).
 	available, err := s.getAvailableExtension(ctx, name)
 	if err != nil {
 		return nil, err
 	}
 	if available == nil {
-		return &EnableExtensionResponse{
-			Name:    name,
-			Success: false,
-			Message: "Extension not found in catalog",
-		}, nil
+		// Fallback: check if the extension is available in PostgreSQL directly.
+		pgAvailable, pgErr := s.isExtensionAvailableInPostgres(ctx, name)
+		if pgErr != nil || !pgAvailable {
+			return &EnableExtensionResponse{
+				Name:    name,
+				Success: false,
+				Message: "Extension not found in catalog or available in PostgreSQL",
+			}, nil
+		}
+		// Extension is available in PostgreSQL but not in the catalog — proceed.
+		// Use a minimal available-extension stub so downstream logic works.
+		available = &AvailableExtension{Name: name, Category: categoryForExtension(name)}
 	}
 
 	// Check if already enabled
@@ -636,6 +647,114 @@ func (s *Service) getAvailableExtension(ctx context.Context, name string) (*Avai
 		return nil, fmt.Errorf("failed to get extension: %w", err)
 	}
 	return &ext, nil
+}
+
+// SyncExtensionCatalog populates platform.available_extensions from
+// pg_available_extensions, upserting any missing rows with sensible category
+// defaults. Returns the number of extensions synced. Called on startup and via
+// the POST /api/v1/admin/extensions/sync endpoint.
+func (s *Service) SyncExtensionCatalog(ctx context.Context) (int, error) {
+	// Query all available extensions from PostgreSQL.
+	type pgExt struct {
+		Name    string
+		Version string
+		Comment string
+	}
+	var exts []pgExt
+	err := database.WrapWithServiceRole(ctx, s.db, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT name, COALESCE(default_version, ''), COALESCE(comment, '')
+			FROM pg_available_extensions
+			ORDER BY name
+		`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var e pgExt
+			if err := rows.Scan(&e.Name, &e.Version, &e.Comment); err != nil {
+				return err
+			}
+			exts = append(exts, e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to query pg_available_extensions: %w", err)
+	}
+
+	// Upsert each into the catalog (skip rows that already exist — don't overwrite
+	// admin-customized metadata).
+	synced := 0
+	for _, e := range exts {
+		category := categoryForExtension(e.Name)
+		displayName := strings.Title(strings.ReplaceAll(e.Name, "_", " "))
+		var affected int64
+		err := database.WrapWithServiceRole(ctx, s.db, func(tx pgx.Tx) error {
+			tag, err := tx.Exec(ctx, `
+				INSERT INTO platform.available_extensions (name, display_name, description, category)
+				VALUES ($1, $2, $3, $4)
+				ON CONFLICT (name) DO NOTHING
+			`, e.Name, displayName, e.Comment, category)
+			if err != nil {
+				return err
+			}
+			affected = tag.RowsAffected()
+			return nil
+		})
+		if err != nil {
+			log.Warn().Err(err).Str("extension", e.Name).Msg("Failed to upsert extension in catalog")
+			continue
+		}
+		if affected > 0 {
+			synced++
+		}
+	}
+
+	log.Info().Int("synced", synced).Int("total_available", len(exts)).Msg("Extension catalog synced from PostgreSQL")
+	return synced, nil
+}
+
+// isExtensionAvailableInPostgres checks whether an extension is installable
+// on the main database by querying pg_available_extensions. This is the
+// fallback when the extension isn't in the platform.available_extensions catalog.
+func (s *Service) isExtensionAvailableInPostgres(ctx context.Context, name string) (bool, error) {
+	var exists bool
+	err := database.WrapWithServiceRole(ctx, s.db, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `
+			SELECT EXISTS(SELECT 1 FROM pg_available_extensions WHERE name = $1)
+		`, name).Scan(&exists)
+	})
+	return exists, err
+}
+
+// categoryForExtension returns a sensible default category for known extensions.
+// Used when enabling an extension that isn't yet in the catalog.
+func categoryForExtension(name string) string {
+	switch strings.ToLower(name) {
+	case "postgis", "postgis_topology", "postgis_raster", "postgis_sfcgal",
+		"address_standardizer", "address_standardizer_data_us", "pgrouting":
+		return "geospatial"
+	case "vector", "vectorscale", "ai":
+		return "ai_ml"
+	case "pg_trgm", "unaccent", "fuzzystrmatch":
+		return "text_search"
+	case "pg_stat_statements", "pg_stat_monitor", "pg_buffercache":
+		return "monitoring"
+	case "timescaledb", "pg_cron", "pg_partman":
+		return "scheduling"
+	case "pgcrypto", "pgjwt":
+		return "data_types"
+	case "uuid-ossp", "btree_gin", "btree_gist", "intarray", "citext":
+		return "indexing"
+	case "postgres_fdw", "dblink", "file_fdw":
+		return "foreign_data"
+	case "pg_repack", "pg_squeeze":
+		return "maintenance"
+	default:
+		return "utilities"
+	}
 }
 
 // recordExtensionErrorForTenant records an error for a tenant's extension operation

--- a/internal/extensions/service_test.go
+++ b/internal/extensions/service_test.go
@@ -486,3 +486,33 @@ func BenchmarkIsValidIdentifier_Invalid(b *testing.B) {
 		_ = isValidIdentifier("invalid-identifier")
 	}
 }
+
+// =============================================================================
+// categoryForExtension Tests
+// =============================================================================
+
+func TestCategoryForExtension(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"postgis", "geospatial"},
+		{"postgis_topology", "geospatial"},
+		{"PostGIS", "geospatial"}, // case-insensitive
+		{"vector", "ai_ml"},
+		{"pg_trgm", "text_search"},
+		{"pgcrypto", "data_types"},
+		{"uuid-ossp", "indexing"},
+		{"timescaledb", "scheduling"},
+		{"postgres_fdw", "foreign_data"},
+		{"pg_stat_statements", "monitoring"},
+		{"some_unknown_ext", "utilities"},
+		{"", "utilities"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := categoryForExtension(tt.name)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`fluxbase extensions enable <name>` was broken out-of-the-box: `platform.available_extensions` was never seeded, and the enable path unconditionally checked the catalog before `CREATE EXTENSION` — always returning "Extension not found in catalog".

This blocked apps (e.g. Wayli needing PostGIS) from enabling extensions through the proper Fluxbase API, forcing workarounds like raw psql or `CREATE EXTENSION` in schema content.

### Root cause
The catalog (`platform.available_extensions`) is empty on fresh installs. `SyncExtensions` was a stub (returned success without doing anything). `InitializeCoreExtensions` is dead code (never called). The privilege model was already correct (`CREATE EXTENSION` runs via `ExecuteWithAdminRole` = superuser); only the catalog gate was blocking.

### Fixes

**1. Relax the catalog guard** (`service.go:352-363`): when an extension isn't in `platform.available_extensions`, fall back to checking `pg_available_extensions` (the live PostgreSQL view). If PostgreSQL knows about it, proceed — `CREATE EXTENSION` already runs as admin. Makes `fluxbase extensions enable postgis` work immediately, even on fresh installs.

**2. Implement `SyncExtensionCatalog`** (`service.go` + `handler.go`): replaces the `SyncExtensions` stub. Populates `platform.available_extensions` from `pg_available_extensions` with sensible category defaults (postgis → geospatial, pgvector → ai_ml, etc.). Upserts missing rows without overwriting admin-customized metadata. Returns the count synced.

**3. Wire into startup** (`main.go`): calls `SyncExtensionCatalog` after bootstrap, before the declarative schema apply. The catalog is always populated on startup.

## Testing
- `go build ./...` ✅ · `go test ./internal/extensions/` ✅ · `golangci-lint` 0 issues ✅
- New `TestCategoryForExtension` unit tests (12 cases: known extensions + unknown fallback + case-insensitivity).
- Pending end-to-end: verify `fluxbase extensions enable postgis` works after this ships (needs a new RC).

## Impact on Wayli
Once this ships, Wayli can replace the `CREATE EXTENSION` workaround in `public.sql` with `fluxbase extensions enable postgis` in its `sync:schema` flow — the proper Fluxbase API, with extensions tracked in `platform.enabled_extensions`.