### PR TITLE
fix(extensions): catalog sync ordering + empty userID normalization

### DIFF
--- a/cmd/fluxbase/main.go
+++ b/cmd/fluxbase/main.go
@@ -181,16 +181,6 @@ func main() {
 	}
 	log.Info().Msg("Database bootstrap completed successfully")
 
-	// Sync the extension catalog from pg_available_extensions so that
-	// `fluxbase extensions enable <name>` works out-of-the-box (the catalog
-	// is empty on fresh installs, which blocked the enable path).
-	extService := extensions.NewService(db)
-	if count, err := extService.SyncExtensionCatalog(context.Background()); err != nil {
-		log.Warn().Err(err).Msg("Failed to sync extension catalog, continuing")
-	} else if count > 0 {
-		log.Info().Int("synced", count).Msg("Extension catalog synced from PostgreSQL")
-	}
-
 	// Apply declarative schema (tables, indexes, functions, policies)
 	// This uses pgschema to apply the internal Fluxbase schema
 	log.Info().Msg("Applying declarative schema...")
@@ -280,6 +270,16 @@ func main() {
 	log.Debug().Msg("Recreating connection pool after migrations...")
 	if err := db.RecreatePool(); err != nil {
 		log.Warn().Err(err).Msg("Failed to recreate connection pool, continuing with existing pool")
+	}
+
+	// Sync the extension catalog from pg_available_extensions so that
+	// `fluxbase extensions enable <name>` works out-of-the-box. Must run AFTER
+	// the declarative schema apply (which creates platform.available_extensions).
+	extService := extensions.NewService(db)
+	if count, err := extService.SyncExtensionCatalog(context.Background()); err != nil {
+		log.Warn().Err(err).Msg("Failed to sync extension catalog, continuing")
+	} else if count > 0 {
+		log.Info().Int("synced", count).Msg("Extension catalog synced from PostgreSQL")
 	}
 
 	// Apply declarative app schema (opt-in). Lets an application developer manage

--- a/internal/extensions/service.go
+++ b/internal/extensions/service.go
@@ -349,6 +349,12 @@ func (s *Service) enableExtensionRecursive(ctx context.Context, name string, use
 		return nil, fmt.Errorf("extension dependency chain too deep (>%d), possible circular dependency", maxDepth)
 	}
 
+	// Normalize: empty-string userID (e.g. from service-role CLI calls with no
+	// user context) must be NULL for UUID columns, not an empty string.
+	if userID != nil && *userID == "" {
+		userID = nil
+	}
+
 	// Validate extension exists in catalog, falling back to pg_available_extensions.
 	// The catalog (platform.available_extensions) may be empty on fresh installs
 	// (it's populated lazily by SyncExtensions). If the extension isn't in the


### PR DESCRIPTION
## Summary

Two follow-up fixes to #300 (extension catalog sync), found during end-to-end testing.

### 1. Catalog sync runs AFTER declarative schema, not before
`SyncExtensionCatalog` ran after bootstrap but **before** the declarative schema apply — which creates `platform.available_extensions`. On fresh installs, every catalog upsert failed: `relation "platform.available_extensions" does not exist`. Moved the sync to after the declarative schema + pool recreation.

### 2. Normalize empty-string userID to nil
Service-role CLI/API calls (no user context) pass an empty-string `userID` to `platform.enabled_extensions.enabled_by` (a UUID column): `invalid input syntax for type uuid: ""`. Fixed by normalizing empty-string `userID` to `nil` at the top of `enableExtensionRecursive`, covering all INSERT sites.

## Testing
- `go build ./...` ✅ · `go test ./internal/extensions/` ✅ · `golangci-lint` 0 issues ✅
- Reproduced both bugs against the running devcontainer; these fixes resolve them.