### PR TITLE
feat(sdk): allow rpc() callable to accept namespace option

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -65,21 +65,28 @@ import type { FluxbaseClientOptions } from "./types";
  */
 export type CallableRPC = {
   /**
-   * Call a PostgreSQL function (RPC) - Supabase compatible
-   * Uses 'default' namespace
+   * Call a PostgreSQL function (RPC) - Supabase compatible.
+   * Defaults to the 'default' namespace; pass options.namespace to target a
+   * different one.
    *
    * @param fn - Function name
    * @param params - Function parameters
+   * @param options - Optional: { namespace?, async?, timeout? }
    * @returns Promise with data or error
    *
    * @example
    * ```typescript
+   * // Default namespace
    * const { data, error } = await client.rpc('get_user_orders', { user_id: '123' })
+   *
+   * // Custom namespace (shorthand for rpc.invoke with namespace)
+   * const { data, error } = await client.rpc('get_orders', { id: 1 }, { namespace: 'myapp' })
    * ```
    */
   <T = unknown>(
     fn: string,
     params?: Record<string, unknown>,
+    options?: { namespace?: string; async?: boolean; timeout?: number },
   ): Promise<{ data: T | null; error: Error | null }>;
 } & FluxbaseRPC;
 
@@ -230,6 +237,9 @@ export class FluxbaseClient<
    * // Supabase-style direct call (uses 'default' namespace)
    * const { data, error } = await client.rpc('get_user_orders', { user_id: '123' })
    *
+   * // With a custom namespace (shorthand for rpc.invoke)
+   * const { data, error } = await client.rpc('get_orders', { id: 1 }, { namespace: 'myapp' })
+   *
    * // With full options
    * const { data, error } = await client.rpc.invoke('get_user_orders', { user_id: '123' }, {
    *   namespace: 'custom',
@@ -377,12 +387,16 @@ export class FluxbaseClient<
     // Initialize RPC module with callable wrapper (Supabase-compatible)
     const rpcInstance = new FluxbaseRPC(this.fetch);
 
-    // Create callable function that wraps invoke() for Supabase-style calls
+    // Create callable function that wraps invoke() for Supabase-style calls.
+    // Accepts an optional options arg (namespace, async, timeout) so callers
+    // can use the shorthand syntax with a non-default namespace:
+    //   client.rpc('get_orders', { id: 1 }, { namespace: 'myapp' })
     const rpcCallable = async <T = unknown>(
       fn: string,
       params?: Record<string, unknown>,
+      options?: { namespace?: string; async?: boolean; timeout?: number },
     ): Promise<{ data: T | null; error: Error | null }> => {
-      const result = await rpcInstance.invoke<T>(fn, params);
+      const result = await rpcInstance.invoke<T>(fn, params, options);
       return {
         data: (result.data?.result as T) ?? null,
         error: result.error,


### PR DESCRIPTION
## Summary

The Supabase-compatible `rpc(fn, params)` callable was hardcoded to the `'default'` namespace. For multi-namespace apps (e.g. Wayli uses `'wayli'`), callers had to use the verbose `rpc.invoke(fn, params, { namespace })` form.

Now `rpc(fn, params, options)` accepts an optional third argument with `namespace`, `async`, and `timeout` — matching `invoke`'s full signature. **Backward compatible**: omitting options still uses `'default'`.

```typescript
// Before — only way to use a custom namespace:
client.rpc.invoke('get_orders', { id: 1 }, { namespace: 'myapp' })

// After — shorthand:
client.rpc('get_orders', { id: 1 }, { namespace: 'myapp' })
```

Updated `CallableRPC` type and JSDoc.

## Test plan
- [x] SDK builds (tsup + DTS)
- [x] Backward compatible — existing `rpc(fn, params)` calls still use `'default'`
- [ ] Wayli consumes the shorthand for `is-discoverable-to` RPC in the `wayli` namespace