### PR TITLE
test(branching): cover pure helpers (unit-only 14.9% → 19.6%)

### DIFF
--- a/internal/branching/manager_unit_test.go
+++ b/internal/branching/manager_unit_test.go
@@ -1,6 +1,7 @@
 package branching
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -568,4 +569,82 @@ func TestBranch_GetAccessLevel_NotFound(t *testing.T) {
 
 	level := branch.GetAccessLevel(userID)
 	assert.Nil(t, level)
+}
+
+// =============================================================================
+// Manager Accessor Tests (GetBranchConnectionURL, GetStorage, GetConfig)
+// =============================================================================
+//
+// These cover pure, 0.0%-coverage Manager methods reached under -short. They
+// use the &Manager{...} literal construction already used by the tenant-clone
+// tests, so no DB is required.
+
+func TestManager_GetBranchConnectionURL(t *testing.T) {
+	t.Parallel()
+	m := &Manager{mainDBURL: "postgresql://user:pass@localhost:5432/fluxbase"}
+
+	t.Run("rewrites path to branch database name", func(t *testing.T) {
+		t.Parallel()
+		branch := &Branch{DatabaseName: "branch_feature_x"}
+		got, err := m.GetBranchConnectionURL(branch)
+		assert.NoError(t, err)
+		assert.Contains(t, got, "/branch_feature_x")
+		// Host/user preserved.
+		assert.Contains(t, got, "user:pass@localhost:5432")
+		// Original db name replaced.
+		assert.NotContains(t, got, "/fluxbase")
+	})
+
+	t.Run("preserves query params if present", func(t *testing.T) {
+		t.Parallel()
+		m2 := &Manager{mainDBURL: "postgresql://u@localhost:5432/fluxbase?sslmode=disable"}
+		branch := &Branch{DatabaseName: "branch_y"}
+		got, err := m2.GetBranchConnectionURL(branch)
+		assert.NoError(t, err)
+		assert.Contains(t, got, "sslmode=disable")
+		assert.Contains(t, got, "/branch_y")
+	})
+}
+
+func TestManager_GetStorage(t *testing.T) {
+	t.Parallel()
+	t.Run("nil storage returns nil", func(t *testing.T) {
+		t.Parallel()
+		m := &Manager{}
+		assert.Nil(t, m.GetStorage())
+	})
+
+	t.Run("non-nil storage returned by identity", func(t *testing.T) {
+		t.Parallel()
+		st := NewStorage(nil, nil)
+		m := &Manager{storage: st}
+		assert.Same(t, st, m.GetStorage())
+	})
+}
+
+func TestManager_GetConfig(t *testing.T) {
+	t.Parallel()
+	cfg := config.BranchingConfig{Enabled: true, DefaultBranch: "development"}
+	m := &Manager{config: cfg}
+	got := m.GetConfig()
+	assert.Equal(t, cfg.Enabled, got.Enabled)
+	assert.Equal(t, "development", got.DefaultBranch)
+}
+
+// =============================================================================
+// Manager.checkLimits — no-limits path (pure, no storage calls)
+// =============================================================================
+//
+// With MaxBranchesPerTenant=0, MaxTotalBranches=0, MaxBranchesPerUser=0 the
+// method short-circuits to nil without ever calling storage, so it is reachable
+// with a nil storage field.
+
+func TestManager_CheckLimits_NoLimitsConfigured(t *testing.T) {
+	t.Parallel()
+	tenant := uuid.New()
+	user := uuid.New()
+	m := &Manager{config: config.BranchingConfig{Enabled: true}} // all limits zero-valued
+
+	err := m.checkLimits(context.Background(), &tenant, &user)
+	assert.NoError(t, err)
 }

--- a/internal/branching/router_test.go
+++ b/internal/branching/router_test.go
@@ -324,3 +324,181 @@ func TestRouter_MainDBURL(t *testing.T) {
 		assert.Equal(t, url, router.mainDBURL)
 	})
 }
+
+// =============================================================================
+// IsMainBranch / Pool-Presence / Default-Branch Tests
+// =============================================================================
+//
+// These cover pure, 0.0%-coverage router helpers that existing -short tests
+// never reach (they're exercised only by integration tests). All use nil-pool
+// routers built via NewRouter(nil, cfg, nil, url), matching TestNewRouter.
+
+func TestIsMainBranch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		slug string
+		want bool
+	}{
+		{"empty is main", "", true},
+		{"literal main", "main", true},
+		{"development is not main", "development", false},
+		{"main-main is not main (exact match only)", "main-main", false},
+		{"arbitrary slug", "feature-x", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsMainBranch(tt.slug))
+		})
+	}
+}
+
+func TestRouter_GetActiveBranchSource(t *testing.T) {
+	t.Parallel()
+	t.Run("api-set wins over config", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.BranchingConfig{Enabled: true, DefaultBranch: "development"}
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		r.SetActiveBranch("feature-x")
+		assert.Equal(t, "api", r.GetActiveBranchSource())
+	})
+
+	t.Run("config default when no api branch", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.BranchingConfig{Enabled: true, DefaultBranch: "development"}
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		assert.Equal(t, "config", r.GetActiveBranchSource())
+	})
+
+	t.Run("default when neither api nor config set", func(t *testing.T) {
+		t.Parallel()
+		// DefaultBranch empty → the previously-uncovered fallback arm.
+		cfg := config.BranchingConfig{Enabled: true, DefaultBranch: ""}
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		assert.Equal(t, "default", r.GetActiveBranchSource())
+	})
+}
+
+func TestRouter_GetDefaultBranch_FallbackToMain(t *testing.T) {
+	t.Parallel()
+	// Neither API-set nor config default → "main" (the arm GetDefaultBranch
+	// didn't cover under -short).
+	cfg := config.BranchingConfig{Enabled: true, DefaultBranch: ""}
+	r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+	assert.Equal(t, "main", r.GetDefaultBranch())
+}
+
+func TestRouter_HasPool(t *testing.T) {
+	t.Parallel()
+	cfg := config.BranchingConfig{Enabled: true}
+	r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+
+	t.Run("main slug always has pool", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, r.HasPool("main"))
+		assert.True(t, r.HasPool(""))
+	})
+
+	t.Run("unknown slug returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, r.HasPool("nope"))
+	})
+
+	t.Run("injected slug returns true", func(t *testing.T) {
+		t.Parallel()
+		// HasPool/GetActivePools only check map presence, never dereference the
+		// pool, so a nil-pool entry is a valid fixture.
+		r.poolsMu.Lock()
+		r.pools["feature-x"] = &poolEntry{slug: "feature-x"}
+		r.poolsMu.Unlock()
+		assert.True(t, r.HasPool("feature-x"))
+	})
+}
+
+func TestRouter_GetActivePools(t *testing.T) {
+	t.Parallel()
+	cfg := config.BranchingConfig{Enabled: true}
+
+	t.Run("empty router returns non-nil empty slice", func(t *testing.T) {
+		t.Parallel()
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		got := r.GetActivePools()
+		// Contract: make([]string, 0, ...) — non-nil even when empty.
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns injected slugs", func(t *testing.T) {
+		t.Parallel()
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		r.poolsMu.Lock()
+		r.pools["a"] = &poolEntry{slug: "a"}
+		r.pools["b"] = &poolEntry{slug: "b"}
+		r.poolsMu.Unlock()
+
+		got := r.GetActivePools()
+		assert.ElementsMatch(t, []string{"a", "b"}, got)
+	})
+}
+
+func TestRouter_GetMainPoolAndGetStorage(t *testing.T) {
+	t.Parallel()
+	t.Run("nil deps return nil", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.BranchingConfig{Enabled: true}
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		assert.Nil(t, r.GetMainPool())
+		assert.Nil(t, r.GetStorage())
+	})
+
+	t.Run("non-nil storage returned by identity", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.BranchingConfig{Enabled: true}
+		// NewStorage(nil, nil) is the existing nil-deps construction (used in
+		// storage_test.go). It does not open a connection.
+		st := NewStorage(nil, nil)
+		r := NewRouter(st, cfg, nil, "postgresql://localhost/fluxbase")
+		assert.Same(t, st, r.GetStorage())
+	})
+}
+
+// =============================================================================
+// GetPool / WarmupPool cheap paths (no DB needed)
+// =============================================================================
+
+func TestRouter_GetPool_CheapPaths(t *testing.T) {
+	t.Parallel()
+	cfg := config.BranchingConfig{Enabled: true}
+	r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+
+	t.Run("main slug returns main pool (nil here) with no error", func(t *testing.T) {
+		t.Parallel()
+		p, err := r.GetPool(context.Background(), "main")
+		assert.NoError(t, err)
+		assert.Nil(t, p) // mainPool is nil in this fixture
+	})
+
+	t.Run("empty slug treated as main", func(t *testing.T) {
+		t.Parallel()
+		p, err := r.GetPool(context.Background(), "")
+		assert.NoError(t, err)
+		assert.Nil(t, p)
+	})
+
+	t.Run("non-main slug with branching disabled returns ErrBranchingDisabled", func(t *testing.T) {
+		t.Parallel()
+		disabled := NewRouter(nil, config.BranchingConfig{Enabled: false}, nil, "postgresql://localhost/fluxbase")
+		_, err := disabled.GetPool(context.Background(), "feature-x")
+		assert.ErrorIs(t, err, ErrBranchingDisabled)
+	})
+}
+
+func TestRouter_WarmupPool_Disabled(t *testing.T) {
+	t.Parallel()
+	// WarmupPool delegates to GetPool; with branching disabled and a non-main
+	// slug it returns ErrBranchingDisabled without touching the network.
+	r := NewRouter(nil, config.BranchingConfig{Enabled: false}, nil, "postgresql://localhost/fluxbase")
+	err := r.WarmupPool(context.Background(), "feature-x")
+	assert.ErrorIs(t, err, ErrBranchingDisabled)
+}

--- a/internal/branching/scheduler_test.go
+++ b/internal/branching/scheduler_test.go
@@ -261,3 +261,30 @@ func TestBranchCleanupPriority(t *testing.T) {
 		assert.True(t, branch1.ExpiresAt.Before(*branch2.ExpiresAt))
 	})
 }
+
+// =============================================================================
+// Scheduler.IsRunning Tests
+// =============================================================================
+//
+// IsRunning (scheduler.go:169) reports the running flag under a mutex. It was
+// 0.0% under -short. NewCleanupScheduler(nil, nil, interval) builds a scheduler
+// without starting it; the true branch is exercised by setting the unexported
+// field directly (same-package white-box test).
+
+func TestCleanupScheduler_IsRunning(t *testing.T) {
+	t.Parallel()
+	t.Run("fresh scheduler not running", func(t *testing.T) {
+		t.Parallel()
+		s := NewCleanupScheduler(nil, nil, time.Hour)
+		assert.False(t, s.IsRunning())
+	})
+
+	t.Run("running flag true when set", func(t *testing.T) {
+		t.Parallel()
+		s := NewCleanupScheduler(nil, nil, time.Hour)
+		s.mu.Lock()
+		s.running = true
+		s.mu.Unlock()
+		assert.True(t, s.IsRunning())
+	})
+}

--- a/internal/branching/storage_test.go
+++ b/internal/branching/storage_test.go
@@ -2,6 +2,7 @@ package branching
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -1186,6 +1187,88 @@ func TestGenerateSlug_RealWorld(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GenerateSlug(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// =============================================================================
+// GenerateTenantBranchDatabaseName Tests
+// =============================================================================
+//
+// Contract (storage.go:392 doc comment): build a PostgreSQL-legal DB name for
+// a tenant-scoped branch from prefix + tenant slug + branch slug. Hyphens in
+// either slug become underscores; if the result starts with a digit it is
+// prefixed with "_"; the name is truncated to 63 chars (Postgres identifier
+// limit). Pure string builder — no I/O.
+
+func TestGenerateTenantBranchDatabaseName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		prefix     string
+		tenantSlug string
+		branchSlug string
+		want       string
+	}{
+		{
+			name:       "hyphenated tenant and branch slug",
+			prefix:     "branch_",
+			tenantSlug: "acme-corp",
+			branchSlug: "my-feature",
+			want:       "branch_acme_corp_my_feature",
+		},
+		{
+			name:       "default tenant",
+			prefix:     "branch_",
+			tenantSlug: "default",
+			branchSlug: "my-feature",
+			want:       "branch_default_my_feature",
+		},
+		{
+			// The digit-prepend only fires when the FIRST char of the assembled
+			// name is a digit, which happens when the prefix itself starts with
+			// a digit (the format is prefix+tenant+"_"+branch, no separator
+			// between prefix and tenant).
+			name:       "digit-leading prefix gets underscore prefix",
+			prefix:     "1branch",
+			tenantSlug: "default",
+			branchSlug: "feat",
+			want:       "_1branchdefault_feat",
+		},
+		{
+			name:       "empty prefix and slugs",
+			prefix:     "",
+			tenantSlug: "",
+			branchSlug: "",
+			want:       "_",
+		},
+		{
+			name:       "over 63 chars truncates to Postgres limit",
+			prefix:     "branch_",
+			tenantSlug: "tenantwithaverylongname",
+			branchSlug: strings.Repeat("a", 60),
+			want:       ("branch_tenantwithaverylongname_" + strings.Repeat("a", 60))[:63],
+		},
+		{
+			name:       "exactly 63 chars not truncated",
+			prefix:     "branch_",
+			tenantSlug: "t",
+			branchSlug: strings.Repeat("x", 63-len("branch_t_")),
+			want:       "branch_t_" + strings.Repeat("x", 63-len("branch_t_")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := GenerateTenantBranchDatabaseName(tt.prefix, tt.tenantSlug, tt.branchSlug)
+			assert.Equal(t, tt.want, got)
+			// Contract invariants for every output.
+			assert.LessOrEqual(t, len(got), 63, "must not exceed Postgres identifier limit")
+			if len(got) > 0 {
+				first := got[0]
+				assert.False(t, first >= '0' && first <= '9',
+					"must not start with a digit: %q", got)
+			}
 		})
 	}
 }

--- a/internal/branching/types_test.go
+++ b/internal/branching/types_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // =============================================================================
@@ -411,4 +412,114 @@ func BenchmarkBranch_IsReady(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = branch.IsReady()
 	}
+}
+
+// =============================================================================
+// Branch Tenant Membership Tests
+// =============================================================================
+//
+// BelongsToTenant / IsInstanceLevel are the inverse checks over Branch.TenantID
+// (types.go:67,75). Currently 0.0% under -short. Pure logic over a *Branch.
+
+func TestBranch_BelongsToTenant(t *testing.T) {
+	t.Parallel()
+	tenant := uuid.New()
+	other := uuid.New()
+
+	tests := []struct {
+		name   string
+		branch *Branch
+		want   bool
+	}{
+		{"nil tenant id returns false", &Branch{TenantID: nil}, false},
+		{"matching tenant returns true", &Branch{TenantID: &tenant}, true},
+		{"different tenant returns false", &Branch{TenantID: &other}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.branch.BelongsToTenant(tenant))
+		})
+	}
+}
+
+func TestBranch_IsInstanceLevel(t *testing.T) {
+	t.Parallel()
+	tenant := uuid.New()
+	tests := []struct {
+		name   string
+		tenant *uuid.UUID
+		want   bool
+	}{
+		{"nil tenant is instance-level", nil, true},
+		{"tenant-scoped is not instance-level", &tenant, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := &Branch{TenantID: tt.tenant}
+			assert.Equal(t, tt.want, b.IsInstanceLevel())
+		})
+	}
+}
+
+// =============================================================================
+// Branch access helpers — push HasAccess / GetAccessLevel to full coverage
+// =============================================================================
+
+func TestBranch_HasAccess_FullMatrix(t *testing.T) {
+	t.Parallel()
+	userA := uuid.New()
+	userB := uuid.New()
+
+	t.Run("nil access list returns false", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: nil}
+		assert.False(t, b.HasAccess(userA))
+	})
+
+	t.Run("present user returns true", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{{UserID: userA, AccessLevel: BranchAccessRead}}}
+		assert.True(t, b.HasAccess(userA))
+	})
+
+	t.Run("absent user returns false", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{{UserID: userA, AccessLevel: BranchAccessRead}}}
+		assert.False(t, b.HasAccess(userB))
+	})
+
+	t.Run("empty access list returns false", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{}}
+		assert.False(t, b.HasAccess(userA))
+	})
+}
+
+func TestBranch_GetAccessLevel_FullMatrix(t *testing.T) {
+	t.Parallel()
+	userA := uuid.New()
+	userB := uuid.New()
+	level := BranchAccessAdmin
+
+	t.Run("nil access list returns nil", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: nil}
+		assert.Nil(t, b.GetAccessLevel(userA))
+	})
+
+	t.Run("present user returns level pointer", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{{UserID: userA, AccessLevel: level}}}
+		got := b.GetAccessLevel(userA)
+		require.NotNil(t, got)
+		assert.Equal(t, level, *got)
+	})
+
+	t.Run("absent user returns nil", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{{UserID: userA, AccessLevel: level}}}
+		assert.Nil(t, b.GetAccessLevel(userB))
+	})
 }


### PR DESCRIPTION
## Summary

Adds unit tests for the pure, previously-0.0%-coverage helpers in `internal/branching`. Lifts **unit-only** (`-short`) coverage from 14.9% to 19.6%.

## ⚠️ Correction on the framing

I originally pitched this as "unblock CI — branching is failing the coverage gate." **That was wrong.** On investigation, CI on main is green: branching's 25% threshold is met by the **merged unit+e2e** coverage profile the gate reads (the DB-coupled branching code is covered by integration tests, which don't run under `-short`). The `-short`-only measurement that led me astray is not what CI's gate sees.

These unit tests are a genuine **improvement**, not a CI-unblock:
- They cover pure logic that e2e doesn't specifically target.
- They strengthen the unit-only selective-run gate (introduced in #312) for branching-only changes.

## What was added
- **`storage_test.go`** — `GenerateTenantBranchDatabaseName` (slug sanitization, digit-prefix guard, 63-char truncation).
- **`types_test.go`** — `BelongsToTenant`, `IsInstanceLevel`, and full-matrix coverage for `HasAccess` / `GetAccessLevel`.
- **`router_test.go`** — `IsMainBranch`, `GetActiveBranchSource` (all 3 source arms), `GetDefaultBranch` fallback, `HasPool`, `GetActivePools`, `GetMainPool`/`GetStorage`, `GetPool`/`WarmupPool` cheap paths.
- **`manager_unit_test.go`** — `GetBranchConnectionURL`, `GetStorage`/`GetConfig`, `checkLimits` no-limits path.
- **`scheduler_test.go`** — `IsRunning`.

All targets were at 0.0% under `-short`; fixtures use the package's existing nil-pool construction patterns (no DB, no mocks).

## Testing-discipline notes
Three test-vs-code catches during writing — all were **test bugs** (misreading `GenerateTenantBranchDatabaseName`'s format string), fixed to match the actual contract rather than pinning incorrect expectations.

## Verification
- `go test -race -short ./internal/branching/` green.
- `golangci-lint v2.10.0` (CI version) + `gofumpt` clean.

## Out of scope
The remaining branching surface is DB-coupled (`CreateBranch`, `GetBranch`, `GrantAccess`, pool creation/eviction) and is integration-test territory.