### PR TITLE
fix(reliability): auto-restart crashed workers and retry DB startup on transient errors

### DIFF
--- a/cmd/fluxbase/main.go
+++ b/cmd/fluxbase/main.go
@@ -33,9 +33,11 @@ var (
 	BuildDate = "unknown"
 
 	// CLI flags
-	showVersion      = flag.Bool("version", false, "Show version information")
-	validateConfig   = flag.Bool("validate", false, "Validate configuration and exit")
-	maxRetryAttempts = getEnvInt("FLUXBASE_DATABASE_RETRY_ATTEMPTS", 5)
+	showVersion    = flag.Bool("version", false, "Show version information")
+	validateConfig = flag.Bool("validate", false, "Validate configuration and exit")
+	// Legacy env override for the DB connection retry count. When unset, the
+	// value comes from the config (database.retry_attempts, default 8).
+	envRetryAttempts = getEnvInt("FLUXBASE_DATABASE_RETRY_ATTEMPTS", 0)
 
 	// Scaling CLI flags (override config file settings)
 	workerOnly           = flag.Bool("worker-only", false, "Run in worker-only mode (disable API server, only process background jobs)")
@@ -131,7 +133,9 @@ func main() {
 		log.Info().Msg("Testing database connection...")
 		db, err := database.ConnectWithRetry(cfg.Database, 1)
 		if err != nil {
-			db.Close()
+			if db != nil {
+				db.Close()
+			}
 			if cleanupVips != nil {
 				cleanupVips()
 			}
@@ -148,8 +152,14 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Initialize database connection with retry logic
-	db, err := database.ConnectWithRetry(cfg.Database, maxRetryAttempts)
+	// Initialize database connection with retry logic. The legacy
+	// FLUXBASE_DATABASE_RETRY_ATTEMPTS env var overrides the config attempt count
+	// for the initial connection when set.
+	connectAttempts := cfg.Database.RetryAttempts
+	if envRetryAttempts > 0 {
+		connectAttempts = envRetryAttempts
+	}
+	db, err := database.ConnectWithRetry(cfg.Database, connectAttempts)
 	if err != nil {
 		if cleanupVips != nil {
 			cleanupVips()
@@ -171,14 +181,16 @@ func main() {
 		AdminPassword: cfg.Database.AdminPassword,
 	}
 	bootstrapSvc := bootstrap.NewServiceWithConfig(db.Pool(), bootstrapConfig)
-	if err := bootstrapSvc.EnsureBootstrap(context.Background()); err != nil {
+	// Bootstrap opens its own admin pool internally, so a transient DB blip after
+	// the initial connect surfaces here. Retry transient errors before aborting.
+	runStartupStep("database bootstrap", dbRetryConfig(cfg.Database), func() {
 		if cleanupVips != nil {
 			cleanupVips()
 		}
 		db.Close()
-		log.Error().Err(err).Msg("Failed to run bootstrap")
-		os.Exit(1)
-	}
+	}, func() error {
+		return bootstrapSvc.EnsureBootstrap(context.Background())
+	})
 	log.Info().Msg("Database bootstrap completed successfully")
 
 	// Apply declarative schema (tables, indexes, functions, policies)
@@ -253,14 +265,16 @@ func main() {
 		source = "schema_apply"
 	}
 
-	if err := declarativeSvc.ApplyDeclarativeWithSource(context.Background(), source); err != nil {
+	// The declarative apply opens its own pools, so retry transient errors
+	// before aborting startup.
+	runStartupStep("declarative schema apply", dbRetryConfig(cfg.Database), func() {
 		if cleanupVips != nil {
 			cleanupVips()
 		}
 		db.Close()
-		log.Error().Err(err).Msg("Failed to apply declarative schema")
-		os.Exit(1)
-	}
+	}, func() error {
+		return declarativeSvc.ApplyDeclarativeWithSource(context.Background(), source)
+	})
 	log.Info().Str("source", source).Msg("Declarative schema applied successfully")
 
 	// Recreate the pool after migrations to clear any stale prepared statement cache
@@ -302,10 +316,10 @@ func main() {
 
 		appNamespaces := cfg.Database.DeclarativeAppSchema.Namespaces
 		if cfg.Database.DeclarativeAppSchema.OnStartup {
-			if err := appDeclarative.ApplyAllPending(context.Background(), appNamespaces); err != nil {
-				log.Error().Err(err).Msg("Failed to apply declarative app schema")
-				os.Exit(1)
-			}
+			// App-schema apply opens its own pools; retry transient errors.
+			runStartupStep("declarative app schema apply", dbRetryConfig(cfg.Database), nil, func() error {
+				return appDeclarative.ApplyAllPending(context.Background(), appNamespaces)
+			})
 		}
 
 		// Coexistence guard: warn (do not fail) if the same namespace also has
@@ -499,6 +513,39 @@ func getEnvInt(key string, defaultValue int) int {
 		}
 	}
 	return defaultValue
+}
+
+// dbRetryConfig builds the RetryConfig for DB-dependent startup steps from the
+// database config. The legacy FLUXBASE_DATABASE_RETRY_ATTEMPTS env var, when set,
+// overrides the configured attempt count for the initial connection only.
+func dbRetryConfig(db config.DatabaseConfig) database.RetryConfig {
+	rc := database.DefaultRetryConfig()
+	if db.RetryAttempts > 0 {
+		rc.MaxAttempts = db.RetryAttempts
+	}
+	if db.RetryInitialBackoff > 0 {
+		rc.InitialBackoff = db.RetryInitialBackoff
+	}
+	if db.RetryMaxBackoff > 0 {
+		rc.MaxBackoff = db.RetryMaxBackoff
+	}
+	return rc
+}
+
+// runStartupStep runs a DB-dependent startup step with transient-error retry.
+// On success it returns nil; on final failure it logs and exits the process
+// (matching the prior os.Exit(1) behavior). cleanup runs once before exit when
+// the step fails terminally (e.g. close the DB, release vips).
+func runStartupStep(name string, rc database.RetryConfig, cleanup func(), fn func() error) {
+	err := database.RetryTransient(context.Background(), name, rc, fn)
+	if err == nil {
+		return
+	}
+	if cleanup != nil {
+		cleanup()
+	}
+	log.Error().Err(err).Msg(name + " failed")
+	os.Exit(1)
 }
 
 // validateStorageHealth checks if the storage provider is accessible

--- a/fluxbase.yaml.example
+++ b/fluxbase.yaml.example
@@ -46,6 +46,13 @@ database:
   health_check_period: "1m"             # FLUXBASE_DATABASE_HEALTH_CHECK_PERIOD - Health check interval
   user_migrations_path: "/migrations/user"  # FLUXBASE_DATABASE_USER_MIGRATIONS_PATH - Path to user-provided migration files
 
+  # Reliability: startup DB-dependent steps (connect, bootstrap, schema apply)
+  # retry on transient errors so a slow-to-start Postgres doesn't abort startup.
+  connect_timeout: "10s"                # FLUXBASE_DATABASE_CONNECT_TIMEOUT - libpq connect_timeout (fails fast on hung connect)
+  retry_attempts: 8                     # FLUXBASE_DATABASE_RETRY_ATTEMPTS - total attempts per startup step
+  retry_initial_backoff: "1s"           # FLUXBASE_DATABASE_RETRY_INITIAL_BACKOFF - first retry backoff
+  retry_max_backoff: "30s"              # FLUXBASE_DATABASE_RETRY_MAX_BACKOFF - cap on each retry backoff
+
 # Authentication Configuration
 auth:
   jwt_secret: "your-secret-key-change-in-production"  # FLUXBASE_AUTH_JWT_SECRET - JWT signing secret (REQUIRED - must be changed!)
@@ -408,6 +415,11 @@ jobs:
 
   # Graceful shutdown
   graceful_shutdown_timeout: "5m"       # FLUXBASE_JOBS_GRACEFUL_SHUTDOWN_TIMEOUT - Time to wait for running jobs during shutdown
+
+  # Reliability: crashed embedded workers are automatically restarted. Backoff
+  # between restarts escalates exponentially up to this cap and never gives up,
+  # so the system self-heals once the underlying issue clears.
+  worker_max_restart_backoff: "60s"    # FLUXBASE_JOBS_WORKER_MAX_RESTART_BACKOFF - Cap for restart backoff
 
 # OpenTelemetry Tracing Configuration
 # Distributed tracing for observability (Jaeger, Tempo, Honeycomb, etc.)

--- a/internal/config/config_database.go
+++ b/internal/config/config_database.go
@@ -26,6 +26,10 @@ type DatabaseConfig struct {
 	UserMigrationsPath   string                      `mapstructure:"user_migrations_path"`   // Path to user-provided migration files
 	SlowQueryThreshold   time.Duration               `mapstructure:"slow_query_threshold"`   // Log queries slower than this (default: 1s)
 	DeclarativeAppSchema *DeclarativeAppSchemaConfig `mapstructure:"declarative_app_schema"` // Opt-in declarative schema for application tables (e.g. public)
+	ConnectTimeout       time.Duration               `mapstructure:"connect_timeout"`        // Per-attempt TCP connect timeout sent to Postgres (default: 10s)
+	RetryAttempts        int                         `mapstructure:"retry_attempts"`         // Startup retry attempts for DB-dependent steps (default: 8)
+	RetryInitialBackoff  time.Duration               `mapstructure:"retry_initial_backoff"`  // First retry backoff (default: 1s)
+	RetryMaxBackoff      time.Duration               `mapstructure:"retry_max_backoff"`      // Cap on each retry backoff (default: 30s)
 }
 
 // DeclarativeAppSchemaConfig enables declarative (desired-state) schema management for
@@ -116,6 +120,20 @@ func (dc *DatabaseConfig) Validate() error {
 		return fmt.Errorf("health_check_period must be positive, got: %v", dc.HealthCheck)
 	}
 
+	// Validate retry settings (<=0 means "use default" and is allowed).
+	if dc.RetryAttempts < 0 {
+		return fmt.Errorf("retry_attempts cannot be negative, got: %d", dc.RetryAttempts)
+	}
+	if dc.RetryInitialBackoff < 0 {
+		return fmt.Errorf("retry_initial_backoff cannot be negative, got: %v", dc.RetryInitialBackoff)
+	}
+	if dc.RetryMaxBackoff < 0 {
+		return fmt.Errorf("retry_max_backoff cannot be negative, got: %v", dc.RetryMaxBackoff)
+	}
+	if dc.ConnectTimeout < 0 {
+		return fmt.Errorf("connect_timeout cannot be negative, got: %v", dc.ConnectTimeout)
+	}
+
 	return nil
 }
 
@@ -151,11 +169,20 @@ func (dc *DatabaseConfig) AdminConnectionString() string {
 func (dc *DatabaseConfig) buildSecureConnString(user, password string) string {
 	// Use url.URL to properly encode credentials and prevent injection
 	u := &url.URL{
-		Scheme:   "postgres",
-		Host:     fmt.Sprintf("%s:%d", dc.Host, dc.Port),
-		Path:     "/" + dc.Database,
-		RawQuery: fmt.Sprintf("sslmode=%s", dc.SSLMode),
+		Scheme: "postgres",
+		Host:   fmt.Sprintf("%s:%d", dc.Host, dc.Port),
+		Path:   "/" + dc.Database,
 	}
+	// Always set a connect_timeout so a hung TCP connect fails fast (the libpq
+	// default relies on the OS, which can be very long). Falls back to 10s.
+	connectTimeout := dc.ConnectTimeout
+	if connectTimeout <= 0 {
+		connectTimeout = 10 * time.Second
+	}
+	q := u.Query()
+	q.Set("sslmode", dc.SSLMode)
+	q.Set("connect_timeout", fmt.Sprintf("%d", int(connectTimeout.Seconds())))
+	u.RawQuery = q.Encode()
 	u.User = url.UserPassword(user, password)
 	return u.String()
 }

--- a/internal/config/config_database_retry_test.go
+++ b/internal/config/config_database_retry_test.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Verifies that the connection string always carries a connect_timeout so a hung
+// TCP connect fails fast instead of waiting on the OS default.
+func TestDatabaseConfig_ConnectionStringIncludesConnectTimeout(t *testing.T) {
+	dc := DatabaseConfig{
+		Host:     "localhost",
+		Port:     5432,
+		User:     "postgres",
+		Password: "p@ss w0rd!",
+		Database: "fluxbase",
+		SSLMode:  "disable",
+	}
+
+	got := dc.RuntimeConnectionString()
+	assert.Contains(t, got, "connect_timeout=10", "default connect_timeout=10 should be present")
+
+	// Custom timeout.
+	dc.ConnectTimeout = 7 * time.Second
+	got = dc.RuntimeConnectionString()
+	assert.Contains(t, got, "connect_timeout=7", "custom connect_timeout should be honored")
+
+	// The password contains spaces/special chars that must be percent-encoded,
+	// proving the builder uses url.UserPassword rather than naive concatenation.
+	assert.True(t, strings.HasPrefix(got, "postgres://"))
+	assert.NotContains(t, got, "p@ss w0rd!", "raw password must not appear; it should be percent-encoded")
+	assert.Contains(t, got, "p%40ss", "special char '@' should be percent-encoded")
+}
+
+func TestDatabaseConfig_RetryDefaultsValidate(t *testing.T) {
+	// Zero/negative retry values are allowed (treated as defaults); validation
+	// only rejects explicit negatives.
+	dc := DatabaseConfig{
+		Host:            "localhost",
+		Port:            5432,
+		User:            "postgres",
+		Database:        "fluxbase",
+		SSLMode:         "disable",
+		MaxConnections:  10,
+		MaxConnLifetime: time.Hour,
+		MaxConnIdleTime: 30 * time.Minute,
+		HealthCheck:     time.Minute,
+	}
+	require.NoError(t, dc.Validate())
+
+	dc.RetryAttempts = -1
+	assert.Error(t, dc.Validate(), "negative retry_attempts must be rejected")
+}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -45,6 +45,13 @@ func setDefaults() {
 	viper.SetDefault("database.health_check_period", "1m")
 	viper.SetDefault("database.user_migrations_path", "/migrations/user")
 	viper.SetDefault("database.slow_query_threshold", "1s")
+	// Reliability: startup DB-dependent steps (connect, bootstrap, schema apply)
+	// retry on transient errors with exponential backoff. Defaults are bounded so
+	// startup waits ~1-2 min for a slow-to-start Postgres rather than aborting.
+	viper.SetDefault("database.connect_timeout", "10s")      // libpq connect_timeout
+	viper.SetDefault("database.retry_attempts", 8)           // total attempts per step
+	viper.SetDefault("database.retry_initial_backoff", "1s") // first retry backoff
+	viper.SetDefault("database.retry_max_backoff", "30s")    // cap on each backoff
 
 	// Declarative app-schema defaults (opt-in — off by default so existing apps are unaffected)
 	viper.SetDefault("database.declarative_app_schema.enabled", false)
@@ -266,7 +273,8 @@ func setDefaults() {
 		"192.168.0.0/16", // Private networks
 		"127.0.0.0/8",    // Loopback (localhost)
 	})
-	viper.SetDefault("jobs.graceful_shutdown_timeout", "5m") // Wait up to 5 minutes for jobs during shutdown
+	viper.SetDefault("jobs.graceful_shutdown_timeout", "5m")   // Wait up to 5 minutes for jobs during shutdown
+	viper.SetDefault("jobs.worker_max_restart_backoff", "60s") // Cap exponential backoff between worker restarts
 
 	// Tracing defaults (OpenTelemetry)
 	viper.SetDefault("tracing.enabled", false)             // Disabled by default

--- a/internal/config/config_jobs.go
+++ b/internal/config/config_jobs.go
@@ -24,6 +24,7 @@ type JobsConfig struct {
 	WorkerTimeout             time.Duration `mapstructure:"worker_timeout"`               // Worker considered dead after this
 	SyncAllowedIPRanges       []string      `mapstructure:"sync_allowed_ip_ranges"`       // IP CIDR ranges allowed to sync jobs
 	GracefulShutdownTimeout   time.Duration `mapstructure:"graceful_shutdown_timeout"`    // Time to wait for running jobs during shutdown (default: 5m)
+	WorkerMaxRestartBackoff   time.Duration `mapstructure:"worker_max_restart_backoff"`   // Cap for exponential backoff between worker restarts (default: 60s)
 }
 
 // Validate validates jobs configuration
@@ -86,6 +87,12 @@ func (jc *JobsConfig) Validate() error {
 	// single missed heartbeat never triggers cleanup.
 	if jc.WorkerTimeout < 2*jc.WorkerHeartbeatInterval {
 		return fmt.Errorf("worker_timeout (%v) must be at least 2x worker_heartbeat_interval (%v)", jc.WorkerTimeout, jc.WorkerHeartbeatInterval)
+	}
+
+	// Validate restart backoff cap. <=0 is allowed (means "use default") and is
+	// normalized in defaults; explicitly negative-after-normalize is invalid.
+	if jc.WorkerMaxRestartBackoff < 0 {
+		return fmt.Errorf("worker_max_restart_backoff cannot be negative, got: %v", jc.WorkerMaxRestartBackoff)
 	}
 
 	// Warn if max_max_duration is very high (over 1 hour)

--- a/internal/database/errors.go
+++ b/internal/database/errors.go
@@ -1,7 +1,12 @@
 package database
 
 import (
+	"context"
 	"errors"
+	"io"
+	"net"
+	"strings"
+	"syscall"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
@@ -15,6 +20,105 @@ const (
 	// ErrCodeCheckViolation is the PostgreSQL error code for check constraint violations
 	ErrCodeCheckViolation = "23514"
 )
+
+// transientSQLStateCodes are PostgreSQL SQLSTATE codes that indicate a transient
+// (retryable) failure rather than a logic/config error: the connection / admin
+// state is temporarily unavailable. See https://www.postgresql.org/docs/current/errcodes-appendix.html
+var transientSQLStateCodes = map[string]struct{}{
+	// Class 08 — Connection Exception
+	"08000": {}, // connection_exception
+	"08003": {}, // connection_does_not_exist
+	"08006": {}, // connection_failure
+	"08001": {}, // sqlclient_unable_to_establish_sqlconnection
+	"08004": {}, // sqlserver_rejected_establishment_of_sqlconnection
+	"08007": {}, // transaction_resolution_unknown
+	// Class 57 — Operator Intervention
+	"57P03": {}, // cannot_connect_now
+	"55006": {}, // object_in_use (transient during DDL)
+	// Class 40 — Transaction Rollback
+	"40001": {}, // serialization_failure
+	"40P01": {}, // deadlock_detected
+	"53":    {}, // Class 53 — Insufficient Resources (prefix match handled separately)
+}
+
+// isTransientSQLState reports whether a SQLSTATE code is in the transient set,
+// including a prefix match for class 53 (insufficient_resources, 53000-53114).
+func isTransientSQLState(code string) bool {
+	if _, ok := transientSQLStateCodes[code]; ok {
+		return true
+	}
+	// Class 53 — insufficient resources (53000..53114) are all retryable.
+	if len(code) == 5 && code[:2] == "53" {
+		return true
+	}
+	return false
+}
+
+// IsTransientError reports whether err represents a failure that may succeed on
+// retry: connection/network problems, the server temporarily refusing
+// connections (e.g. still starting up), context deadlines during connect, or
+// transient SQL states (serialization/deadlock/resource limits). It is used to
+// decide whether to retry DB-dependent startup steps instead of aborting.
+//
+// Non-transient errors (constraint violations, syntax errors, permission
+// errors, nil) report false so they fail fast rather than retrying forever.
+func IsTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Wrapped SQLSTATE.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return isTransientSQLState(pgErr.Code)
+	}
+
+	// Context deadline during a connect/operation is transient for startup.
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	// Network-layer errors: timeouts, refused, reset, closed, EOF.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	// pgx/pq connection errors often arrive as opaque strings wrapping these
+	// substrings (e.g. "failed to connect to ... connection refused"). Match
+	// conservatively to cover pool/wrapper errors that don't carry a typed cause.
+	msg := strings.ToLower(err.Error())
+	for _, frag := range transientErrorFragments {
+		if strings.Contains(msg, frag) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// transientErrorFragments are message substrings that indicate a transient
+// connection failure when the underlying error is not a typed net/syscall error.
+var transientErrorFragments = []string{
+	"connection refused",
+	"connection reset",
+	"broken pipe",
+	"timeout",
+	"timed out",
+	"no such host", // DNS hiccup
+	"server closed the connection unexpectedly",
+	"the database system is starting up",
+	"cannot connect now",
+	"eof",
+	"i/o timeout",
+}
 
 // IsUniqueViolation checks if an error is a unique constraint violation
 func IsUniqueViolation(err error) bool {

--- a/internal/database/retry.go
+++ b/internal/database/retry.go
@@ -1,8 +1,9 @@
 package database
 
 import (
+	"context"
 	"fmt"
-	"math"
+	"math/rand/v2"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -10,37 +11,142 @@ import (
 	"github.com/nimbleflux/fluxbase/internal/config"
 )
 
-// ConnectWithRetry attempts to connect to the database with exponential backoff.
-func ConnectWithRetry(cfg config.DatabaseConfig, maxAttempts int) (*Connection, error) {
-	var db *Connection
-	var err error
+// RetryConfig controls the retry behavior of RetryTransient and ConnectWithRetry.
+type RetryConfig struct {
+	MaxAttempts    int           // total attempts (>=1)
+	InitialBackoff time.Duration // backoff for the first retry
+	MaxBackoff     time.Duration // cap on each backoff
+}
 
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		log.Info().
+// DefaultRetryConfig returns sensible defaults: 8 attempts, 1s..30s backoff.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts:    8,
+		InitialBackoff: 1 * time.Second,
+		MaxBackoff:     30 * time.Second,
+	}
+}
+
+// backoffFor returns the (jittered) backoff to wait before attempt n+1, where n
+// is the number of failures so far (n>=1). It is exponential with full jitter,
+// capped at MaxBackoff. The returned value is suitable for selecting against a
+// context so callers can be interrupted during the wait.
+func (rc RetryConfig) backoffFor(failures int) time.Duration {
+	if failures <= 0 || rc.InitialBackoff <= 0 {
+		return 0
+	}
+	// 2^(failures-1) * initial, capped at MaxBackoff.
+	shift := uint(failures - 1)
+	if shift > 20 {
+		shift = 20
+	}
+	d := rc.InitialBackoff << shift
+	if rc.MaxBackoff > 0 && d > rc.MaxBackoff {
+		d = rc.MaxBackoff
+	}
+	// Full jitter in [d/2, d].
+	jitter := time.Duration(rand.Int64N(int64(d/2 + 1)))
+	return d/2 + jitter
+}
+
+// sleepCtx waits for d or until ctx is cancelled. Returns ctx.Err() if cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// RetryTransient runs fn, retrying only while it returns a transient error (per
+// IsTransientError). Non-transient errors and nil return immediately. Between
+// retries it sleeps with exponential backoff (jittered, capped) that is
+// interruptible by ctx. name is used in log lines to identify the step.
+//
+// This wraps DB-dependent startup steps (bootstrap, schema apply, initial
+// connection) so a transient blip after the initial connect doesn't abort
+// startup. On persistent real errors the original error is returned unchanged.
+func RetryTransient(ctx context.Context, name string, rc RetryConfig, fn func() error) error {
+	if rc.MaxAttempts < 1 {
+		rc.MaxAttempts = 1
+	}
+	var lastErr error
+	for attempt := 1; attempt <= rc.MaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		err := fn()
+		if err == nil {
+			if attempt > 1 {
+				log.Info().Str("step", name).Int("attempt", attempt).Msg("Step succeeded after retry")
+			}
+			return nil
+		}
+		lastErr = err
+
+		// Non-transient errors fail fast — don't retry a real permission/syntax error.
+		if !IsTransientError(err) {
+			return err
+		}
+
+		if attempt >= rc.MaxAttempts {
+			break
+		}
+		backoff := rc.backoffFor(attempt)
+		log.Warn().
+			Err(err).
+			Str("step", name).
 			Int("attempt", attempt).
-			Int("max_attempts", maxAttempts).
+			Int("max_attempts", rc.MaxAttempts).
+			Dur("retry_in", backoff).
+			Msg("Transient error, retrying")
+		if werr := sleepCtx(ctx, backoff); werr != nil {
+			return werr
+		}
+	}
+	return fmt.Errorf("%s failed after %d attempts: %w", name, rc.MaxAttempts, lastErr)
+}
+
+// ConnectWithRetry attempts to connect to the database with exponential backoff.
+//
+// It retries while NewConnection returns a transient error (per IsTransientError)
+// and fails fast on non-transient errors. The backoff is interruptible by ctx so
+// SIGTERM during startup isn't delayed. maxAttempts <= 0 falls back to a default.
+func ConnectWithRetry(cfg config.DatabaseConfig, maxAttempts int) (*Connection, error) {
+	if maxAttempts <= 0 {
+		maxAttempts = 8
+	}
+	rc := RetryConfig{
+		MaxAttempts:    maxAttempts,
+		InitialBackoff: 1 * time.Second,
+		MaxBackoff:     30 * time.Second,
+	}
+
+	var db *Connection
+	// RetryTransient has no cancellation channel from the caller (main blocks on
+	// this returning), so use a background context; backoff is still bounded.
+	err := RetryTransient(context.Background(), "database connect", rc, func() error {
+		log.Info().
 			Str("host", cfg.Host).
 			Int("port", cfg.Port).
 			Msg("Attempting to connect to database...")
-
-		db, err = NewConnection(cfg)
-		if err == nil {
-			log.Info().Msg("Successfully connected to database")
-			return db, nil
+		conn, err := NewConnection(cfg)
+		if err != nil {
+			return err
 		}
-
-		if attempt >= maxAttempts {
-			break
-		}
-
-		backoff := time.Duration(math.Pow(2, float64(attempt-1))) * time.Second
-		log.Warn().
-			Err(err).
-			Int("attempt", attempt).
-			Dur("retry_in", backoff).
-			Msg("Database connection failed, retrying...")
-		time.Sleep(backoff)
+		db = conn
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	return nil, fmt.Errorf("failed to connect after %d attempts: %w", maxAttempts, err)
+	log.Info().Msg("Successfully connected to database")
+	return db, nil
 }

--- a/internal/database/retry_test.go
+++ b/internal/database/retry_test.go
@@ -1,0 +1,133 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// =============================================================================
+// RetryConfig.backoffFor Tests
+// =============================================================================
+
+func TestRetryConfig_BackoffFor_EscalatesAndCaps(t *testing.T) {
+	rc := RetryConfig{InitialBackoff: 1 * time.Second, MaxBackoff: 10 * time.Second}
+
+	// First failure -> base of initial backoff, jittered into [base/2, base].
+	d := rc.backoffFor(1)
+	assert.GreaterOrEqual(t, d, 500*time.Millisecond)
+	assert.LessOrEqual(t, d, time.Second)
+
+	// Higher failure counts escalate but must never exceed the cap.
+	for i := 1; i <= 30; i++ {
+		d := rc.backoffFor(i)
+		assert.LessOrEqual(t, d, rc.MaxBackoff, "iter %d exceeded cap", i)
+	}
+}
+
+func TestRetryConfig_BackoffFor_ZeroAndNegative(t *testing.T) {
+	rc := RetryConfig{InitialBackoff: 1 * time.Second, MaxBackoff: 10 * time.Second}
+	assert.Equal(t, time.Duration(0), rc.backoffFor(0))
+	assert.Equal(t, time.Duration(0), rc.backoffFor(-3))
+
+	// Zero initial backoff always yields zero.
+	rc0 := RetryConfig{InitialBackoff: 0, MaxBackoff: 10 * time.Second}
+	assert.Equal(t, time.Duration(0), rc0.backoffFor(5))
+}
+
+// =============================================================================
+// RetryTransient Tests
+// =============================================================================
+
+func TestRetryTransient_SuccessFirstTry(t *testing.T) {
+	var calls int32
+	rc := RetryConfig{MaxAttempts: 5, InitialBackoff: 10 * time.Millisecond, MaxBackoff: 100 * time.Millisecond}
+	err := RetryTransient(context.Background(), "step", rc, func() error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls))
+}
+
+func TestRetryTransient_RetriesUntilSuccess(t *testing.T) {
+	var calls int32
+	rc := RetryConfig{MaxAttempts: 5, InitialBackoff: 1 * time.Millisecond, MaxBackoff: 10 * time.Millisecond}
+	err := RetryTransient(context.Background(), "step", rc, func() error {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			return errors.New("dial tcp: connection refused") // transient
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), atomic.LoadInt32(&calls), "should succeed on the 3rd call")
+}
+
+func TestRetryTransient_ExhaustsAttemptsOnPersistentTransient(t *testing.T) {
+	var calls int32
+	rc := RetryConfig{MaxAttempts: 4, InitialBackoff: 1 * time.Millisecond, MaxBackoff: 5 * time.Millisecond}
+	err := RetryTransient(context.Background(), "step", rc, func() error {
+		atomic.AddInt32(&calls, 1)
+		return errors.New("connection refused")
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "step")
+	assert.Equal(t, int32(4), atomic.LoadInt32(&calls))
+}
+
+func TestRetryTransient_NonTransientFailsFast(t *testing.T) {
+	var calls int32
+	rc := RetryConfig{MaxAttempts: 10, InitialBackoff: 1 * time.Millisecond, MaxBackoff: 10 * time.Millisecond}
+	sentinel := errors.New("permission denied")
+	err := RetryTransient(context.Background(), "step", rc, func() error {
+		atomic.AddInt32(&calls, 1)
+		return sentinel
+	})
+	// Non-transient must return the original error immediately, single call.
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&calls), "non-transient should not be retried")
+}
+
+func TestRetryTransient_RespectsContextCancellation(t *testing.T) {
+	var calls int32
+	rc := RetryConfig{MaxAttempts: 100, InitialBackoff: 50 * time.Millisecond, MaxBackoff: 50 * time.Millisecond}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel shortly after the first attempt so the backoff sleep is interrupted.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := RetryTransient(ctx, "step", rc, func() error {
+		atomic.AddInt32(&calls, 1)
+		return errors.New("connection refused") // transient -> would retry
+	})
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	// Must NOT have waited through many 50ms backoffs.
+	assert.Less(t, elapsed, 500*time.Millisecond, "should abort promptly on ctx cancel")
+}
+
+func TestRetryTransient_PreCancelledContext(t *testing.T) {
+	rc := RetryConfig{MaxAttempts: 5, InitialBackoff: 1 * time.Millisecond, MaxBackoff: 10 * time.Millisecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var calls int32
+	err := RetryTransient(ctx, "step", rc, func() error {
+		atomic.AddInt32(&calls, 1)
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&calls), "should not run fn on pre-cancelled ctx")
+}

--- a/internal/database/transient_errors_test.go
+++ b/internal/database/transient_errors_test.go
@@ -1,0 +1,112 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+)
+
+// =============================================================================
+// IsTransientError Tests
+//
+// IsTransientError decides whether a DB-dependent startup step should retry.
+// It must be true for connection/network problems and transient SQL states, and
+// false for logic/config errors (constraint violations, nil) so those fail fast.
+// =============================================================================
+
+func TestIsTransientError_Nil(t *testing.T) {
+	assert.False(t, IsTransientError(nil))
+}
+
+func TestIsTransientError_TransientPGStates(t *testing.T) {
+	transient := []string{
+		"08000", // connection_exception
+		"08001", // sqlclient_unable_to_establish_sqlconnection
+		"08003", // connection_does_not_exist
+		"08004", // sqlserver_rejected_establishment_of_sqlconnection
+		"08006", // connection_failure
+		"08007", // transaction_resolution_unknown
+		"57P03", // cannot_connect_now
+		"40001", // serialization_failure
+		"40P01", // deadlock_detected
+		"53000", // insufficient_resources (class prefix 53)
+		"53100", // disk_full
+	}
+	for _, code := range transient {
+		err := &pgconn.PgError{Code: code, Message: "x"}
+		assert.Truef(t, IsTransientError(err), "expected %s to be transient", code)
+	}
+}
+
+func TestIsTransientError_NonTransientPGStates(t *testing.T) {
+	nonTransient := []string{
+		"23505", // unique_violation
+		"23503", // foreign_key_violation
+		"42601", // syntax_error
+		"42501", // insufficient_privilege
+		"42P01", // undefined_table
+	}
+	for _, code := range nonTransient {
+		err := &pgconn.PgError{Code: code, Message: "x"}
+		assert.Falsef(t, IsTransientError(err), "expected %s to NOT be transient", code)
+	}
+}
+
+func TestIsTransientError_PGErrorWrapped(t *testing.T) {
+	// Wrapped PgError must still be detected via errors.As.
+	inner := &pgconn.PgError{Code: "08006"}
+	wrapped := fmt.Errorf("during apply: %w", inner)
+	assert.True(t, IsTransientError(wrapped))
+}
+
+func TestIsTransientError_Context(t *testing.T) {
+	assert.True(t, IsTransientError(context.DeadlineExceeded))
+	assert.False(t, IsTransientError(context.Canceled))
+}
+
+func TestIsTransientError_NetworkErrors(t *testing.T) {
+	// net.OpError with timeout.
+	ne := &net.OpError{Op: "dial", Net: "tcp", Err: &fakeTimeout{}}
+	assert.True(t, IsTransientError(ne))
+
+	// Common syscalls / io errors.
+	assert.True(t, IsTransientError(syscall.ECONNREFUSED))
+	assert.True(t, IsTransientError(syscall.ECONNRESET))
+	assert.True(t, IsTransientError(syscall.EPIPE))
+	assert.True(t, IsTransientError(io.EOF))
+	assert.True(t, IsTransientError(io.ErrUnexpectedEOF))
+}
+
+func TestIsTransientError_MessageFragments(t *testing.T) {
+	cases := []string{
+		"dial tcp 127.0.0.1:5432: connect: connection refused",
+		"server closed the connection unexpectedly",
+		"the database system is starting up",
+		"read tcp: i/o timeout",
+		"lookup postgres: no such host",
+	}
+	for _, msg := range cases {
+		assert.Truef(t, IsTransientError(errors.New(msg)), "expected transient: %s", msg)
+	}
+}
+
+func TestIsTransientError_NonTransientPlainError(t *testing.T) {
+	// A plain, non-network, non-pg error with no transient fragments is not
+	// retried (fail fast).
+	assert.False(t, IsTransientError(errors.New("permission denied for relation users")))
+}
+
+// fakeTimeout is a minimal net.Error reporting a timeout, for testing the
+// net.Error branch without a real network.
+type fakeTimeout struct{}
+
+func (fakeTimeout) Error() string   { return "i/o timeout" }
+func (fakeTimeout) Timeout() bool   { return true }
+func (fakeTimeout) Temporary() bool { return true }

--- a/internal/jobs/manager.go
+++ b/internal/jobs/manager.go
@@ -36,15 +36,20 @@ type Manager struct {
 	stopCh                 chan struct{}
 
 	// Worker supervision
-	workerErrors   chan workerError
-	workersMutex   sync.RWMutex
-	activeWorkers  map[uuid.UUID]bool
-	restartCounts  map[uuid.UUID]int
-	restartTimes   map[uuid.UUID]time.Time
-	restartMutex   sync.Mutex
-	targetCount    int
-	supervisorCtx  context.Context
-	supervisorStop context.CancelFunc
+	workerErrors  chan workerError
+	workersMutex  sync.RWMutex
+	activeWorkers map[uuid.UUID]bool
+	// restartFailures tracks recent worker restart timestamps (manager-level, so
+	// backoff escalates across replacements rather than resetting on each new
+	// worker ID). Guarded by restartMutex.
+	restartFailures []time.Time
+	restartMutex    sync.Mutex
+	targetCount     int
+	supervisorCtx   context.Context
+	supervisorStop  context.CancelFunc
+	// startWorkerFn spawns a single worker. Overridable for tests; in production
+	// it is nil and Start falls back to the real startWorker.
+	startWorkerFn func(ctx context.Context) *Worker
 }
 
 // NewManager creates a new worker manager
@@ -61,8 +66,6 @@ func NewManager(cfg *config.JobsConfig, conn *database.Connection, jwtSecret, pu
 		stopCh:         make(chan struct{}),
 		workerErrors:   make(chan workerError, 100),
 		activeWorkers:  make(map[uuid.UUID]bool),
-		restartCounts:  make(map[uuid.UUID]int),
-		restartTimes:   make(map[uuid.UUID]time.Time),
 	}
 }
 
@@ -106,7 +109,7 @@ func (m *Manager) Start(ctx context.Context, workerCount int) error {
 
 	// Start initial workers
 	for i := 0; i < workerCount; i++ {
-		m.startWorker(ctx)
+		m.spawn(ctx)
 	}
 
 	log.Info().
@@ -153,67 +156,71 @@ func (m *Manager) startWorker(ctx context.Context) *Worker {
 	return worker
 }
 
-// superviseWorkers monitors worker health and restarts failed workers
+// spawn starts a worker, using the test override startWorkerFn when set, else
+// the real startWorker.
+func (m *Manager) spawn(ctx context.Context) *Worker {
+	if m.startWorkerFn != nil {
+		return m.startWorkerFn(ctx)
+	}
+	return m.startWorker(ctx)
+}
+
+// superviseWorkers monitors worker health and restarts failed workers.
+//
+// It always attempts to recover (never permanently gives up): under repeated
+// failures the inter-restart backoff escalates exponentially up to a cap
+// (Config.WorkerMaxRestartBackoff, default 60s) and stays there, so the system
+// self-heals once the underlying issue clears without hammering the database.
+// The backoff is tracked at the manager level (not per worker ID) so it keeps
+// escalating across replacement workers, each of which gets a fresh UUID.
+//
+// Recent failures older than restartResetWindow are pruned, so a worker that
+// runs stably for a while resets the escalation.
 func (m *Manager) superviseWorkers() {
+	const restartResetWindow = 5 * time.Minute
+
 	for {
 		select {
 		case err := <-m.workerErrors:
 			log.Warn().
 				Err(err.err).
 				Str("worker_id", err.workerID.String()).
-				Msg("Worker failed, checking restart eligibility")
+				Msg("Worker failed, scheduling restart")
 
-			// Check if we should restart
-			m.restartMutex.Lock()
-			// Reset restart count after 5 minutes of stability
-			if lastTime, ok := m.restartTimes[err.workerID]; ok && time.Since(lastTime) >= 5*time.Minute {
-				delete(m.restartCounts, err.workerID)
-				delete(m.restartTimes, err.workerID)
-			}
-			restartCount := m.restartCounts[err.workerID]
-			maxRestarts := 5
-			shouldRestart := restartCount < maxRestarts
-			if shouldRestart {
-				m.restartCounts[err.workerID] = restartCount + 1
-				m.restartTimes[err.workerID] = time.Now()
-			}
-			m.restartMutex.Unlock()
+			backoff, recentFailures := m.nextRestartBackoff(restartResetWindow)
 
-			if shouldRestart {
-				// Exponential backoff: 1s, 2s, 4s, 8s, 16s
-				backoff := time.Second << time.Duration(restartCount)
-				if backoff > 30*time.Second {
-					backoff = 30 * time.Second
-				}
+			log.Info().
+				Str("failed_worker_id", err.workerID.String()).
+				Int("recent_failures", recentFailures).
+				Dur("backoff", backoff).
+				Msg("Scheduling worker restart with backoff")
+
+			// Wait for backoff, but bail out immediately if we're shutting down.
+			timer := time.NewTimer(backoff)
+			select {
+			case <-timer.C:
+			case <-m.supervisorCtx.Done():
+				timer.Stop()
+				log.Info().Msg("Worker supervisor stopped during restart backoff")
+				return
+			}
+
+			// Start a replacement only if we're below the target count.
+			m.workersMutex.RLock()
+			currentCount := len(m.activeWorkers)
+			m.workersMutex.RUnlock()
+
+			if currentCount < m.targetCount {
 				log.Info().
-					Str("failed_worker_id", err.workerID.String()).
-					Int("restart_count", restartCount+1).
-					Dur("backoff", backoff).
-					Msg("Scheduling worker restart with backoff")
-
-				time.Sleep(backoff)
-
-				// Check current worker count
-				m.workersMutex.RLock()
-				currentCount := len(m.activeWorkers)
-				m.workersMutex.RUnlock()
-
-				if currentCount < m.targetCount {
-					log.Info().
-						Int("current_workers", currentCount).
-						Int("target_workers", m.targetCount).
-						Msg("Starting replacement worker")
-					m.startWorker(m.supervisorCtx)
-				} else {
-					log.Info().
-						Int("current_workers", currentCount).
-						Msg("Worker count at target, not starting replacement")
-				}
+					Int("current_workers", currentCount).
+					Int("target_workers", m.targetCount).
+					Msg("Starting replacement worker")
+				m.spawn(m.supervisorCtx)
 			} else {
-				log.Error().
-					Str("worker_id", err.workerID.String()).
-					Int("restart_count", restartCount).
-					Msg("Worker exceeded max restarts, not restarting")
+				log.Info().
+					Int("current_workers", currentCount).
+					Int("target_workers", m.targetCount).
+					Msg("Worker count at target, not starting replacement")
 			}
 
 		case <-m.supervisorCtx.Done():
@@ -221,6 +228,55 @@ func (m *Manager) superviseWorkers() {
 			return
 		}
 	}
+}
+
+// nextRestartBackoff records a failure now, prunes failures older than the
+// reset window, and returns the backoff to wait before the next restart plus
+// the count of recent failures. Backoff escalates 1s, 2s, 4s, ... capped at
+// Config.WorkerMaxRestartBackoff (default 60s).
+func (m *Manager) nextRestartBackoff(resetWindow time.Duration) (time.Duration, int) {
+	now := time.Now()
+
+	m.restartMutex.Lock()
+	defer m.restartMutex.Unlock()
+
+	// Prune failures outside the reset window.
+	cutoff := now.Add(-resetWindow)
+	kept := m.restartFailures[:0]
+	for _, t := range m.restartFailures {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	kept = append(kept, now)
+	m.restartFailures = kept
+
+	recent := len(kept)
+
+	// Backoff = 2^(recent-1) * base, capped. recent starts at 1 on the first
+	// failure, so the first backoff is the base (1s).
+	const base = time.Second
+	shift := uint(recent - 1)
+	// Guard against shift overflow for very high failure counts.
+	if shift > 20 {
+		shift = 20
+	}
+	backoff := base << shift
+
+	cap := m.maxRestartBackoff()
+	if backoff > cap {
+		backoff = cap
+	}
+	return backoff, recent
+}
+
+// maxRestartBackoff returns the configured restart-backoff cap, defaulting to
+// 60s when unset or non-positive.
+func (m *Manager) maxRestartBackoff() time.Duration {
+	if m.Config == nil || m.Config.WorkerMaxRestartBackoff <= 0 {
+		return 60 * time.Second
+	}
+	return m.Config.WorkerMaxRestartBackoff
 }
 
 // Stop stops all workers gracefully

--- a/internal/jobs/manager_restart_helpers_test.go
+++ b/internal/jobs/manager_restart_helpers_test.go
@@ -1,0 +1,13 @@
+package jobs
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// newTestUUID returns a fresh random UUID for tests.
+func newTestUUID() uuid.UUID { return uuid.New() }
+
+// errFail returns a simple error used only by restart tests.
+func errFail(msg string) error { return fmt.Errorf("test failure: %s", msg) }

--- a/internal/jobs/manager_restart_test.go
+++ b/internal/jobs/manager_restart_test.go
@@ -1,0 +1,207 @@
+package jobs
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nimbleflux/fluxbase/internal/config"
+)
+
+// =============================================================================
+// Manager restart / supervision Tests
+//
+// superviseWorkers always recovers failed workers (never permanently gives up),
+// with manager-level exponential backoff that escalates across replacements and
+// caps at WorkerMaxRestartBackoff. These tests pin that behavior.
+// =============================================================================
+
+func TestManager_NextRestartBackoff_Escalates(t *testing.T) {
+	t.Run("backoff escalates 1s,2s,4s,... up to cap", func(t *testing.T) {
+		cfg := &config.JobsConfig{WorkerMaxRestartBackoff: 60 * time.Second}
+		m := NewManager(cfg, nil, "secret", "http://localhost", nil, nil)
+
+		// First failure: base 1s.
+		b, n := m.nextRestartBackoff(5 * time.Minute)
+		assert.Equal(t, time.Second, b)
+		assert.Equal(t, 1, n)
+
+		b, n = m.nextRestartBackoff(5 * time.Minute)
+		assert.Equal(t, 2*time.Second, b)
+		assert.Equal(t, 2, n)
+
+		b, n = m.nextRestartBackoff(5 * time.Minute)
+		assert.Equal(t, 4*time.Second, b)
+		assert.Equal(t, 3, n)
+
+		b, n = m.nextRestartBackoff(5 * time.Minute)
+		assert.Equal(t, 8*time.Second, b)
+		assert.Equal(t, 4, n)
+	})
+}
+
+func TestManager_NextRestartBackoff_Capped(t *testing.T) {
+	t.Run("backoff never exceeds configured cap", func(t *testing.T) {
+		cap := 10 * time.Second
+		cfg := &config.JobsConfig{WorkerMaxRestartBackoff: cap}
+		m := NewManager(cfg, nil, "secret", "http://localhost", nil, nil)
+
+		// Drive enough failures to exceed the cap.
+		var last time.Duration
+		for i := 0; i < 30; i++ {
+			b, n := m.nextRestartBackoff(5 * time.Minute)
+			last = b
+			require.Equal(t, i+1, n)
+			assert.LessOrEqual(t, b, cap, "backoff must not exceed cap on iter %d", i)
+		}
+		assert.Equal(t, cap, last, "backoff should reach the cap under sustained failure")
+	})
+}
+
+func TestManager_NextRestartBackoff_DefaultCap(t *testing.T) {
+	t.Run("non-positive config cap defaults to 60s", func(t *testing.T) {
+		m := NewManager(&config.JobsConfig{}, nil, "secret", "http://localhost", nil, nil)
+		assert.Equal(t, 60*time.Second, m.maxRestartBackoff())
+
+		m2 := NewManager(nil, nil, "secret", "http://localhost", nil, nil)
+		assert.Equal(t, 60*time.Second, m2.maxRestartBackoff())
+	})
+}
+
+func TestManager_NextRestartBackoff_ResetWindow(t *testing.T) {
+	t.Run("failures older than the reset window are pruned", func(t *testing.T) {
+		cfg := &config.JobsConfig{WorkerMaxRestartBackoff: 60 * time.Second}
+		m := NewManager(cfg, nil, "secret", "http://localhost", nil, nil)
+
+		// Accumulate a few failures within the window.
+		_, n := m.nextRestartBackoff(5 * time.Minute)
+		assert.Equal(t, 1, n)
+		_, n = m.nextRestartBackoff(5 * time.Minute)
+		assert.Equal(t, 2, n)
+		_, n = m.nextRestartBackoff(5 * time.Minute)
+		assert.Equal(t, 3, n)
+
+		// Now backdate all recorded failures so they fall outside the window.
+		m.restartMutex.Lock()
+		old := time.Now().Add(-10 * time.Minute)
+		for i := range m.restartFailures {
+			m.restartFailures[i] = old
+		}
+		m.restartMutex.Unlock()
+
+		// Next failure should reset the escalation (only the new one counts).
+		b, n := m.nextRestartBackoff(5 * time.Minute)
+		assert.Equal(t, 1, n)
+		assert.Equal(t, time.Second, b)
+	})
+}
+
+// spawnCountingManager returns a Manager whose worker spawns are counted via an
+// override, plus a cancel for its supervisor context. No DB is involved.
+func spawnCountingManager(t *testing.T, targetCount int, spawnDelay time.Duration) (*Manager, *int32, context.CancelFunc) {
+	t.Helper()
+	cfg := &config.JobsConfig{WorkerMaxRestartBackoff: 60 * time.Second}
+	m := NewManager(cfg, nil, "secret", "http://localhost", nil, nil)
+	m.targetCount = targetCount
+
+	m.supervisorCtx, m.supervisorStop = context.WithCancel(context.Background())
+
+	var spawns int32
+	m.startWorkerFn = func(ctx context.Context) *Worker {
+		atomic.AddInt32(&spawns, 1)
+		if spawnDelay > 0 {
+			time.Sleep(spawnDelay)
+		}
+		return nil
+	}
+	return m, &spawns, m.supervisorStop
+}
+
+func TestManager_SuperviseWorkers_RestartsOnFailure(t *testing.T) {
+	t.Run("a worker error triggers a replacement spawn", func(t *testing.T) {
+		m, spawns, stop := spawnCountingManager(t, 1, 0)
+		defer stop()
+
+		go m.superviseWorkers()
+		defer stop()
+
+		// First failure: backoff is 1s, then a spawn should occur.
+		m.workerErrors <- workerError{workerID: newTestUUID(), err: errFail("loop panic")}
+
+		// Wait a bit longer than the 1s backoff for the spawn.
+		done := make(chan struct{})
+		go func() {
+			for atomic.LoadInt32(spawns) == 0 {
+				time.Sleep(10 * time.Millisecond)
+			}
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("expected a replacement spawn, got %d", atomic.LoadInt32(spawns))
+		}
+	})
+}
+
+func TestManager_SuperviseWorkers_InterruptibleBackoff(t *testing.T) {
+	t.Run("Stop returns promptly during a long backoff", func(t *testing.T) {
+		// Large cap + many pre-seeded failures -> a long backoff. The supervisor
+		// must still exit immediately when its context is cancelled.
+		cfg := &config.JobsConfig{WorkerMaxRestartBackoff: 60 * time.Second}
+		m := NewManager(cfg, nil, "secret", "http://localhost", nil, nil)
+		m.targetCount = 1
+		m.supervisorCtx, m.supervisorStop = context.WithCancel(context.Background())
+
+		var spawns int32
+		m.startWorkerFn = func(ctx context.Context) *Worker {
+			atomic.AddInt32(&spawns, 1)
+			return nil
+		}
+
+		// Pre-seed a high failure count so the next backoff is large.
+		for i := 0; i < 10; i++ {
+			_, _ = m.nextRestartBackoff(5 * time.Minute)
+		}
+
+		go m.superviseWorkers()
+
+		start := time.Now()
+		// Feed an error to park the supervisor in its backoff select, then stop.
+		m.workerErrors <- workerError{workerID: newTestUUID(), err: errFail("boom")}
+		// Give the supervisor a moment to enter the backoff wait.
+		time.Sleep(50 * time.Millisecond)
+		m.supervisorStop()
+
+		// superviseWorkers returns on ctx Done; we only assert that stopping did
+		// not block for the full (multi-second) backoff.
+		elapsed := time.Since(start)
+		assert.Less(t, elapsed, 2*time.Second, "supervisor should exit during backoff, not wait it out")
+	})
+}
+
+func TestManager_SuperviseWorkers_AtTargetNoSpawn(t *testing.T) {
+	t.Run("does not spawn when already at target count", func(t *testing.T) {
+		m, spawns, stop := spawnCountingManager(t, 2, 0)
+		defer stop()
+
+		// Pretend we already have targetCount active workers.
+		m.workersMutex.Lock()
+		m.activeWorkers[newTestUUID()] = true
+		m.activeWorkers[newTestUUID()] = true
+		m.workersMutex.Unlock()
+
+		go m.superviseWorkers()
+		defer stop()
+
+		m.workerErrors <- workerError{workerID: newTestUUID(), err: errFail("boom")}
+
+		// Allow enough time for the 1s backoff + check; no spawn should happen.
+		time.Sleep(1500 * time.Millisecond)
+		assert.Equal(t, int32(0), atomic.LoadInt32(spawns), "no spawn expected at target count")
+	})
+}

--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -42,6 +42,8 @@ type Worker struct {
 	currentJobCountMutex   sync.RWMutex
 	shutdownChan           chan struct{}
 	shutdownComplete       chan struct{}
+	fatalErr               chan error // delivered exactly once when a background loop dies (see fail)
+	failed                 atomic.Bool
 	draining               bool // True when worker is draining (not accepting new jobs)
 	drainingMutex          sync.RWMutex
 }
@@ -84,6 +86,7 @@ func NewWorker(cfg *config.JobsConfig, storage *Storage, jwtSecret, publicURL st
 		publicURL:        publicURL,
 		shutdownChan:     make(chan struct{}),
 		shutdownComplete: make(chan struct{}),
+		fatalErr:         make(chan error, 1),
 	}
 
 	// Set up runtime callbacks
@@ -137,8 +140,17 @@ func (w *Worker) Start(ctx context.Context) error {
 	// Start job poll loop
 	go w.pollLoop(ctx)
 
-	// Wait for shutdown signal
-	<-w.shutdownChan
+	// Wait for shutdown signal or a fatal error from one of the background
+	// loops. A fatal error means the worker can no longer process jobs (e.g.
+	// a loop panicked); in that case we run the same graceful drain and
+	// surface the error so the manager's supervisor can start a replacement.
+	var fatal error
+	select {
+	case <-w.shutdownChan:
+	case fatal = <-w.fatalErr:
+		// Initiate the normal drain path so running jobs are handled.
+		w.signalShutdown()
+	}
 
 	// Set draining mode to stop accepting new jobs
 	w.setDraining(true)
@@ -173,14 +185,42 @@ func (w *Worker) Start(ctx context.Context) error {
 				Msg("Shutdown timeout reached, interrupting remaining jobs")
 			w.interruptAllJobs()
 			close(w.shutdownComplete)
-			return nil
+			return fatal
 		case <-ticker.C:
 			if w.getCurrentJobCount() == 0 {
 				log.Info().Str("worker_id", w.ID.String()).Msg("All jobs completed, worker stopped")
 				close(w.shutdownComplete)
-				return nil
+				return fatal
 			}
 		}
+	}
+}
+
+// fail marks the worker as fatally failed. It delivers a single error to the
+// fatalErr channel (buffered, size 1) so Worker.Start can surface it to the
+// manager's supervisor. Subsequent calls are no-ops: a worker fails at most
+// once. This is used by background loops (poll/heartbeat/timeout/cleanup) to
+// report unrecoverable panics so a replacement worker can be started; without
+// it, a dead loop would leave the worker silently idle forever.
+func (w *Worker) fail(reason string) {
+	if w.failed.Swap(true) {
+		return
+	}
+	err := fmt.Errorf("worker %s: %s", w.ID, reason)
+	select {
+	case w.fatalErr <- err:
+	default:
+	}
+}
+
+// signalShutdown closes shutdownChan once (idempotent), unblocking Start and
+// the background loops that select on it.
+func (w *Worker) signalShutdown() {
+	select {
+	case <-w.shutdownChan:
+		// already closed
+	default:
+		close(w.shutdownChan)
 	}
 }
 
@@ -222,7 +262,10 @@ func (w *Worker) pollLoop(ctx context.Context) {
 				Interface("panic", rec).
 				Str("worker_id", w.ID.String()).
 				Str("goroutine", "pollLoop").
-				Msg("Panic in poll loop - recovered, worker will stop processing jobs")
+				Msg("Panic in poll loop - recovered, marking worker as failed for restart")
+			// Without this the worker would silently stop polling forever;
+			// fail() lets the supervisor start a replacement.
+			w.fail(fmt.Sprintf("pollLoop panic: %v", rec))
 		}
 	}()
 
@@ -328,7 +371,8 @@ func (w *Worker) staleWorkerCleanupLoop(ctx context.Context) {
 				Interface("panic", rec).
 				Str("worker_id", w.ID.String()).
 				Str("goroutine", "staleWorkerCleanupLoop").
-				Msg("Panic in stale worker cleanup loop - recovered")
+				Msg("Panic in stale worker cleanup loop - recovered, marking worker as failed for restart")
+			w.fail(fmt.Sprintf("staleWorkerCleanupLoop panic: %v", rec))
 		}
 	}()
 
@@ -372,7 +416,8 @@ func (w *Worker) progressTimeoutLoop(ctx context.Context) {
 				Interface("panic", rec).
 				Str("worker_id", w.ID.String()).
 				Str("goroutine", "progressTimeoutLoop").
-				Msg("Panic in progress timeout loop - recovered")
+				Msg("Panic in progress timeout loop - recovered, marking worker as failed for restart")
+			w.fail(fmt.Sprintf("progressTimeoutLoop panic: %v", rec))
 		}
 	}()
 

--- a/internal/jobs/worker_fail_test.go
+++ b/internal/jobs/worker_fail_test.go
@@ -1,0 +1,90 @@
+package jobs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nimbleflux/fluxbase/internal/config"
+)
+
+// =============================================================================
+// Worker fail() Tests
+//
+// fail() lets a background loop report an unrecoverable error so Worker.Start
+// surfaces it to the manager's supervisor (which starts a replacement). Without
+// it, a panicked loop would leave the worker silently idle forever. These tests
+// pin the contract: fail() delivers exactly once, and signalShutdown() is a
+// safe double-close guard.
+// =============================================================================
+
+func TestWorker_Fail_Idempotent(t *testing.T) {
+	t.Run("delivers exactly one fatal error", func(t *testing.T) {
+		cfg := &config.JobsConfig{MaxConcurrentPerWorker: 5}
+		worker := NewWorker(cfg, nil, "secret", "http://localhost", nil, nil, nil)
+
+		// First call delivers.
+		worker.fail("boom-1")
+		select {
+		case err := <-worker.fatalErr:
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "boom-1")
+			assert.Contains(t, err.Error(), worker.ID.String())
+		default:
+			t.Fatal("expected a fatal error to be delivered")
+		}
+
+		// Subsequent calls must not deliver again.
+		worker.fail("boom-2")
+		worker.fail("boom-3")
+		select {
+		case err := <-worker.fatalErr:
+			t.Fatalf("fail() delivered a second error: %v", err)
+		default:
+			// expected: channel empty
+		}
+
+		assert.True(t, worker.failed.Load(), "failed flag should remain set")
+	})
+}
+
+func TestWorker_Fail_PrePopulatedChannel(t *testing.T) {
+	t.Run("does not block when channel already holds an error", func(t *testing.T) {
+		cfg := &config.JobsConfig{MaxConcurrentPerWorker: 5}
+		worker := NewWorker(cfg, nil, "secret", "http://localhost", nil, nil, nil)
+
+		worker.fail("first")
+		// Channel is now full (buffered size 1). A second fail() must not block.
+		done := make(chan struct{})
+		go func() {
+			worker.fail("second") // non-blocking via select/default
+			close(done)
+		}()
+		select {
+		case <-done:
+			// expected
+		case <-time.After(time.Second):
+			t.Fatal("second fail() blocked instead of dropping")
+		}
+	})
+}
+
+func TestWorker_SignalShutdown_Idempotent(t *testing.T) {
+	t.Run("closes shutdownChan exactly once", func(t *testing.T) {
+		cfg := &config.JobsConfig{MaxConcurrentPerWorker: 5}
+		worker := NewWorker(cfg, nil, "secret", "http://localhost", nil, nil, nil)
+
+		worker.signalShutdown()
+		worker.signalShutdown() // must not panic (double close guard)
+		worker.signalShutdown()
+
+		select {
+		case <-worker.shutdownChan:
+			// expected: closed
+		default:
+			t.Fatal("shutdownChan should be closed after signalShutdown")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Two independent reliability fixes that restore service after transient failures instead of leaving the system permanently degraded.

### Worker auto-restart (embedded mode)
A supervisor already existed but could only learn a worker died via the `workerErrors` channel, which fired **only** when `Worker.Start` returned an error. The only error path in `Start` was the initial `RegisterWorker`; once a background loop (poll/heartbeat/timeout/cleanup) panicked, its `defer recover()` swallowed the panic and the goroutine died **silently**. `Start` kept blocking, the supervisor never learned, the zombie stayed in `activeWorkers`, and no replacement started. If all workers hit this → zero live pollers with the system reporting healthy.

- **`worker.go`**: add a `fatalErr` channel + idempotent `fail()`. The poll/cleanup/progress loops now call `fail()` on panic so the death is observable. `Start` selects on `shutdownChan` and `fatalErr`; on a fatal error it drains gracefully and returns the error so the manager's existing error path fires.
- **`manager.go`**: replace per-worker-ID restart counters (which reset on each fresh-UUID replacement, so backoff never escalated) with **manager-level** tracking. Restart now **always recovers, rate-limited**: backoff escalates `1s, 2s, 4s, ...` capped at `worker_max_restart_backoff` (default `60s`), never permanently gives up, resets after 5 min of stability. Backoff is interruptible by `supervisorCtx` so `Manager.Stop()` returns promptly.

### DB startup retry
`ConnectWithRetry` already retried the *initial* connection, but the post-connect steps (`EnsureBootstrap`, `ApplyDeclarativeWithSource`, `ApplyAllPending`) open their **own** pools with **no retry**, so a transient blip after the initial ping aborted startup straight to `os.Exit(1)`.

- **`database/errors.go`**: add `IsTransientError` (connection-class SQLSTATEs, network/syscall errors, context deadlines, known message fragments); returns false for constraint/syntax/permission errors so those fail fast.
- **`database/retry.go`**: add generic `RetryTransient` (jittered exponential backoff, context-interruptible, retries only transient errors); refactor `ConnectWithRetry` to use it (default raised to 8 attempts).
- **`cmd/fluxbase/main.go`**: wrap the three post-connect startup steps via a `runStartupStep` helper; also fix a latent nil-deref in the `--validate` path (`db.Close()` on a nil `db`).
- **`config`**: add `connect_timeout` to the connection string (so hung TCP connects fail fast instead of waiting on the OS) plus `retry_attempts` / `retry_initial_backoff` / `retry_max_backoff` config fields with defaults. The legacy `FLUXBASE_DATABASE_RETRY_ATTEMPTS` env var still overrides for backward compat.

## Test plan
- [x] `gofmt` clean, `go vet` clean, `go build ./...` clean
- [x] New unit tests pass: worker `fail()` idempotency, supervisor escalation/cap/reset-window/interruptible-backoff/restart-on-failure/no-spawn-at-target, `IsTransientError` classification matrix, `RetryTransient` retry-until-success / non-transient-fails-fast / ctx-cancellation
- [x] Full suites pass for `jobs`, `database`, `config`
- [x] Applied cleanly on top of `main` (no conflicts — no file overlap with other in-flight branches)
- [ ] CI green

## Out of scope
- `heartbeatLoop` is intentionally left non-fatal (it already retries per-tick; the stale-worker reaper covers true death once restarts restore capacity).
- `worker_mode = "standalone"` is a dead setting (no standalone worker binary exists); that's tracked separately.

## Config additions
```yaml
database:
  connect_timeout: "10s"
  retry_attempts: 8
  retry_initial_backoff: "1s"
  retry_max_backoff: "30s"

jobs:
  worker_max_restart_backoff: "60s"
```