### PR TITLE
fix(storage): chunked/multipart/S3 uploads don't create RLS-owned storage.objects rows

### DIFF
--- a/internal/api/storage_chunked.go
+++ b/internal/api/storage_chunked.go
@@ -132,9 +132,15 @@ func (h *StorageHandler) InitChunkedUpload(c fiber.Ctx) error {
 
 	session.OwnerID = ownerID
 
-	// Store session in database for persistence
-	if err := h.storeChunkedUploadSession(ctx, session); err != nil {
-		log.Warn().Err(err).Str("uploadID", session.UploadID).Msg("Failed to store session in database, session will be ephemeral")
+	// Persist the owner onto the session file. InitChunkedUpload writes
+	// session.json before returning (before OwnerID is set above), so without
+	// this re-persist the owner is lost when CompleteChunkedUpload reloads the
+	// session from disk — and storeUploadedObject then inserts owner_id = NULL,
+	// failing the storage_objects_insert RLS policy for authenticated users.
+	// storeUploadedObject also falls back to the live request user as a safety
+	// net, but keeping the session correct is the durable fix.
+	if err := h.updateChunkedUploadSessionInProvider(svc.Provider, session); err != nil {
+		log.Warn().Err(err).Str("uploadID", session.UploadID).Msg("Failed to persist session owner, will fall back to request user at completion")
 	}
 
 	log.Info().
@@ -489,12 +495,6 @@ func (h *StorageHandler) AbortChunkedUpload(c fiber.Ctx) error {
 
 // Helper functions for session management
 
-func (h *StorageHandler) storeChunkedUploadSession(ctx interface{}, session *storage.ChunkedUploadSession) error {
-	// For now, sessions are stored by the storage provider (local storage stores in files)
-	// Database storage can be added later for cross-server session sharing
-	return nil
-}
-
 func (h *StorageHandler) getChunkedUploadSessionFromProvider(provider storage.Provider, uploadID string) (*storage.ChunkedUploadSession, error) {
 	// Try to get session from storage provider
 	switch p := provider.(type) {
@@ -569,6 +569,20 @@ func (h *StorageHandler) storeUploadedObject(fiberCtx interface{}, session *stor
 	var ownerID interface{} = nil
 	if session.OwnerID != "" && session.OwnerID != "anonymous" {
 		ownerID = session.OwnerID
+	}
+	// Fall back to the authenticated user from the live request when the
+	// session has no owner. Chunked sessions persist session.json inside
+	// InitChunkedUpload — before OwnerID is assigned on the returned struct —
+	// so the owner can be lost if the session is reloaded from disk before the
+	// init handler re-persists it (see InitChunkedUpload call site). A NULL
+	// owner_id fails the storage_objects_insert RLS policy for authenticated
+	// users (requires auth.current_user_id() = owner_id). This mirrors the
+	// regular upload path in storage_files.go, which reads the user from the
+	// live request at insert time.
+	if ownerID == nil {
+		if liveOwnerID := getUserID(c); liveOwnerID != "" && liveOwnerID != "anonymous" {
+			ownerID = liveOwnerID
+		}
 	}
 
 	_, err = tx.Exec(

--- a/internal/api/storage_chunked.go
+++ b/internal/api/storage_chunked.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -132,14 +133,19 @@ func (h *StorageHandler) InitChunkedUpload(c fiber.Ctx) error {
 
 	session.OwnerID = ownerID
 
-	// Persist the owner onto the session file. InitChunkedUpload writes
-	// session.json before returning (before OwnerID is set above), so without
-	// this re-persist the owner is lost when CompleteChunkedUpload reloads the
-	// session from disk — and storeUploadedObject then inserts owner_id = NULL,
-	// failing the storage_objects_insert RLS policy for authenticated users.
-	// storeUploadedObject also falls back to the live request user as a safety
-	// net, but keeping the session correct is the durable fix.
-	if err := h.updateChunkedUploadSessionInProvider(svc.Provider, session); err != nil {
+	// Persist the session so the owner (and, for S3, the whole session) survives
+	// a reload at completion. For LocalStorage, InitChunkedUpload writes
+	// session.json before returning (before OwnerID is set above), so the owner
+	// is lost unless re-persisted here — and storeUploadedObject then inserts
+	// owner_id = NULL, failing the storage_objects_insert RLS policy. For S3,
+	// there is no on-disk store at all, so the session must be created in the
+	// storage.chunked_upload_sessions table here.
+	if isS3Provider(svc.Provider) {
+		if err := h.createChunkedSessionDB(ctx, c, session); err != nil {
+			log.Error().Err(err).Str("uploadID", session.UploadID).Msg("Failed to persist S3 chunked upload session")
+			return SendInternalError(c, "Failed to initialize chunked upload session")
+		}
+	} else if err := h.updateChunkedUploadSessionInProvider(ctx, c, svc.Provider, session); err != nil {
 		log.Warn().Err(err).Str("uploadID", session.UploadID).Msg("Failed to persist session owner, will fall back to request user at completion")
 	}
 
@@ -196,7 +202,7 @@ func (h *StorageHandler) UploadChunk(c fiber.Ctx) error {
 	ctx := c.RequestCtx()
 
 	// Retrieve session
-	session, err := h.getChunkedUploadSessionFromProvider(svc.Provider, uploadID)
+	session, err := h.getChunkedUploadSessionFromProvider(ctx, c, svc.Provider, uploadID)
 	if err != nil {
 		return SendNotFound(c, "Upload session not found")
 	}
@@ -255,7 +261,7 @@ func (h *StorageHandler) UploadChunk(c fiber.Ctx) error {
 	session.S3PartETags[chunkIndex] = result.ETag
 
 	// Store updated session
-	if err := h.updateChunkedUploadSessionInProvider(svc.Provider, session); err != nil {
+	if err := h.updateChunkedUploadSessionInProvider(ctx, c, svc.Provider, session); err != nil {
 		log.Warn().Err(err).Str("uploadID", uploadID).Msg("Failed to update session in database")
 	}
 
@@ -303,7 +309,7 @@ func (h *StorageHandler) CompleteChunkedUpload(c fiber.Ctx) error {
 	ctx := c.RequestCtx()
 
 	// Retrieve session
-	session, err := h.getChunkedUploadSessionFromProvider(svc.Provider, uploadID)
+	session, err := h.getChunkedUploadSessionFromProvider(ctx, c, svc.Provider, uploadID)
 	if err != nil {
 		return SendNotFound(c, "Upload session not found")
 	}
@@ -336,7 +342,7 @@ func (h *StorageHandler) CompleteChunkedUpload(c fiber.Ctx) error {
 
 	// Mark session as completing
 	session.Status = "completing"
-	_ = h.updateChunkedUploadSessionInProvider(svc.Provider, session)
+	_ = h.updateChunkedUploadSessionInProvider(ctx, c, svc.Provider, session)
 
 	// Complete the upload
 	var object *storage.Object
@@ -352,7 +358,7 @@ func (h *StorageHandler) CompleteChunkedUpload(c fiber.Ctx) error {
 
 	if err != nil {
 		session.Status = "active" // Revert status on failure
-		_ = h.updateChunkedUploadSessionInProvider(svc.Provider, session)
+		_ = h.updateChunkedUploadSessionInProvider(ctx, c, svc.Provider, session)
 		log.Error().Err(err).Str("uploadID", uploadID).Msg("Failed to complete chunked upload")
 		return SendInternalError(c, "Failed to complete chunked upload")
 	}
@@ -364,7 +370,7 @@ func (h *StorageHandler) CompleteChunkedUpload(c fiber.Ctx) error {
 
 	// Mark session as completed and clean up
 	session.Status = "completed"
-	_ = h.deleteChunkedUploadSession(ctx, uploadID)
+	_ = h.deleteChunkedUploadSession(ctx, c, svc.Provider, uploadID)
 
 	log.Info().
 		Str("uploadID", uploadID).
@@ -399,7 +405,7 @@ func (h *StorageHandler) GetChunkedUploadStatus(c fiber.Ctx) error {
 	}
 
 	// Retrieve session
-	session, err := h.getChunkedUploadSessionFromProvider(svc.Provider, uploadID)
+	session, err := h.getChunkedUploadSessionFromProvider(c.RequestCtx(), c, svc.Provider, uploadID)
 	if err != nil {
 		return SendNotFound(c, "Upload session not found")
 	}
@@ -457,7 +463,7 @@ func (h *StorageHandler) AbortChunkedUpload(c fiber.Ctx) error {
 	ctx := c.RequestCtx()
 
 	// Retrieve session
-	session, err := h.getChunkedUploadSessionFromProvider(svc.Provider, uploadID)
+	session, err := h.getChunkedUploadSessionFromProvider(ctx, c, svc.Provider, uploadID)
 	if err != nil {
 		return SendNotFound(c, "Upload session not found")
 	}
@@ -483,7 +489,7 @@ func (h *StorageHandler) AbortChunkedUpload(c fiber.Ctx) error {
 	}
 
 	// Delete session from database
-	_ = h.deleteChunkedUploadSession(ctx, uploadID)
+	_ = h.deleteChunkedUploadSession(ctx, c, svc.Provider, uploadID)
 
 	log.Info().
 		Str("uploadID", uploadID).
@@ -495,35 +501,42 @@ func (h *StorageHandler) AbortChunkedUpload(c fiber.Ctx) error {
 
 // Helper functions for session management
 
-func (h *StorageHandler) getChunkedUploadSessionFromProvider(provider storage.Provider, uploadID string) (*storage.ChunkedUploadSession, error) {
+func (h *StorageHandler) getChunkedUploadSessionFromProvider(ctx context.Context, c fiber.Ctx, provider storage.Provider, uploadID string) (*storage.ChunkedUploadSession, error) {
 	// Try to get session from storage provider
 	switch p := provider.(type) {
 	case *storage.LocalStorage:
 		return p.GetChunkedUploadSession(uploadID)
 	case *storage.S3Storage:
-		// S3 doesn't have local session storage, we need to query the database
-		// For now, return an error - this would need database session storage
-		return nil, fmt.Errorf("session not found (S3 sessions require database storage)")
+		// S3 has no on-disk session store; sessions live in the
+		// storage.chunked_upload_sessions table (under RLS).
+		return h.getChunkedSessionDB(ctx, c, uploadID)
 	default:
 		return nil, fmt.Errorf("storage provider does not support chunked upload sessions")
 	}
 }
 
-func (h *StorageHandler) updateChunkedUploadSessionInProvider(provider storage.Provider, session *storage.ChunkedUploadSession) error {
+func (h *StorageHandler) updateChunkedUploadSessionInProvider(ctx context.Context, c fiber.Ctx, provider storage.Provider, session *storage.ChunkedUploadSession) error {
 	switch p := provider.(type) {
 	case *storage.LocalStorage:
 		return p.UpdateChunkedUploadSession(session)
 	case *storage.S3Storage:
-		// S3 sessions would be stored in database
-		return nil
+		return h.updateChunkedSessionDB(ctx, c, session)
 	default:
 		return nil
 	}
 }
 
-func (h *StorageHandler) deleteChunkedUploadSession(ctx interface{}, uploadID string) error {
-	// Session cleanup is handled by the provider when completing/aborting
-	return nil
+func (h *StorageHandler) deleteChunkedUploadSession(ctx context.Context, c fiber.Ctx, provider storage.Provider, uploadID string) error {
+	switch provider.(type) {
+	case *storage.LocalStorage:
+		// LocalStorage cleans up the on-disk session dir itself on
+		// complete/abort (see LocalStorage.CompleteChunkedUpload).
+		return nil
+	case *storage.S3Storage:
+		return h.deleteChunkedSessionDB(ctx, c, uploadID)
+	default:
+		return nil
+	}
 }
 
 func (h *StorageHandler) storeUploadedObject(fiberCtx interface{}, session *storage.ChunkedUploadSession, object *storage.Object) error {

--- a/internal/api/storage_chunked_db.go
+++ b/internal/api/storage_chunked_db.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/nimbleflux/fluxbase/internal/storage"
+)
+
+// DB-backed chunked-upload session persistence for providers that don't keep
+// sessions on disk (currently S3). LocalStorage persists session.json itself
+// (see internal/storage/local_chunked.go); S3 has no local store, so its
+// sessions live in the storage.chunked_upload_sessions table.
+//
+// All operations run under RLS using the request's authenticated user, so the
+// storage_chunked_sessions_* policies (which require current_user_id() = owner_id
+// for non-admins) enforce that a user can only read/write their own sessions.
+
+// errChunkedSessionNotFound is returned when a session row is absent or not
+// visible to the caller under RLS. Callers translate this to a 404.
+var errChunkedSessionNotFound = errors.New("chunked upload session not found")
+
+// createChunkedSessionDB inserts a new session row under RLS.
+func (h *StorageHandler) createChunkedSessionDB(ctx context.Context, c fiber.Ctx, session *storage.ChunkedUploadSession) error {
+	completedJSON, err := json.Marshal(session.CompletedChunks)
+	if err != nil {
+		return fmt.Errorf("failed to marshal completed_chunks: %w", err)
+	}
+	// map[int]string marshals to {"0":"etag",...} which round-trips correctly,
+	// but on read keys come back as strings and must be converted (see below).
+	etagsJSON, err := json.Marshal(session.S3PartETags)
+	if err != nil {
+		return fmt.Errorf("failed to marshal s3_part_etags: %w", err)
+	}
+	metadataJSON, err := json.Marshal(session.Metadata)
+	if err != nil {
+		return fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	var ownerID any
+	if session.OwnerID != "" && session.OwnerID != "anonymous" {
+		ownerID = session.OwnerID
+	}
+
+	tx, err := h.getPool(c).Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := h.setRLSContext(ctx, tx, c); err != nil {
+		return fmt.Errorf("failed to set RLS context: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO storage.chunked_upload_sessions
+			(upload_id, bucket_id, path, total_size, chunk_size, total_chunks,
+			 completed_chunks, content_type, metadata, cache_control, owner_id,
+			 s3_upload_id, s3_part_etags, status, created_at, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+	`, session.UploadID, session.Bucket, session.Key, session.TotalSize, session.ChunkSize,
+		session.TotalChunks, completedJSON, session.ContentType, metadataJSON, session.CacheControl,
+		ownerID, session.S3UploadID, etagsJSON, session.Status, session.CreatedAt, session.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("failed to insert chunked upload session: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit chunked upload session: %w", err)
+	}
+	return nil
+}
+
+// getChunkedSessionDB loads a session row under RLS. Returns
+// errChunkedSessionNotFound if the row is absent or not visible to the caller.
+func (h *StorageHandler) getChunkedSessionDB(ctx context.Context, c fiber.Ctx, uploadID string) (*storage.ChunkedUploadSession, error) {
+	tx, err := h.getPool(c).Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := h.setRLSContext(ctx, tx, c); err != nil {
+		return nil, fmt.Errorf("failed to set RLS context: %w", err)
+	}
+
+	var (
+		s             storage.ChunkedUploadSession
+		completedJSON []byte
+		etagsJSON     []byte
+		metadataJSON  []byte
+		cacheControl  sql.NullString
+		contentType   sql.NullString
+		s3UploadID    sql.NullString
+		ownerID       sql.NullString
+	)
+	err = tx.QueryRow(ctx, `
+		SELECT upload_id, bucket_id, path, total_size, chunk_size, total_chunks,
+		       completed_chunks, content_type, metadata, cache_control, owner_id,
+		       s3_upload_id, s3_part_etags, status, created_at, expires_at
+		FROM storage.chunked_upload_sessions
+		WHERE upload_id = $1
+	`, uploadID).Scan(
+		&s.UploadID, &s.Bucket, &s.Key, &s.TotalSize, &s.ChunkSize, &s.TotalChunks,
+		&completedJSON, &contentType, &metadataJSON, &cacheControl, &ownerID,
+		&s3UploadID, &etagsJSON, &s.Status, &s.CreatedAt, &s.ExpiresAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errChunkedSessionNotFound
+		}
+		return nil, fmt.Errorf("failed to query chunked upload session: %w", err)
+	}
+
+	s.ContentType = contentType.String
+	s.CacheControl = cacheControl.String
+	s.S3UploadID = s3UploadID.String
+	s.OwnerID = ownerID.String
+
+	if len(completedJSON) > 0 {
+		if err := json.Unmarshal(completedJSON, &s.CompletedChunks); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal completed_chunks: %w", err)
+		}
+	}
+	if len(etagsJSON) > 0 && string(etagsJSON) != "null" {
+		// S3PartETags is map[int]string; JSON keys are strings, so decode into a
+		// string-keyed map first and convert.
+		var strKeys map[string]string
+		if err := json.Unmarshal(etagsJSON, &strKeys); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal s3_part_etags: %w", err)
+		}
+		s.S3PartETags = make(map[int]string, len(strKeys))
+		for k, v := range strKeys {
+			var idx int
+			if _, err := fmt.Sscanf(k, "%d", &idx); err != nil {
+				return nil, fmt.Errorf("failed to parse part index %q: %w", k, err)
+			}
+			s.S3PartETags[idx] = v
+		}
+	}
+	if len(metadataJSON) > 0 && string(metadataJSON) != "null" {
+		if err := json.Unmarshal(metadataJSON, &s.Metadata); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
+		}
+	}
+
+	return &s, nil
+}
+
+// updateChunkedSessionDB upserts a session row under RLS.
+func (h *StorageHandler) updateChunkedSessionDB(ctx context.Context, c fiber.Ctx, session *storage.ChunkedUploadSession) error {
+	completedJSON, err := json.Marshal(session.CompletedChunks)
+	if err != nil {
+		return fmt.Errorf("failed to marshal completed_chunks: %w", err)
+	}
+	etagsJSON, err := json.Marshal(session.S3PartETags)
+	if err != nil {
+		return fmt.Errorf("failed to marshal s3_part_etags: %w", err)
+	}
+
+	tx, err := h.getPool(c).Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := h.setRLSContext(ctx, tx, c); err != nil {
+		return fmt.Errorf("failed to set RLS context: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `
+		UPDATE storage.chunked_upload_sessions
+		SET completed_chunks = $1,
+		    s3_part_etags = $2,
+		    status = $3,
+		    updated_at = NOW()
+		WHERE upload_id = $4
+	`, completedJSON, etagsJSON, session.Status, session.UploadID)
+	if err != nil {
+		return fmt.Errorf("failed to update chunked upload session: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit chunked upload session: %w", err)
+	}
+	return nil
+}
+
+// deleteChunkedSessionDB removes a session row under RLS.
+func (h *StorageHandler) deleteChunkedSessionDB(ctx context.Context, c fiber.Ctx, uploadID string) error {
+	tx, err := h.getPool(c).Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := h.setRLSContext(ctx, tx, c); err != nil {
+		return fmt.Errorf("failed to set RLS context: %w", err)
+	}
+
+	_, err = tx.Exec(ctx, `DELETE FROM storage.chunked_upload_sessions WHERE upload_id = $1`, uploadID)
+	if err != nil {
+		return fmt.Errorf("failed to delete chunked upload session: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit chunked upload session delete: %w", err)
+	}
+	return nil
+}
+
+// isS3Provider reports whether the given provider is S3-backed (and thus needs
+// DB-backed chunked sessions).
+func isS3Provider(p storage.Provider) bool {
+	_, ok := p.(*storage.S3Storage)
+	return ok
+}

--- a/internal/api/storage_multipart.go
+++ b/internal/api/storage_multipart.go
@@ -118,7 +118,7 @@ func (h *StorageHandler) MultipartUpload(c fiber.Ctx) error {
 		}
 
 		// Upload file
-		if err := uploadMultipartFile(c, svc, bucket, key, file, contentType); err != nil {
+		if err := h.uploadMultipartFile(c, svc, bucket, key, file, contentType); err != nil {
 			errors = append(errors, fmt.Sprintf("%s: %s", file.Filename, err.Error()))
 			continue
 		}
@@ -142,8 +142,12 @@ func (h *StorageHandler) MultipartUpload(c fiber.Ctx) error {
 	return c.Status(fiber.StatusCreated).JSON(response)
 }
 
-// uploadMultipartFile uploads a single file from multipart form
-func uploadMultipartFile(c fiber.Ctx, svc *storage.Service, bucket, key string, file *multipart.FileHeader, contentType string) error {
+// uploadMultipartFile uploads a single file from multipart form and records its
+// metadata row in storage.objects. This mirrors StorageHandler.UploadFile in
+// storage_files.go — without the metadata insert, the uploaded bytes would be
+// invisible to the API (download/list/share/delete key off the objects row) and
+// the file would have no owner_id, failing the storage_objects_insert RLS policy.
+func (h *StorageHandler) uploadMultipartFile(c fiber.Ctx, svc *storage.Service, bucket, key string, file *multipart.FileHeader, contentType string) error {
 	src, err := file.Open()
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
@@ -154,8 +158,72 @@ func uploadMultipartFile(c fiber.Ctx, svc *storage.Service, bucket, key string, 
 		ContentType: contentType,
 	}
 
-	_, err = svc.Provider.Upload(c.RequestCtx(), bucket, key, src, file.Size, opts)
-	return err
+	ctx := c.RequestCtx()
+
+	// Upload the file to the storage provider first
+	object, err := svc.Provider.Upload(ctx, bucket, key, src, file.Size, opts)
+	if err != nil {
+		log.Error().Err(err).Str("bucket", bucket).Str("key", key).Msg("Failed to upload multipart file")
+		return fmt.Errorf("failed to upload file")
+	}
+
+	// Get owner ID from authenticated user (same source as the regular upload path)
+	ownerID := getUserID(c)
+	var ownerUUID *string
+	if ownerID != "" && ownerID != "anonymous" {
+		ownerUUID = &ownerID
+	}
+
+	// Store object metadata in the database under RLS
+	tx, err := h.getPool(c).Begin(ctx)
+	if err != nil {
+		_ = svc.Provider.Delete(ctx, bucket, key)
+		log.Error().Err(err).Msg("Failed to start transaction for multipart file upload")
+		return fmt.Errorf("failed to save file metadata")
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := h.setRLSContext(ctx, tx, c); err != nil {
+		_ = svc.Provider.Delete(ctx, bucket, key)
+		log.Error().Err(err).Msg("Failed to set RLS context for multipart file upload")
+		return fmt.Errorf("failed to save file metadata")
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO storage.objects (bucket_id, path, mime_type, size, metadata, owner_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (bucket_id, path)
+		DO UPDATE SET mime_type = $3, size = $4, owner_id = $6, updated_at = NOW()
+	`, bucket, key, contentType, object.Size, nil, ownerUUID)
+	if err != nil {
+		_ = svc.Provider.Delete(ctx, bucket, key)
+		errMsg := err.Error()
+		log.Error().
+			Err(err).
+			Str("bucket", bucket).
+			Str("key", key).
+			Str("error_message", errMsg).
+			Msg("Failed to insert multipart file metadata into database")
+		if strings.Contains(errMsg, "permission denied") || strings.Contains(errMsg, "policy") {
+			return fmt.Errorf("insufficient permissions to upload file")
+		}
+		return fmt.Errorf("failed to save file metadata")
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		_ = svc.Provider.Delete(ctx, bucket, key)
+		log.Error().Err(err).Str("bucket", bucket).Str("key", key).Msg("Failed to commit multipart file upload")
+		return fmt.Errorf("failed to save file metadata")
+	}
+
+	log.Info().
+		Str("bucket", bucket).
+		Str("key", key).
+		Int64("size", object.Size).
+		Str("user_id", ownerID).
+		Msg("Multipart file uploaded")
+
+	return nil
 }
 
 // fiber:context-methods migrated

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -1064,6 +1064,42 @@ func TestLocalStorage_UpdateChunkedUploadSession(t *testing.T) {
 	assert.Equal(t, "paused", retrieved.Status)
 }
 
+// TestLocalStorage_ChunkedUpload_OwnerIDDurability covers the root cause of the
+// chunked-upload RLS bug: InitChunkedUpload writes session.json before the
+// caller assigns OwnerID on the returned struct. A re-persist via
+// UpdateChunkedUploadSession must make the owner survive a reload, otherwise
+// storeUploadedObject inserts storage.objects with owner_id = NULL and fails
+// the storage_objects_insert RLS policy for authenticated users.
+func TestLocalStorage_ChunkedUpload_OwnerIDDurability(t *testing.T) {
+	storage, _ := setupLocalStorage(t)
+	ctx := context.Background()
+
+	err := storage.CreateBucket(ctx, "temp-files")
+	require.NoError(t, err)
+
+	// Simulate the init handler: InitChunkedUpload returns a session whose
+	// OwnerID is empty (it's not a parameter and never set inside the provider).
+	session, err := storage.InitChunkedUpload(ctx, "temp-files", "user-123/timestamp-file.geojson", 2048, 1024, nil)
+	require.NoError(t, err)
+	require.Empty(t, session.OwnerID, "InitChunkedUpload must not set OwnerID")
+
+	// Reloading right after init reproduces the bug: owner is lost.
+	reloadedBeforeUpdate, err := storage.GetChunkedUploadSession(session.UploadID)
+	require.NoError(t, err)
+	assert.Empty(t, reloadedBeforeUpdate.OwnerID, "owner is empty until re-persisted")
+
+	// The init handler assigns the owner after init and must re-persist it.
+	session.OwnerID = "user-123"
+	err = storage.UpdateChunkedUploadSession(session)
+	require.NoError(t, err)
+
+	// After re-persist, the owner survives a reload — fixing the RLS failure.
+	reloadedAfterUpdate, err := storage.GetChunkedUploadSession(session.UploadID)
+	require.NoError(t, err)
+	assert.Equal(t, "user-123", reloadedAfterUpdate.OwnerID,
+		"OwnerID must survive a session reload after UpdateChunkedUploadSession")
+}
+
 func TestLocalStorage_GenerateSignedURL_NoSecret(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Problem

Several storage upload paths completed the byte transfer but failed to create a RLS-owned `storage.objects` row, so uploaded files were invisible to the API — download/list/share/delete all 404'd, and downstream jobs (e.g. a Wayli `data-import` job reading `temp-files/...`) failed immediately.

Reproduced from a running instance's logs (the trigger for this work):
```
INF Chunked upload completed  size=656314045
WRN Failed to store object in database  error="failed to insert object: ERROR: new row violates row-level security policy for table \"objects\" (SQLSTATE 42501)"
ERR Error in GEOJSON import job: Error: Failed to download file: {}   # 404 on HEAD
```

A sweep found **three** upload paths with the same family of defect. All three are fixed in this PR.

---

## Fix 1 — LocalStorage chunked upload: `owner_id = NULL` (RLS 42501)

`storeUploadedObject` inserted `storage.objects` with `owner_id = NULL` because `session.OwnerID` was lost between init and completion:
- `InitChunkedUpload` writes `session.json` **before** the caller assigns `session.OwnerID`.
- The init handler set the owner *after* persistence, then called `storeChunkedUploadSession` — a **no-op stub**.
- On completion the session was reloaded from disk → empty owner → `NULL` insert → RLS denies (`current_user_id() = owner_id` fails for `NULL`).

**Fix:** (a) init handler re-persists the session via `updateChunkedUploadSessionInProvider` after assigning the owner; (b) defensive fallback in `storeUploadedObject` resolves `owner_id` from the live request (`getUserID(c)`) when the session has none — mirroring the regular `UploadFile` path that was never affected. Removed the dead stub.

Test: `TestLocalStorage_ChunkedUpload_OwnerIDDurability` (passes locally).

---

## Fix 2 — Multipart upload: no `storage.objects` row at all

`uploadMultipartFile` (`POST /:bucket/multipart`) wrote bytes to the provider but **never** inserted a `storage.objects` row. Every file uploaded this way had no owner and 404'd on download/list/share/delete.

**Fix:** converted `uploadMultipartFile` to a handler method mirroring `UploadFile` — transaction + `setRLSContext` + `INSERT INTO storage.objects (..., owner_id from getUserID(c))`, with provider-side cleanup on insert failure.

---

## Fix 3 — S3 chunked upload: entirely non-functional (no-op session stubs)

`S3Storage` has no on-disk session store, and the handler's session helpers had **no-op stubs** for the S3 branches (`\"S3 sessions would be stored in database\"`). Every S3 chunked upload orphaned a multipart upload and 404'd on the second request (`UploadChunk`). The schema even shipped a `chunked_upload_sessions` table (columns, RLS, `owner_id`) that **no Go code ever wrote to**.

**Fix:** implemented DB-backed chunked-upload session persistence for S3 using that existing table:
- **`storage_chunked_db.go`** (new): `create`/`get`/`update`/`delete` session rows under RLS, with JSON (de)serialization of `completed_chunks` and `s3_part_etags` (`map[int]string` round-trips via a string-keyed intermediate).
- Handler session helpers (`get`/`update`/`delete`) now dispatch S3 to the DB methods; the init handler creates the DB row for S3 and persists the owner for LocalStorage.
- All operations run as the authenticated user under RLS (`storage_chunked_sessions_*` policies enforce `current_user_id() = owner_id` for non-admins). LocalStorage's file-based sessions are unchanged.

---

## Verification
- `go build ./...` ✅
- `go vet ./internal/api/... ./internal/storage/...` ✅
- `gofmt` clean on all changed files ✅
- `go test -short ./internal/storage/` ✅, `go test -short ./internal/api/ -run "Storage|Chunked|Upload"` ✅
- New unit test `TestLocalStorage_ChunkedUpload_OwnerIDDurability` passes locally.

The S3 DB-backed session path is an integration-level feature (needs a live DB + S3); the heavier end-to-end coverage will run in CI. Test-machine runs were slow, so I leaned on build/vet/unit + CI for the full suites.

## Notes / follow-ups
- The `chunked_upload_sessions` table is now actually used (previously dead schema). Expired-session cleanup for S3 relies on the table's `expires_at` + the existing `CleanupExpiredMultipartUploads` for S3 orphans; a dedicated row-reaper could be added if S3 chunked volume grows.
- `storeUploadedObject` uses `h.db.Pool()` directly while other handlers use `h.getPool(c)` (tenant-aware) — pre-existing inconsistency, left as-is here.