### PR TITLE
fix(auth): degrade to anonymous on expired tokens for optional-auth routes

### DIFF
--- a/internal/middleware/clientkey_auth.go
+++ b/internal/middleware/clientkey_auth.go
@@ -263,6 +263,17 @@ func RequireScope(requiredScopes ...string) fiber.Handler {
 	}
 }
 
+// isExpiredToken reports whether token validation failed specifically due to
+// expiry. ErrExpiredToken is only ever returned after the JWT signature and
+// claims have validated successfully against the platform secret and only the
+// `exp` claim is past (see internal/auth/jwt.go) — so it cannot be produced by
+// an attacker without the secret. Optional-auth routes use this to degrade to
+// the anonymous role instead of hard-failing, since anonymous access (RLS
+// enforced) is already the baseline for those routes.
+func isExpiredToken(err error) bool {
+	return err != nil && errors.Is(err, auth.ErrExpiredToken)
+}
+
 // RequireAuthOrServiceKey requires either JWT, client key, OR service key authentication
 // This is the most comprehensive auth middleware that accepts all authentication methods
 func RequireAuthOrServiceKey(authService *auth.Service, clientKeyService *auth.ClientKeyService, db *pgxpool.Pool, securityCfg *config.SecurityConfig, jwtManager ...*auth.JWTManager) fiber.Handler {
@@ -272,6 +283,12 @@ func RequireAuthOrServiceKey(authService *auth.Service, clientKeyService *auth.C
 // OptionalAuthOrServiceKey allows either JWT, client key, OR service key authentication
 // If no authentication is provided, the request continues (for anonymous access with RLS)
 // IMPORTANT: If invalid credentials are provided, returns 401 (does not fall back to anonymous)
+//
+// Exception: a token whose signature/claims are valid but whose `exp` has passed
+// (auth.ErrExpiredToken) degrades to the anonymous role instead of 401-ing, since
+// anonymous access — still fully gated by RLS — is already the baseline for these
+// routes. This keeps public reads working when a client (e.g. the SDK) re-sends a
+// stale token. Tampered, wrong-secret, or malformed tokens still return 401.
 //
 // Supports authentication via:
 // - clientkey header containing a JWT with role claim (anon, service_role, authenticated)
@@ -346,9 +363,17 @@ func authOrServiceKey(
 		}
 
 		if token != "" {
+			// Track whether the Bearer token failed specifically due to expiry
+			// across all validation attempts. Optional-auth routes degrade to
+			// anonymous in that case; see OptionalAuthOrServiceKey doc comment.
+			bearerExpired := false
+
 			// First, try to validate as auth.users token (app users)
 			claims, err := authService.JWTManager().ValidateToken(token)
 			if err != nil {
+				if isExpiredToken(err) {
+					bearerExpired = true
+				}
 				log.Debug().
 					Err(err).
 					Msg("authOrServiceKey: authService.JWTManager().ValidateToken failed")
@@ -426,6 +451,11 @@ func authOrServiceKey(
 			// If auth.users validation failed and jwtManager is provided, try platform.users token
 			if len(jwtManager) > 0 && jwtManager[0] != nil {
 				dashboardClaims, err := jwtManager[0].ValidateAccessToken(token)
+				if err != nil {
+					if isExpiredToken(err) {
+						bearerExpired = true
+					}
+				}
 				if err == nil {
 					c.Locals("user_id", dashboardClaims.Subject)
 					c.Locals("user_email", dashboardClaims.Email)
@@ -483,10 +513,25 @@ func authOrServiceKey(
 						return c.Next()
 					}
 				} else {
+					if isExpiredToken(err) {
+						bearerExpired = true
+					}
 					log.Debug().
 						Err(err).
 						Msg("Bearer token validation failed (tried user JWT then service role JWT)")
 				}
+			}
+
+			// Optional-auth routes degrade to the anonymous role when the provided
+			// Bearer token failed only due to expiry — anonymous access (still RLS
+			// enforced) is already the baseline for these routes, so this grants no
+			// extra privilege over a tokenless request. Required routes and all
+			// non-expiry failures (tampered/wrong-secret/malformed) still 401.
+			if !required && bearerExpired {
+				log.Debug().
+					Str("path", c.Path()).
+					Msg("OptionalAuth: provided Bearer token expired, continuing as anonymous")
+				return c.Next()
 			}
 
 			// Bearer token was provided but invalid - return specific error
@@ -497,8 +542,18 @@ func authOrServiceKey(
 		// This header may contain a JWT with role claim (anon, service_role, authenticated)
 		fluxbaseClientKey := c.Get("clientkey")
 		if fluxbaseClientKey != "" && strings.HasPrefix(fluxbaseClientKey, "eyJ") {
+			// Track whether the clientkey JWT failed specifically due to expiry;
+			// optional-auth routes degrade to anonymous in that case (same as
+			// the Bearer path above).
+			clientKeyExpired := false
+
 			// Looks like a JWT - first try user JWT (most common), then service role
 			claims, err := authService.JWTManager().ValidateToken(fluxbaseClientKey)
+			if err != nil {
+				if isExpiredToken(err) {
+					clientKeyExpired = true
+				}
+			}
 			if err == nil {
 				// Check if token has been revoked
 				// SECURITY: Fail-closed behavior - reject if we can't verify revocation status
@@ -528,6 +583,11 @@ func authOrServiceKey(
 
 			// User JWT failed, try service role JWT
 			srClaims, err := authService.JWTManager().ValidateServiceRoleToken(fluxbaseClientKey)
+			if err != nil {
+				if isExpiredToken(err) {
+					clientKeyExpired = true
+				}
+			}
 			if err == nil {
 				// SECURITY: Check emergency revocation for service_role tokens
 				// This provides a mechanism to revoke compromised service_role tokens immediately
@@ -562,6 +622,15 @@ func authOrServiceKey(
 					Str("issuer", srClaims.Issuer).
 					Msg("Authenticated with service role JWT via clientkey header")
 
+				return c.Next()
+			}
+			// Optional-auth routes degrade to the anonymous role when the provided
+			// clientkey JWT failed only due to expiry; see the Bearer-path block for
+			// rationale. Otherwise fall through to try non-JWT client key auth.
+			if !required && clientKeyExpired {
+				log.Debug().
+					Str("path", c.Path()).
+					Msg("OptionalAuth: provided clientkey token expired, continuing as anonymous")
 				return c.Next()
 			}
 			// If clientkey JWT was provided but invalid, log and fall through to try client key auth

--- a/internal/middleware/clientkey_auth_test.go
+++ b/internal/middleware/clientkey_auth_test.go
@@ -1,15 +1,25 @@
 package middleware
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v3"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nimbleflux/fluxbase/internal/auth"
+	"github.com/nimbleflux/fluxbase/internal/config"
+	"github.com/nimbleflux/fluxbase/internal/database"
 	"github.com/nimbleflux/fluxbase/internal/keys"
 )
 
@@ -689,4 +699,239 @@ func TestMin(t *testing.T) {
 	assert.Equal(t, 2, min(10, 2))
 	assert.Equal(t, 5, min(5, 5))
 	assert.Equal(t, 0, min(0, 10))
+}
+
+// =============================================================================
+// isExpiredToken Tests (pure unit — runs in CI under -short)
+//
+// isExpiredToken gates the optional-auth degrade-to-anon behavior. ErrExpiredToken
+// is only ever produced after a JWT's signature and claims have validated against
+// the platform secret, so it must NOT match tampering / wrong-secret / malformed.
+// =============================================================================
+
+func TestIsExpiredToken(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"exact ErrExpiredToken", auth.ErrExpiredToken, true},
+		{"wrapped ErrExpiredToken", fmt.Errorf("validation: %w", auth.ErrExpiredToken), true},
+		{"ErrInvalidToken", auth.ErrInvalidToken, false},
+		{"ErrInvalidSignature", auth.ErrInvalidSignature, false},
+		{"generic error", errors.New("something else"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isExpiredToken(tt.err))
+		})
+	}
+}
+
+// =============================================================================
+// OptionalAuth expired-token degrade (integration — requires DB for auth.Service)
+//
+// These exercise the real OptionalAuthOrServiceKey / RequireAuthOrServiceKey
+// middleware end to end. They require a database to construct auth.Service, so
+// they skip under -short (CI's `make test` runs the unit suite only). The
+// security-relevant predicate (isExpiredToken) is covered above by the pure
+// unit test that always runs.
+// =============================================================================
+
+const testJWTSecret = "test-secret-key-for-testing-only"
+
+// newTestAuthService builds a real auth.Service backed by a database connection.
+// Skips under -short. Mirrors the setup in internal/api/auth_otp_test.go.
+func newTestAuthService(t *testing.T) *auth.Service {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("Skipping DB-backed auth middleware test in short mode")
+	}
+
+	dbHost := os.Getenv("FLUXBASE_DATABASE_HOST")
+	if dbHost == "" {
+		dbHost = os.Getenv("DB_HOST")
+	}
+	if dbHost == "" {
+		dbHost = "localhost"
+	}
+	dbUser := os.Getenv("FLUXBASE_DATABASE_USER")
+	if dbUser == "" {
+		dbUser = "fluxbase_app"
+	}
+	dbPassword := os.Getenv("FLUXBASE_DATABASE_PASSWORD")
+	dbDatabase := os.Getenv("FLUXBASE_TEST_DATABASE")
+	if dbDatabase == "" {
+		dbDatabase = "fluxbase"
+	}
+
+	dbConfig := config.DatabaseConfig{
+		Host:            dbHost,
+		Port:            5432,
+		User:            dbUser,
+		Password:        dbPassword,
+		Database:        dbDatabase,
+		SSLMode:         "disable",
+		MaxConnections:  5,
+		MinConnections:  1,
+		MaxConnLifetime: 5 * time.Minute,
+		MaxConnIdleTime: 5 * time.Minute,
+		HealthCheck:     30 * time.Second,
+	}
+
+	db, err := database.NewConnection(dbConfig)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, db.Health(ctx))
+
+	authConfig := &config.AuthConfig{
+		JWTSecret:           testJWTSecret,
+		JWTExpiry:           15 * time.Minute,
+		RefreshExpiry:       7 * 24 * time.Hour,
+		ServiceRoleTTL:      24 * time.Hour,
+		AnonTTL:             24 * time.Hour,
+		MagicLinkExpiry:     15 * time.Minute,
+		PasswordResetExpiry: 1 * time.Hour,
+		PasswordMinLen:      8,
+		BcryptCost:          4,
+		SignupEnabled:       true,
+	}
+
+	return auth.NewService(db, authConfig, &auth.NoOpOTPSender{}, "http://localhost:3000", nil)
+}
+
+// signTestServiceRoleToken mints a service-role/anon-style JWT signed with the
+// given secret, for the given role, at the provided iat/exp times. Mirrors the
+// token shapes used in internal/auth/jwt_test.go.
+func signTestServiceRoleToken(t *testing.T, secret, role string, iat, exp time.Time) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"role": role,
+		"iss":  "fluxbase",
+		"iat":  iat.Unix(),
+		"exp":  exp.Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := token.SignedString([]byte(secret))
+	require.NoError(t, err)
+	return s
+}
+
+// authTestApp wires a Fiber app with the chosen auth middleware, returning the
+// auth service so tests can mint tokens signed with the same secret.
+func authTestApp(t *testing.T, required bool) (*fiber.App, *auth.Service) {
+	t.Helper()
+	authService := newTestAuthService(t)
+
+	// ClientKeyService is only reached on the success / client-key paths, which
+	// the failure-path tests below never exercise. A nil DB is safe here.
+	cks := auth.NewClientKeyService(nil, nil)
+	var mw fiber.Handler
+	if required {
+		mw = RequireAuthOrServiceKey(authService, cks, nil, &config.SecurityConfig{})
+	} else {
+		mw = OptionalAuthOrServiceKey(authService, cks, nil, &config.SecurityConfig{})
+	}
+
+	app := fiber.New(fiber.Config{
+		ErrorHandler: func(c fiber.Ctx, err error) error {
+			return c.SendStatus(http.StatusInternalServerError)
+		},
+	})
+	app.Use(mw)
+	app.Get("/settings/:key", func(c fiber.Ctx) error {
+		// Mirror what the real settings handler observes: an anonymous request
+		// has no rls_role/user_id set (rls.go later defaults nil -> "anon").
+		role, _ := c.Locals("rls_role").(string)
+		userID := c.Locals("rls_user_id")
+		return c.JSON(fiber.Map{"rls_role": role, "has_user_id": userID != nil})
+	})
+	return app, authService
+}
+
+func TestOptionalAuth_ExpiredBearerDegradesToAnonymous(t *testing.T) {
+	app, authService := authTestApp(t, false)
+
+	now := time.Now()
+	// Signature is valid (signed with the platform secret) but exp is in the past.
+	expired := signTestServiceRoleToken(t, testJWTSecret, "anon",
+		now.Add(-2*time.Hour), now.Add(-1*time.Hour))
+	// Sanity: the token really is expired (signature valid, exp past).
+	_, err := authService.JWTManager().ValidateServiceRoleToken(expired)
+	require.ErrorIs(t, err, auth.ErrExpiredToken)
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/wayli.is_setup_complete", nil)
+	req.Header.Set("Authorization", "Bearer "+expired)
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	// Degrades to anonymous (200), not 401 INVALID_TOKEN.
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), `"rls_role":""`)
+	assert.Contains(t, string(body), `"has_user_id":false`)
+}
+
+func TestOptionalAuth_TamperedBearerStillRejects(t *testing.T) {
+	app, _ := authTestApp(t, false)
+
+	// Garbage "eyJ"-prefixed token: signature won't validate -> ErrInvalidToken,
+	// NOT ErrExpiredToken. Must still 401.
+	req := httptest.NewRequest(http.MethodGet, "/settings/wayli.is_setup_complete", nil)
+	req.Header.Set("Authorization", "Bearer "+strings.Repeat("a", 40))
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestOptionalAuth_ValidBearerAuthenticates(t *testing.T) {
+	app, authService := authTestApp(t, false)
+
+	// Fresh anon token (signature valid, not expired) -> authenticates as anon.
+	valid, err := authService.JWTManager().GenerateAnonToken()
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/wayli.is_setup_complete", nil)
+	req.Header.Set("Authorization", "Bearer "+valid)
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), `"rls_role":"anon"`)
+}
+
+func TestOptionalAuth_NoTokenIsAnonymous(t *testing.T) {
+	app, _ := authTestApp(t, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/wayli.is_setup_complete", nil)
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Contains(t, string(body), `"rls_role":""`)
+	assert.Contains(t, string(body), `"has_user_id":false`)
+}
+
+func TestRequireAuth_ExpiredBearerStillRejects(t *testing.T) {
+	app, authService := authTestApp(t, true) // required = true
+
+	now := time.Now()
+	expired := signTestServiceRoleToken(t, testJWTSecret, "anon",
+		now.Add(-2*time.Hour), now.Add(-1*time.Hour))
+	_, err := authService.JWTManager().ValidateServiceRoleToken(expired)
+	require.ErrorIs(t, err, auth.ErrExpiredToken)
+
+	req := httptest.NewRequest(http.MethodGet, "/settings/wayli.is_setup_complete", nil)
+	req.Header.Set("Authorization", "Bearer "+expired)
+	resp, err := app.Test(req)
+
+	require.NoError(t, err)
+	// Required routes do NOT degrade — expiry still 401s.
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }


### PR DESCRIPTION
## Problem

`OptionalAuthOrServiceKey` hard-rejected *any* token that failed validation — including tokens that had simply expired — returning `401 INVALID_TOKEN` even on routes whose entire purpose is anonymous-OK access gated only by RLS (e.g. `GET /api/v1/settings/:key`). The doc comment stated *"does not fall back to anonymous,"* which broke public reads whenever a client re-sent a stale token.

This is common in practice: the Fluxbase JS SDK persists the access token and stamps `Authorization: Bearer <token>` on **every** request, including public ones. A visitor with an expired session in storage can no longer read public settings, so apps relying on auth-optional endpoints fail in confusing ways.

### Concrete repro (from a Wayli app)
On `/auth/signup`, the page reads `GET /api/v1/settings/wayli.is_setup_complete` to decide whether to show a "you're setting up Wayli for the first time" banner. An unauthenticated visitor with a stale token in `localStorage` gets:
```json
{"error":"Invalid or expired token","code":"INVALID_TOKEN"}
```
The request never reaches the handler/RLS, so the app can't distinguish "first user" from "read failed" and defaults to hiding the banner.

## Fix

When running in **optional** mode (`!required`) and token validation fails **specifically due to expiry** (`auth.ErrExpiredToken`), fall back to the anonymous role (`c.Next()` with no `rls_role`/`user_id` set → defaults to `anon` downstream) instead of 401-ing.

- ✅ Tampered, wrong-secret, and malformed tokens **still** hard-fail with `401`.
- ✅ Required routes (`RequireAuthOrServiceKey`) are **unchanged** — expiry still 401s.
- ✅ Applied symmetrically to both the **Bearer** and **clientkey** JWT paths.

## Why this is safe

Each claim is verified against source:

1. **`ErrExpiredToken` can't be spoofed.** It is only ever returned *after* the JWT signature and claims have validated against the platform secret and only the `exp` claim is past (`internal/auth/jwt.go:367`, `:411`, `:575` — `jwt.ErrTokenExpired` → `ErrExpiredToken`). An attacker without the secret gets `ErrInvalidSignature → ErrInvalidToken`, never `ErrExpiredToken`.
2. **Degrading to `anon` grants zero extra privilege over a tokenless request.** A tokenless request on an `AuthOptional` route *already* runs as `anon` today (`rls.go:352-355` defaults `role == nil` → `"anon"`). `anon` is the floor; RLS still fully applies.
3. **No partial-auth state leaks.** Every `c.Locals(...)` write is gated behind a successful `err == nil`; the degrade returns before any Locals are set.
4. **Required routes untouched** — gated on `!required`.

## Tests

- `TestIsExpiredToken` — pure unit table test for the gating predicate (runs under `-short` / CI).
- `TestOptionalAuth_ExpiredBearerDegradesToAnonymous` — expired Bearer → 200, anonymous (no `rls_role`/`user_id`).
- `TestOptionalAuth_TamperedBearerStillRejects` — garbage token → still `401`.
- `TestOptionalAuth_ValidBearerAuthenticates` — fresh anon token → authenticates as `anon`.
- `TestOptionalAuth_NoTokenIsAnonymous` — tokenless → anonymous (unchanged baseline).
- `TestRequireAuth_ExpiredBearerStillRejects` — required route + expired → still `401`.

The integration tests require a database to construct `auth.Service` (mirroring `internal/api/auth_otp_test.go`), so they skip under `-short`. All five pass end-to-end against a local Postgres; `TestIsExpiredToken` runs in CI.

## Out of scope

- `RequireAuthOrServiceKey` behavior (required routes) — intentionally unchanged.
- A complementary **SDK-side** hardening (clear the stale session when a 401-triggered refresh fails) is planned as a follow-up PR — defense in depth so the SDK stops re-sending a dead token.

## Follow-up for consuming apps

Once this lands, anonymous reads on auth-optional endpoints will work again regardless of stale client tokens. Apps that gate a setting behind anon reads should also ensure the `app.settings` row has `is_public = true` if it must be readable by anonymous visitors once set (separate, app-specific concern — not in scope here).