### PR TITLE
fix(schema): prepend DROP FUNCTION for CREATE [OR REPLACE] FUNCTION

### DIFF
--- a/internal/database/schema/idempotent.go
+++ b/internal/database/schema/idempotent.go
@@ -86,6 +86,24 @@ func MakeSQLIdempotent(sql string) string {
 				drops = append(drops, dropInfo{pattern: patternUnquoted, dropSQL: dropSQL, foundPos: -1})
 			}
 
+		case *nodes.CreateFunctionStmt:
+			// CREATE OR REPLACE FUNCTION cannot change a function's argument
+			// types or RETURN TYPE (Postgres rejects with SQLSTATE 42P13:
+			// "cannot change return type of existing function"). Prepend
+			// DROP FUNCTION IF EXISTS <name>(<argtypes>) CASCADE so the
+			// function is recreated fresh on re-apply. The signature (argument
+			// type list) is required by DROP FUNCTION to identify the overload.
+			fnName, fnQualBare := formatFunctionName(stmt.Funcname)
+			if fnName != "" {
+				argTypes := formatFunctionArgTypes(stmt.Parameters)
+				dropSQL := fmt.Sprintf("DROP FUNCTION IF EXISTS %s(%s) CASCADE;\n", fnName, argTypes)
+				// Match both "CREATE FUNCTION" and "CREATE OR REPLACE FUNCTION"
+				// forms (and quoted/unqualified name variants).
+				for _, p := range functionCreatePatterns(fnQualBare) {
+					drops = append(drops, dropInfo{pattern: p, dropSQL: dropSQL, foundPos: -1})
+				}
+			}
+
 		case *nodes.AlterTableStmt:
 			if stmt.Cmds != nil && stmt.Relation != nil {
 				for _, cmd := range stmt.Cmds.Items {
@@ -154,4 +172,103 @@ func quoteIdent(name string) string {
 		return name
 	}
 	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(name, `"`, `""`))
+}
+
+// formatFunctionName builds the function name from a CreateFunctionStmt.Funcname
+// list (a *List of *nodes.String, e.g. ["public", "get_public_trip_track"]).
+// Returns ("", "") if the list is empty.
+//   - First return: schema-qualified, quoted form for the DROP statement
+//     (e.g. `"public"."get_public_trip_track"`).
+//   - Second return: schema-qualified, unquoted form as it typically appears in
+//     the CREATE statement (e.g. `public.get_public_trip_track`), used to build
+//     the textual match pattern.
+func formatFunctionName(funcname *nodes.List) (string, string) {
+	if funcname == nil || len(funcname.Items) == 0 {
+		return "", ""
+	}
+	parts := make([]string, 0, len(funcname.Items))
+	for _, item := range funcname.Items {
+		s, ok := item.(*nodes.String)
+		if !ok || s == nil {
+			return "", ""
+		}
+		parts = append(parts, s.Str)
+	}
+	quoted := make([]string, len(parts))
+	for i, p := range parts {
+		quoted[i] = quoteIdent(p)
+	}
+	return strings.Join(quoted, "."), strings.Join(parts, ".")
+}
+
+// formatFunctionArgTypes builds the comma-separated IN-argument-type list for
+// a DROP FUNCTION signature (e.g. "uuid, integer") from a CreateFunctionStmt
+// Parameters list. Returns an empty string for no args.
+//
+// PostgreSQL identifies a function by its name + IN-argument types only. The
+// RETURNS TABLE(...) columns and OUT args are parsed as Parameters too (with
+// mode FUNC_PARAM_TABLE / FUNC_PARAM_OUT) and MUST be excluded, or the DROP's
+// signature won't match the function. Only IN (i), INOUT (b), and VARIADIC (v)
+// args form the signature.
+func formatFunctionArgTypes(parameters *nodes.List) string {
+	if parameters == nil {
+		return ""
+	}
+	var types []string
+	for _, item := range parameters.Items {
+		param, ok := item.(*nodes.FunctionParameter)
+		if !ok || param == nil || param.ArgType == nil {
+			continue
+		}
+		switch param.Mode {
+		case nodes.FUNC_PARAM_IN, nodes.FUNC_PARAM_INOUT, nodes.FUNC_PARAM_VARIADIC:
+			// included in the signature
+		default:
+			// FUNC_PARAM_OUT / FUNC_PARAM_TABLE — not part of the identity.
+			continue
+		}
+		types = append(types, formatTypeName(param.ArgType))
+	}
+	return strings.Join(types, ", ")
+}
+
+// formatTypeName renders a *nodes.TypeName as a SQL type reference (e.g.
+// "uuid", "double precision", "public.geometry"). Uses the qualified Names
+// list when present; falls back to "<unknown>" if unparseable (rare).
+func formatTypeName(tn *nodes.TypeName) string {
+	if tn == nil || tn.Names == nil || len(tn.Names.Items) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(tn.Names.Items))
+	for _, item := range tn.Names.Items {
+		s, ok := item.(*nodes.String)
+		if !ok || s == nil {
+			continue
+		}
+		parts = append(parts, s.Str)
+	}
+	name := strings.Join(parts, ".")
+	// "double precision" and similar are parsed as a single list element
+	// ("double precision"); keep them as-is. Array types carry ArrayBounds.
+	if tn.ArrayBounds != nil && len(tn.ArrayBounds.Items) > 0 {
+		name += "[]"
+	}
+	return name
+}
+
+// functionCreatePatterns returns the textual CREATE-statement prefixes to
+// locate in the original SQL so the DROP is injected immediately before them.
+// Covers "CREATE FUNCTION" and "CREATE OR REPLACE FUNCTION", matching the
+// qualified name as it typically appears (unquoted, e.g.
+// `public.get_public_trip_track`) and as a fully-quoted form. Matching is
+// case-insensitive (the caller upper-cases both the pattern and the SQL).
+func functionCreatePatterns(qualBareName string) []string {
+	if qualBareName == "" {
+		return nil
+	}
+	var out []string
+	for _, kw := range []string{"CREATE OR REPLACE FUNCTION ", "CREATE FUNCTION "} {
+		out = append(out, kw+qualBareName)
+	}
+	return out
 }

--- a/internal/database/schema/idempotent_test.go
+++ b/internal/database/schema/idempotent_test.go
@@ -79,6 +79,56 @@ func TestMakeSQLIdempotent_CreateOrReplaceViewQuoted(t *testing.T) {
 	}
 }
 
+func TestMakeSQLIdempotent_CreateOrReplaceFunction(t *testing.T) {
+	// CREATE OR REPLACE FUNCTION cannot change its return type (SQLSTATE 42P13).
+	// Regression test: a DROP FUNCTION IF EXISTS with the arg-type signature must
+	// be prepended so the function is recreated fresh.
+	sql := `CREATE OR REPLACE FUNCTION public.get_public_trip_track(trip_uuid uuid) RETURNS TABLE(lat double precision, lng double precision, recorded_at timestamptz) LANGUAGE plpgsql AS $$ BEGIN END; $$;`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP FUNCTION IF EXISTS "public"."get_public_trip_track"(uuid) CASCADE;`) {
+		t.Errorf("expected DROP FUNCTION with signature prepended, got:\n%s", out)
+	}
+	if !strings.Contains(out, `CREATE OR REPLACE FUNCTION public.get_public_trip_track`) {
+		t.Errorf("expected original CREATE FUNCTION preserved, got:\n%s", out)
+	}
+	dropIdx := strings.Index(out, "DROP FUNCTION")
+	createIdx := strings.Index(out, "CREATE OR REPLACE FUNCTION")
+	if dropIdx < 0 || createIdx < 0 || dropIdx > createIdx {
+		t.Errorf("expected DROP before CREATE, got dropIdx=%d createIdx=%d", dropIdx, createIdx)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateFunctionMultipleArgs(t *testing.T) {
+	// Multiple arguments of different types: the signature must list them all.
+	// Note: pgparser normalizes "double precision" to its canonical
+	// "pg_catalog.float8" form; the DROP uses whatever the parser emits.
+	sql := `CREATE FUNCTION public.calc_distance(lat double precision, lng double precision, user_uuid uuid) RETURNS integer LANGUAGE sql AS $$ SELECT 1; $$;`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP FUNCTION IF EXISTS "public"."calc_distance"(`) {
+		t.Errorf("expected DROP FUNCTION with arg signature prepended, got:\n%s", out)
+	}
+	if !strings.Contains(out, `uuid) CASCADE;`) {
+		t.Errorf("expected uuid as last arg in DROP signature, got:\n%s", out)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateFunctionNoArgs(t *testing.T) {
+	sql := `CREATE FUNCTION public.now_utc() RETURNS timestamptz LANGUAGE sql AS $$ SELECT now(); $$;`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP FUNCTION IF EXISTS "public"."now_utc"() CASCADE;`) {
+		t.Errorf("expected DROP FUNCTION with empty arg list, got:\n%s", out)
+	}
+}
+
+func TestMakeSQLIdempotent_CreateFunctionUnqualified(t *testing.T) {
+	// Unqualified function name (no schema): DROP uses the bare name.
+	sql := `CREATE OR REPLACE FUNCTION my_func(id integer) RETURNS void LANGUAGE plpgsql AS $$ BEGIN END; $$;`
+	out := MakeSQLIdempotent(sql)
+	if !strings.Contains(out, `DROP FUNCTION IF EXISTS "my_func"(`) {
+		t.Errorf("expected DROP FUNCTION for unqualified name, got:\n%s", out)
+	}
+}
+
 func TestMakeSQLIdempotent_CreateIndex(t *testing.T) {
 	sql := `CREATE INDEX idx_users_email ON public.users (email);`
 	out := MakeSQLIdempotent(sql)

--- a/internal/migrations/app_declarative.go
+++ b/internal/migrations/app_declarative.go
@@ -769,7 +769,9 @@ func countDestructiveStatements(content string) int {
 			strings.HasPrefix(trimmed, "DROP TRIGGER IF EXISTS") ||
 			strings.HasPrefix(trimmed, "DROP CONSTRAINT IF EXISTS") ||
 			strings.HasPrefix(trimmed, "ALTER TABLE") && strings.Contains(trimmed, "DROP CONSTRAINT IF EXISTS") ||
-			strings.HasPrefix(trimmed, "DROP INDEX IF EXISTS") {
+			strings.HasPrefix(trimmed, "DROP INDEX IF EXISTS") ||
+			strings.HasPrefix(trimmed, "DROP FUNCTION IF EXISTS") ||
+			strings.HasPrefix(trimmed, "DROP PROCEDURE IF EXISTS") {
 			continue
 		}
 		if strings.HasPrefix(trimmed, "DROP TABLE") ||


### PR DESCRIPTION
## Problem

`MakeSQLIdempotent` (the transform used by the declarative schema-sync fallback path) had cases for POLICY, TRIGGER, INDEX, VIEW, and CONSTRAINT statements but **no case for FUNCTION**. A `CREATE OR REPLACE FUNCTION` whose **return type** or **argument types** changed was sent to Postgres verbatim and failed:

```
ERROR: cannot change return type of existing function (SQLSTATE 42P13)
```

This blocked `fluxbase schema sync` on every environment that still had the old signature — the second time this exact class of bug has blocked a Wayli deploy (the function gained a `recorded_at` column in its `RETURNS TABLE(...)`). It's the same bug class fixed for VIEWs in #303 (`CREATE OR REPLACE VIEW` couldn't change columns); the FUNCTION case was never added.

`--allow-destructive` does **not** help here: it only governs explicit DROPs of *removed* objects, not signature changes on *retained* functions. A `DROP FUNCTION IF EXISTS` line in the SQL file is also ignored (the transform parses object definitions, not arbitrary DDL).

## Fix

**`internal/database/schema/idempotent.go`** — add a `*nodes.CreateFunctionStmt` case (next to the VIEW case) that prepends:
```sql
DROP FUNCTION IF EXISTS <schema>.<name>(<IN-arg-types>) CASCADE;
```
before the `CREATE [OR REPLACE] FUNCTION`. Mirrors the VIEW handling exactly.

Key detail: the DROP signature uses **only IN/INOUT/VARIADIC args**. `RETURNS TABLE(...)` columns and OUT args are parsed as `FunctionParameter` nodes too, but Postgres identifies a function by name + IN-arg types only — including OUT args would make the DROP signature not match. The arg-type names come from the parser (which canonicalizes, e.g. `integer` → `pg_catalog.int4`, `double precision` → `pg_catalog.float8`); these are valid for `DROP FUNCTION`.

**`internal/migrations/app_declarative.go`** — add `DROP FUNCTION IF EXISTS` and `DROP PROCEDURE IF EXISTS` to the `countDestructiveStatements` skip-list, so the transform-generated DROPs aren't counted as destructive and blocked when `allow_destructive=false`. Matches the existing POLICY/TRIGGER/INDEX/CONSTRAINT skips.

**`internal/database/schema/idempotent_test.go`** — regression tests mirroring the VIEW tests: return-type change, multiple args, no args, unqualified name.

## Test plan
- [ ] `go test ./internal/database/schema/...` — new + existing idempotency tests pass (verified locally).
- [ ] `go test ./internal/migrations/...` — destructive-count tests unaffected.
- [ ] Full CI suite.

## Relation to #296
The function return-type gap is one of the fallback no-op cases listed in #296. This PR closes that specific gap. The other #296 gaps (inline constraint changes, column type changes, index operator/method changes) are separate and not addressed here.

## Notes
- The transform prepends an unconditional DROP for every `CREATE FUNCTION`, so even no-op re-applies drop+recreate the function. This is safe (matches the VIEW behavior exactly) but slightly heavier than `CREATE OR REPLACE` would be for unchanged functions. The transform is purely textual (no DB access), so it can't compare against the live signature to skip unchanged functions — consistent with how VIEWs are already handled.