### PR TITLE
fix(schema): DROP VIEW before CREATE OR REPLACE VIEW in MakeSQLIdempotent

### DIFF
--- a/internal/database/schema/idempotent.go
+++ b/internal/database/schema/idempotent.go
@@ -71,6 +71,21 @@ func MakeSQLIdempotent(sql string) string {
 				drops = append(drops, dropInfo{pattern: patternUnquoted, dropSQL: dropSQL, foundPos: -1})
 			}
 
+		case *nodes.ViewStmt:
+			// CREATE OR REPLACE VIEW cannot change column names, types, or order
+			// of an existing view. When the view definition changes (e.g. a new
+			// column is added to the underlying table and selected), OR REPLACE
+			// fails with "cannot change name of view column". Prepend
+			// DROP VIEW IF EXISTS so the view is recreated fresh.
+			if stmt.View != nil {
+				viewName := formatRangeVar(stmt.View)
+				dropSQL := fmt.Sprintf("DROP VIEW IF EXISTS %s CASCADE;\n", viewName)
+				patternQuoted := "CREATE OR REPLACE VIEW \"" + stmt.View.Relname + "\""
+				patternUnquoted := "CREATE OR REPLACE VIEW " + stmt.View.Relname
+				drops = append(drops, dropInfo{pattern: patternQuoted, dropSQL: dropSQL, foundPos: -1})
+				drops = append(drops, dropInfo{pattern: patternUnquoted, dropSQL: dropSQL, foundPos: -1})
+			}
+
 		case *nodes.AlterTableStmt:
 			if stmt.Cmds != nil && stmt.Relation != nil {
 				for _, cmd := range stmt.Cmds.Items {

--- a/internal/database/schema/idempotent_test.go
+++ b/internal/database/schema/idempotent_test.go
@@ -55,6 +55,30 @@ func TestMakeSQLIdempotent_CreateTriggerQuoted(t *testing.T) {
 	}
 }
 
+func TestMakeSQLIdempotent_CreateOrReplaceView(t *testing.T) {
+	sql := `CREATE OR REPLACE VIEW my_tracker_data WITH (security_barrier=true) AS SELECT id, name FROM tracker_data WHERE user_id = 1;`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP VIEW IF EXISTS "my_tracker_data" CASCADE;`) {
+		t.Errorf("expected DROP VIEW prepended, got:\n%s", out)
+	}
+	if !strings.Contains(out, `CREATE OR REPLACE VIEW my_tracker_data`) {
+		t.Errorf("expected original CREATE VIEW preserved, got:\n%s", out)
+	}
+	dropIdx := strings.Index(out, "DROP VIEW")
+	createIdx := strings.Index(out, "CREATE OR REPLACE VIEW")
+	if dropIdx < 0 || createIdx < 0 || dropIdx > createIdx {
+		t.Errorf("expected DROP before CREATE, got dropIdx=%d createIdx=%d", dropIdx, createIdx)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateOrReplaceViewQuoted(t *testing.T) {
+	sql := `CREATE OR REPLACE VIEW "My View" AS SELECT 1;`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP VIEW IF EXISTS "My View" CASCADE;`) {
+		t.Errorf("expected DROP VIEW for quoted name, got:\n%s", out)
+	}
+}
+
 func TestMakeSQLIdempotent_CreateIndex(t *testing.T) {
 	sql := `CREATE INDEX idx_users_email ON public.users (email);`
 	out := MakeSQLIdempotent(sql)


### PR DESCRIPTION
## Summary

`CREATE OR REPLACE VIEW` cannot change column names, types, or order of an existing view. When the underlying table gains a column and the view selects it, OR REPLACE fails:

```
ERROR: cannot change name of view column "created_at" to "transport_mode_manual"
```

This happened in production: `my_tracker_data` gained a `transport_mode_manual` column (additive change via `ensureMissingColumns`), but the existing view had `created_at` at that position. `CREATE OR REPLACE VIEW` refused to rename the column.

## Fix

`MakeSQLIdempotent` now prepends `DROP VIEW IF EXISTS CASCADE` before `CREATE OR REPLACE VIEW` statements, so the view is recreated fresh when its definition changes. Safe because views hold no data, and CASCADE drops dependent objects that are recreated by subsequent statements in the same content.

Same pattern as the existing handling for CREATE TRIGGER, CREATE INDEX, and CREATE POLICY.

## Testing
- `go build ./...` ✅ · `go test ./internal/database/schema/` ✅ · `golangci-lint` 0 issues ✅
- New tests: `TestMakeSQLIdempotent_CreateOrReplaceView` + `TestMakeSQLIdempotent_CreateOrReplaceViewQuoted`
- Reproduced in production (Wayli prod K8s).