### PR TITLE
fix(routes): generic settings :key shadowed secret/user index routes

### DIFF
--- a/internal/api/routes/registry.go
+++ b/internal/api/routes/registry.go
@@ -393,12 +393,19 @@ func registerAllGroups(registry *Registry, deps *AllDeps) {
 	if deps.AI != nil {
 		registry.MustRegister(BuildAIRoutes(deps.AI))
 	}
-	if deps.Settings != nil {
-		registry.MustRegister(BuildSettingsRoutes(deps.Settings))
-	}
+	// Register the child settings groups (user, secret) BEFORE the generic
+	// /api/v1/settings group. The generic group defines GET /api/v1/settings/:key,
+	// whose :key param would otherwise shadow the static "user" and "secret"
+	// child prefixes at their index path (e.g. GET /api/v1/settings/secret/ was
+	// matched as the generic handler with key="secret" → 404 "Setting not found").
+	// Fiber's radix tree resolves static segments ahead of params only when the
+	// static route is inserted first, so registration order is load-bearing here.
 	if deps.UserSettings != nil {
 		registry.MustRegister(BuildUserSettingsRoutes(deps.UserSettings))
 		registry.MustRegister(BuildUserSecretsRoutes(deps.UserSettings))
+	}
+	if deps.Settings != nil {
+		registry.MustRegister(BuildSettingsRoutes(deps.Settings))
 	}
 	if deps.Dashboard != nil {
 		registry.MustRegister(BuildDashboardAuthRoutes(deps.Dashboard))

--- a/internal/api/routes/settings_test.go
+++ b/internal/api/routes/settings_test.go
@@ -1,6 +1,8 @@
 package routes
 
 import (
+	"io"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/gofiber/fiber/v3"
@@ -67,4 +69,83 @@ func TestBuildSettingsRoutes_NoTenantMiddlewareIsSafe(t *testing.T) {
 		}
 	}
 	assert.False(t, foundTenant, "no TenantContext middleware should be added when none is provided")
+}
+
+// TestSettingsRoutePrecedence guards against a Fiber routing regression where
+// the generic GET /api/v1/settings/:key param route shadowed the static child
+// groups at their index path. Before the fix, GET /api/v1/settings/secret/ was
+// dispatched to the generic GetSetting handler with key="secret", returning
+// 404 "Setting not found or access denied" — which broke the SDK's
+// listSecrets() / listSettings() calls and surfaced in Wayli as
+// "Couldn't check API key status".
+//
+// This test registers the three settings groups exactly as registerAllGroups
+// does (via the Registry) and asserts that the secret + user index routes and
+// the generic param route all dispatch to their own handlers. The static
+// "secret"/"user" segments must win over the :key param at the index path.
+func TestSettingsRoutePrecedence(t *testing.T) {
+	next := func(c fiber.Ctx) error { return c.Next() }
+
+	// Distinct handlers so we can assert which one served each request.
+	genericKey := func(c fiber.Ctx) error { return c.SendString("generic:" + c.Params("key")) }
+	secretList := func(c fiber.Ctx) error { return c.SendString("secret-list") }
+	secretGet := func(c fiber.Ctx) error { return c.SendString("secret:" + c.Params("*")) }
+	userList := func(c fiber.Ctx) error { return c.SendString("user-list") }
+	userGet := func(c fiber.Ctx) error { return c.SendString("user:" + c.Params("key")) }
+
+	deps := &AllDeps{
+		Settings: &SettingsDeps{
+			OptionalAuth: next,
+			RequireAuth:  next,
+			GetSetting:   genericKey,
+			GetSettings:  func(c fiber.Ctx) error { return c.SendString("generic-index") },
+			BatchGet:     next,
+		},
+		UserSettings: &UserSettingsDeps{
+			RequireAuth:       next,
+			ListSettings:      userList,
+			GetUserOwnSetting: next,
+			GetSystemSetting:  next,
+			GetSetting:        userGet,
+			SetSetting:        next,
+			DeleteSetting:     next,
+			CreateSecret:      next,
+			ListSecrets:       secretList,
+			GetSecret:         secretGet,
+			UpdateSecret:      next,
+			DeleteSecret:      next,
+		},
+	}
+
+	registry := NewRegistry()
+	registerAllGroups(registry, deps)
+
+	app := fiber.New()
+	require.NoError(t, registry.Apply(app))
+
+	cases := []struct {
+		name       string
+		method     string
+		path       string
+		wantBody   string
+		wantStatus int
+	}{
+		{"secret list (SDK listSecrets)", "GET", "/api/v1/settings/secret/", "secret-list", 200},
+		{"secret list no trailing slash", "GET", "/api/v1/settings/secret", "secret-list", 200},
+		{"secret per-key (SDK getSecret)", "GET", "/api/v1/settings/secret/owntracks_api_key", "secret:owntracks_api_key", 200},
+		{"user list (SDK listSettings)", "GET", "/api/v1/settings/user/list", "user-list", 200},
+		{"user per-key", "GET", "/api/v1/settings/user/somekey", "user:somekey", 200},
+		{"generic param not shadowed", "GET", "/api/v1/settings/somekey", "generic:somekey", 200},
+		{"generic index", "GET", "/api/v1/settings/", "generic-index", 200},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			resp, err := app.Test(req)
+			require.NoError(t, err)
+			body, _ := io.ReadAll(resp.Body)
+			assert.Equal(t, tc.wantStatus, resp.StatusCode, "body: %s", string(body))
+			assert.Equal(t, tc.wantBody, string(body))
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`GET /api/v1/settings/secret/` (the SDK's `listSecrets()`) returned **404 "Setting not found or access denied"** in production, breaking any client that lists a user's secrets. In Wayli this surfaced as **"Couldn't check API key status"** on the Connections page even though the OwnTracks API key existed and was actively in use.

The per-key `getSecret('owntracks_api_key')` (`GET /secret/{key}`) worked fine — only the collection/index route was broken.

## Root cause

A Fiber route-precedence bug. The generic settings group defines:

\`\`\`
GET /api/v1/settings/:key   (param)
GET /api/v1/settings/       (index)
\`\`\`

and it was registered **before** the static child groups:

\`\`\`
GET /api/v1/settings/secret/   (user-secrets index — ListSecrets)
GET /api/v1/settings/secret/*  (user-secrets per-key — GetSecret)
GET /api/v1/settings/user/...  (user-settings)
\`\`\`

In Fiber's radix tree, a param route inserted **before** a static segment shadows that segment's **index path**. So `GET /api/v1/settings/secret/` was dispatched to the generic `GetSetting` handler with `key="secret"` — which queried \`app.settings WHERE key = 'secret'\`, found nothing, and returned the 404.

**Proof** (minimal Fiber repro, current order):
\`\`\`
GET /api/v1/settings/secret/                -> 200 GENERIC key=secret   ← BUG
GET /api/v1/settings/secret/owntracks_api_key -> 200 SECRET key=...      ← works (wildcard wins)
GET /api/v1/settings/user/                  -> 200 GENERIC key=user      ← also broken
\`\`\`

The error string \`"Setting not found or access denied"\` only exists in \`SettingsHandler.GetSetting\` (the generic handler), confirming the mis-dispatch.

## Fix

Register the user-settings and user-secrets groups **before** the generic settings group in \`registerAllGroups\`. Static segments then win over the \`:key\` param at the index path, while the generic param route continues to serve genuine single-key reads unchanged.

After the fix (same repro):
\`\`\`
GET /api/v1/settings/secret/                  -> 200 SECRET index
GET /api/v1/settings/secret                   -> 200 SECRET index
GET /api/v1/settings/secret/owntracks_api_key -> 200 SECRET key=...
GET /api/v1/settings/user/                    -> 200 US index
GET /api/v1/settings/somekey                  -> 200 GENERIC key=somekey
GET /api/v1/settings/                         -> 200 GENERIC index
\`\`\`

## Test

Added \`TestSettingsRoutePrecedence\` — an HTTP-level regression test that registers the three settings groups through the real \`Registry\`/\`Apply\` flow and asserts each route dispatches to its own handler (secret list, secret per-key, user list, user per-key, generic param, generic index).

Verified the test **fails without the fix** (\`secret-list\` case returns \`generic:secret\` — the exact prod bug) and **passes with it**.

## Verification
- \`go build ./...\` → OK
- \`go test ./internal/api/routes/...\` → PASS (incl. new test)
- Note: \`internal/api\` has 3 pre-existing failures (\`TestOTPFlow\`, \`TestReauthenticate\`, \`TestIdentityRoutes\`) that fail identically on a clean \`main\` — unrelated to this change.

## Impact

This unblocks the Wayli Connections page (and any SDK consumer of \`listSecrets()\` / \`listSettings()\`). No SDK changes required — the SDK already calls the correct endpoint; the server just wasn't routing it.