### PR TITLE
fix(sdk): clear stale session when 401 token refresh fails

### DIFF
--- a/sdk/src/auth.test.ts
+++ b/sdk/src/auth.test.ts
@@ -463,6 +463,126 @@ describe("FluxbaseAuth", () => {
     });
   });
 
+  describe("401 refresh callback", () => {
+    // The SDK registers a refresh callback with FluxbaseFetch that runs on 401.
+    // When refresh fails (refresh token expired/revoked), it must clear the stale
+    // session so the access token is dropped and subsequent requests fall back to
+    // the anon key instead of re-sending a dead token that keeps 401-ing.
+
+    /** Captures the refresh callback registered with the (mocked) fetch client. */
+    const buildAuthWithCapturedCallback = () => {
+      let captured: (() => Promise<boolean>) | null = null;
+      const fetchWithCapture = {
+        ...mockFetch,
+        setRefreshTokenCallback: vi.fn((cb: () => Promise<boolean>) => {
+          captured = cb;
+        }),
+      } as unknown as FluxbaseFetch;
+      const a = new FluxbaseAuth(fetchWithCapture, true, true);
+      return {
+        a,
+        getCallback: () => captured as unknown as () => Promise<boolean>,
+      };
+    };
+
+    /** Establishes a signed-in session on `a` (so a stale token exists). */
+    const signInSession = async (a: FluxbaseAuth) => {
+      const authResponse: AuthResponse = {
+        access_token: "stale-access-token",
+        refresh_token: "stale-refresh-token",
+        expires_in: 3600,
+        token_type: "Bearer",
+        user: { id: "1", email: "user@example.com", created_at: "" },
+      };
+      vi.mocked(mockFetch.post).mockResolvedValue(authResponse);
+      await a.signIn({ email: "user@example.com", password: "password" });
+    };
+
+    it("clears the stale session when refresh fails", async () => {
+      const { a, getCallback } = buildAuthWithCapturedCallback();
+      const callback = getCallback();
+      expect(callback).toBeDefined();
+      await signInSession(a);
+
+      // Sanity: we hold a session and the access token was applied.
+      expect(a.getAccessToken()).toBe("stale-access-token");
+
+      // Make refresh fail (refresh endpoint rejects / errors).
+      vi.mocked(mockFetch.post).mockRejectedValueOnce(
+        new Error("Invalid or expired token"),
+      );
+
+      const ok = await callback();
+
+      // Refresh failed -> callback returns false (fetch layer will surface 401).
+      expect(ok).toBe(false);
+      // Stale session dropped: token cleared and no session held.
+      expect(a.getAccessToken()).toBeNull();
+      const { data } = await a.getSession();
+      expect(data.session).toBeNull();
+      expect(mockFetch.setAuthToken).toHaveBeenLastCalledWith(null);
+    });
+
+    it("does not clear and returns true when refresh succeeds", async () => {
+      const { a, getCallback } = buildAuthWithCapturedCallback();
+      const callback = getCallback();
+      await signInSession(a);
+
+      const refreshed: AuthResponse = {
+        access_token: "fresh-access-token",
+        refresh_token: "fresh-refresh-token",
+        expires_in: 3600,
+        token_type: "Bearer",
+        user: { id: "1", email: "user@example.com", created_at: "" },
+      };
+      vi.mocked(mockFetch.post).mockResolvedValueOnce(refreshed);
+
+      const ok = await callback();
+
+      expect(ok).toBe(true);
+      expect(a.getAccessToken()).toBe("fresh-access-token");
+      expect(mockFetch.setAuthToken).toHaveBeenLastCalledWith("fresh-access-token");
+    });
+
+    it("does not emit SIGNED_OUT when there was no session to clear", async () => {
+      // No session established. Even if the refresh callback is invoked with a
+      // failing refresh, we must not emit a spurious SIGNED_OUT (the header is
+      // already the anon key).
+      const { a, getCallback } = buildAuthWithCapturedCallback();
+      const callback = getCallback();
+
+      const events: string[] = [];
+      a.onAuthStateChange((event) => events.push(event));
+
+      vi.mocked(mockFetch.post).mockRejectedValueOnce(
+        new Error("Invalid or expired token"),
+      );
+
+      const ok = await callback();
+
+      expect(ok).toBe(false);
+      expect(events).not.toContain("SIGNED_OUT");
+    });
+
+    it("emits SIGNED_OUT when an existing session is cleared", async () => {
+      const { a, getCallback } = buildAuthWithCapturedCallback();
+      const callback = getCallback();
+      await signInSession(a);
+
+      const events: string[] = [];
+      a.onAuthStateChange((event) => events.push(event));
+
+      vi.mocked(mockFetch.post).mockRejectedValueOnce(
+        new Error("Invalid or expired token"),
+      );
+
+      await callback();
+
+      // A genuine session was dropped -> consumers are notified.
+      expect(events).toContain("SIGNED_OUT");
+    });
+  });
+
   describe("getCurrentUser()", () => {
     it("should fetch current user", async () => {
       // Set up session

--- a/sdk/src/auth.ts
+++ b/sdk/src/auth.ts
@@ -138,8 +138,21 @@ export class FluxbaseAuth {
 
     // Register refresh callback for automatic 401 handling
     this.fetch.setRefreshTokenCallback(async () => {
+      const hadSession = this.session !== null;
       const result = await this.refreshSession();
-      return !result.error;
+      if (result.error) {
+        // Refresh failed (refresh token expired/revoked/absent). If we were
+        // holding a session, drop it: clearSession() restores the anon key via
+        // setAuthToken(null), so subsequent requests stop re-sending the dead
+        // access token that will keep 401-ing. Skipped when there was no
+        // session to avoid emitting a spurious SIGNED_OUT event (in that case
+        // the header is already the anon key).
+        if (hadSession) {
+          this.clearSession();
+        }
+        return false;
+      }
+      return true;
     });
 
     // Initialize storage: an explicit adapter wins; otherwise fall back to the


### PR DESCRIPTION
## Problem

When automatic token refresh on a `401` failed (refresh token expired, revoked, or absent), the SDK left the dead access token in the fetch client's `defaultHeaders["Authorization"]`. Every subsequent request then re-sent the same expired token, so public / anon-capable reads **kept** failing with `401` even though the client could have fallen back to the anon key.

This is the compounding half of the signup-page issue: a visitor with a stale session in `localStorage` hits a `401` on a public settings read, the SDK tries to refresh, refresh fails, and — instead of dropping the dead token — it leaves it in place, so the next public read fails too.

## Fix

In the refresh callback registered with `FluxbaseFetch`, drop the session on refresh failure:

```ts
this.fetch.setRefreshTokenCallback(async () => {
  const hadSession = this.session !== null;
  const result = await this.refreshSession();
  if (result.error) {
    if (hadSession) {
      this.clearSession(); // restores the anon key via setAuthToken(null)
    }
    return false;
  }
  return true;
});
```

`clearSession()` restores the anon key via `setAuthToken(null)` (which `FluxbaseFetch` turns back into `Bearer <anonKey>` when an anon key was registered), so following requests fall back to anonymous instead of re-sending a token that will keep 401-ing. It's skipped when there was no session, to avoid emitting a spurious `SIGNED_OUT` event (in that case the header is already the anon key).

## Relationship to the platform fix

This complements **#304** (`fix(auth): degrade to anonymous on expired tokens for optional-auth routes`):

- **#304 (platform)** makes auth-optional routes tolerate an expired token by degrading to the anonymous role (RLS still applies). Root-cause fix.
- **This PR (SDK)** stops the client from re-sending a dead token at all, falling back to the anon key once refresh fails. Defense in depth.

Together they keep public reads working for visitors with stale sessions. Either alone fixes the reported symptom; both together are robust.

## Tests

Added a `401 refresh callback` describe block in `sdk/src/auth.test.ts` (169 tests pass):

- clears the stale session when refresh fails — token cleared, `getAccessToken()` is `null`, `setAuthToken(null)` called.
- does **not** clear and returns `true` when refresh succeeds — new token applied.
- does **not** emit `SIGNED_OUT` when there was no session (no spurious event).
- **does** emit `SIGNED_OUT` when a genuine existing session is dropped (consumers notified).

`bun run type-check` (`tsc --noEmit`) passes clean.

## Verification

```
✓ src/auth.test.ts (123 tests)
✓ src/fetch.test.ts (46 tests)
Test Files  2 passed (2)
     Tests  169 passed (169)
```