### PR TITLE
fix(schema): run ensureMissingColumns BEFORE bulk SQL exec in fallback

### DIFF
--- a/internal/migrations/app_declarative.go
+++ b/internal/migrations/app_declarative.go
@@ -389,18 +389,18 @@ func (s *AppDeclarativeService) applyDirectFallback(ctx context.Context, schemaN
 		return nil, fmt.Errorf("failed to set search_path: %w", err)
 	}
 
+	// Add missing columns BEFORE the bulk SQL exec. LANGUAGE sql function bodies
+	// are validated at creation time and reference columns by name — if a column
+	// is declared in a CREATE TABLE but missing from the live DB (additive change),
+	// a CREATE OR REPLACE FUNCTION referencing it would fail before the column is
+	// added. Running ensureMissingColumns first prevents this ordering issue.
+	if err := s.ensureMissingColumnsFromContent(ctx, schemaName, content, pool); err != nil {
+		log.Warn().Err(err).Str("schema", schemaName).Msg("Failed to ensure missing columns, continuing")
+	}
+
 	idempotentSQL := dbschema.MakeSQLIdempotent(content)
 	if _, err := pool.Exec(ctx, idempotentSQL); err != nil {
 		return nil, fmt.Errorf("failed to execute schema: %w", err)
-	}
-
-	// pgschema treats CREATE TABLE IF NOT EXISTS as atomic, so missing columns on
-	// existing tables are not added by the idempotent re-run above. Port the same
-	// ensureMissingColumns step the internal declarative engine uses: scan the
-	// schema content for column definitions and ALTER TABLE ADD COLUMN any that
-	// are absent. This makes additive schema evolution work via the fallback path.
-	if err := s.ensureMissingColumnsFromContent(ctx, schemaName, content, pool); err != nil {
-		log.Warn().Err(err).Str("schema", schemaName).Msg("Failed to ensure missing columns, continuing")
 	}
 
 	// Report the count of top-level statements executed (best-effort feedback;


### PR DESCRIPTION
## Summary

Fixes a production failure: `column "transport_mode_manual" of relation "tracker_data" does not exist`.

The fallback's `applyDirectFallback` ran the full schema content (including `CREATE OR REPLACE FUNCTION` bodies) **before** `ensureMissingColumns`. `LANGUAGE sql` function bodies are validated at creation time and reference columns by name — if a column is declared in `public.sql` but missing from the live DB (an additive change), the function creation fails before `ensureMissingColumns` gets a chance to add it.

In production, `tracker_data.transport_mode_manual` was declared in `public.sql` but missing from the DB. A trigger function referencing it failed during the bulk SQL exec, aborting the entire schema apply.

## Fix

Move `ensureMissingColumnsFromContent` to run **before** `pool.Exec(idempotentSQL)`. Missing columns are added first, so function bodies can validate against them.

## Testing
- `go build ./...` ✅ · `go test ./internal/migrations/` ✅ · `golangci-lint` 0 issues ✅
- Reproduced in production (Wayli prod K8s); this fix resolves the ordering issue.