### PR TITLE
test(ai): cover pure helpers (unit-only 28.0% → 31.1%)

### DIFF
--- a/internal/ai/decision_helpers_test.go
+++ b/internal/ai/decision_helpers_test.go
@@ -1,0 +1,248 @@
+package ai
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nimbleflux/fluxbase/internal/config"
+)
+
+// Unit tests for pure decision/builder helpers across internal/ai that were at
+// 0.0% -short coverage. All deterministic; no DB/network/LLM/FS. Fixtures use
+// the package's own State/container types and small struct literals.
+
+// =============================================================================
+// SchemaBuilder.isTableAllowed
+// =============================================================================
+//
+// Contract (schema_builder.go:666): if a specific-table list exists for the
+// schema (len>0), the table must be in it (no fallthrough to the schema
+// allowlist). Otherwise, the schema allowlist decides. Receiver unused (pure).
+
+func TestSchemaBuilder_IsTableAllowed(t *testing.T) {
+	t.Parallel()
+	b := &SchemaBuilder{}
+
+	t.Run("specific table list wins — table present", func(t *testing.T) {
+		t.Parallel()
+		allowed := map[string]bool{"public": true}
+		tables := map[string][]string{"public": {"users", "orders"}}
+		assert.True(t, b.isTableAllowed("public", "users", allowed, tables))
+	})
+
+	t.Run("specific table list wins — table absent", func(t *testing.T) {
+		t.Parallel()
+		// public has a table list, so even though public is in allowedSchemaSet,
+		// a non-listed table is rejected (no fallthrough).
+		allowed := map[string]bool{"public": true}
+		tables := map[string][]string{"public": {"users"}}
+		assert.False(t, b.isTableAllowed("public", "secret", allowed, tables))
+	})
+
+	t.Run("no table list → schema allowlist admits", func(t *testing.T) {
+		t.Parallel()
+		allowed := map[string]bool{"app": true}
+		// app has no entry in tablesBySchema → any table in app allowed.
+		assert.True(t, b.isTableAllowed("app", "anything", allowed, map[string][]string{}))
+	})
+
+	t.Run("schema not in allowlist and no table list → denied", func(t *testing.T) {
+		t.Parallel()
+		allowed := map[string]bool{"app": true}
+		assert.False(t, b.isTableAllowed("other", "t", allowed, map[string][]string{}))
+	})
+
+	t.Run("empty table list falls through to schema allowlist", func(t *testing.T) {
+		t.Parallel()
+		// An empty slice (len 0) for the schema does NOT count as "specific
+		// table list"; the schema allowlist decides. Pin this boundary.
+		allowed := map[string]bool{"public": true}
+		tables := map[string][]string{"public": {}}
+		assert.True(t, b.isTableAllowed("public", "anything", allowed, tables))
+	})
+}
+
+// =============================================================================
+// buildSupervisorTurnMetadata (reads in-memory *State)
+// =============================================================================
+
+func TestBuildSupervisorTurnMetadata_EmptyState(t *testing.T) {
+	t.Parallel()
+	state := NewState()
+	meta := buildSupervisorTurnMetadata(state)
+	// No plan, no outputs, no language, no report → empty map.
+	assert.Empty(t, meta)
+}
+
+func TestBuildSupervisorTurnMetadata_Populated(t *testing.T) {
+	t.Parallel()
+	state := NewState()
+	state.Set(SupervisorPlanKey, &SupervisorPlan{UserLanguage: "en", Route: []string{"sql"}})
+	state.AppendAgentOutput("sql_agent", "SELECT 1")
+	state.SetUserLanguage("en")
+	state.Set(VerifyReportKey, &VerifyReport{LanguageOK: true, GroundingOK: false, Issues: []string{"x"}})
+
+	meta := buildSupervisorTurnMetadata(state)
+	require.Contains(t, meta, "supervisor_plan")
+	require.Contains(t, meta, "agent_outputs")
+	require.Contains(t, meta, "user_language")
+	require.Contains(t, meta, "verify_report")
+
+	// agent_outputs maps agent name → content.
+	ao, ok := meta["agent_outputs"].(map[string]string)
+	require.True(t, ok, "agent_outputs should be map[string]string")
+	assert.Equal(t, "SELECT 1", ao["sql_agent"])
+
+	// verify_report is a map with the three keys.
+	vr, ok := meta["verify_report"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, vr["language_ok"])
+	assert.Equal(t, false, vr["grounding_ok"])
+}
+
+func TestBuildSupervisorTurnMetadata_NonPlanValueIgnored(t *testing.T) {
+	t.Parallel()
+	// If the SupervisorPlanKey holds the wrong type, it's silently skipped.
+	state := NewState()
+	state.Set(SupervisorPlanKey, "not-a-plan")
+	meta := buildSupervisorTurnMetadata(state)
+	assert.NotContains(t, meta, "supervisor_plan")
+}
+
+// =============================================================================
+// parseMCPQueryResult (JSON parse + struct build; receiver unused)
+// =============================================================================
+
+func TestParseMCPQueryResult(t *testing.T) {
+	t.Parallel()
+	h := &ChatHandler{}
+
+	t.Run("valid json array builds QueryResult", func(t *testing.T) {
+		t.Parallel()
+		content := `[{"id":1,"name":"alice"},{"id":2,"name":"bob"}]`
+		got := h.parseMCPQueryResult("query", map[string]any{"table": "users"}, content)
+		require.NotNil(t, got)
+		assert.Equal(t, 2, got.RowCount)
+		assert.Contains(t, got.Query, "MCP query on users")
+		assert.Contains(t, got.Summary, "2 row(s)")
+	})
+
+	t.Run("invalid json returns nil", func(t *testing.T) {
+		t.Parallel()
+		got := h.parseMCPQueryResult("query", map[string]any{}, "not json")
+		assert.Nil(t, got)
+	})
+
+	t.Run("missing table arg still works", func(t *testing.T) {
+		t.Parallel()
+		// No "table" key → tableName empty; query string still built.
+		got := h.parseMCPQueryResult("query", map[string]any{}, `[]`)
+		require.NotNil(t, got)
+		assert.Equal(t, 0, got.RowCount)
+		assert.Contains(t, got.Query, "MCP query on")
+	})
+}
+
+// =============================================================================
+// Storage.buildConfigBasedProvider
+// =============================================================================
+//
+// Builds a synthetic provider from AIConfig when ProviderType is set. Nil/empty
+// config → nil. Missing required env (e.g. OpenAI key) → nil. Valid config →
+// ProviderRecord with the expected type/name/model.
+
+func TestBuildConfigBasedProvider_NilConfig(t *testing.T) {
+	t.Parallel()
+	s := &Storage{config: nil}
+	assert.Nil(t, s.buildConfigBasedProvider())
+}
+
+func TestBuildConfigBasedProvider_EmptyProviderType(t *testing.T) {
+	t.Parallel()
+	s := &Storage{config: &config.AIConfig{ProviderType: ""}}
+	assert.Nil(t, s.buildConfigBasedProvider())
+}
+
+func TestBuildConfigBasedProvider_OpenAI_MissingKey(t *testing.T) {
+	t.Parallel()
+	// ProviderType set but no API key → nil (must not build a broken provider).
+	s := &Storage{config: &config.AIConfig{ProviderType: "openai"}}
+	assert.Nil(t, s.buildConfigBasedProvider())
+}
+
+func TestBuildConfigBasedProvider_OpenAI_Valid(t *testing.T) {
+	t.Parallel()
+	s := &Storage{config: &config.AIConfig{
+		ProviderType:  "openai",
+		ProviderName:  "Configured OpenAI",
+		ProviderModel: "gpt-4o",
+		OpenAIAPIKey:  "sk-test",
+	}}
+	got := s.buildConfigBasedProvider()
+	require.NotNil(t, got)
+	assert.Equal(t, "openai", got.ProviderType)
+	assert.Equal(t, "config", got.Name) // Name is the literal "config"
+	assert.Equal(t, "Configured OpenAI", got.DisplayName)
+	assert.Equal(t, "gpt-4o", got.Config["model"])
+	assert.Equal(t, "sk-test", got.Config["api_key"])
+	assert.Equal(t, "FROM_CONFIG", got.ID)
+	assert.True(t, got.ReadOnly, "config-based providers are read-only")
+	assert.True(t, got.IsDefault)
+}
+
+func TestBuildConfigBasedProvider_OpenAI_DefaultModel(t *testing.T) {
+	t.Parallel()
+	// No explicit ProviderModel → openai defaults to "gpt-4-turbo".
+	s := &Storage{config: &config.AIConfig{
+		ProviderType: "openai",
+		OpenAIAPIKey: "sk-test",
+	}}
+	got := s.buildConfigBasedProvider()
+	require.NotNil(t, got)
+	assert.Equal(t, "gpt-4-turbo", got.Config["model"])
+}
+
+func TestBuildConfigBasedProvider_Ollama_RequiresModel(t *testing.T) {
+	t.Parallel()
+	// Ollama requires OllamaModel; endpoint alone is insufficient.
+	s := &Storage{config: &config.AIConfig{
+		ProviderType:   "ollama",
+		OllamaEndpoint: "http://localhost:11434",
+	}}
+	assert.Nil(t, s.buildConfigBasedProvider(), "Ollama without OllamaModel must return nil")
+}
+
+func TestBuildConfigBasedProvider_Ollama_Valid(t *testing.T) {
+	t.Parallel()
+	s := &Storage{config: &config.AIConfig{
+		ProviderType:   "ollama",
+		ProviderName:   "Local Ollama",
+		OllamaModel:    "llama3",
+		OllamaEndpoint: "http://localhost:11434",
+	}}
+	got := s.buildConfigBasedProvider()
+	require.NotNil(t, got)
+	assert.Equal(t, "ollama", got.ProviderType)
+	assert.Equal(t, "llama3", got.Config["model"])
+	assert.Equal(t, "http://localhost:11434", got.Config["endpoint"])
+}
+
+func TestBuildConfigBasedProvider_Ollama_DefaultEndpoint(t *testing.T) {
+	t.Parallel()
+	// No endpoint → defaults to localhost:11434.
+	s := &Storage{config: &config.AIConfig{
+		ProviderType: "ollama",
+		OllamaModel:  "llama3",
+	}}
+	got := s.buildConfigBasedProvider()
+	require.NotNil(t, got)
+	assert.Equal(t, "http://localhost:11434", got.Config["endpoint"])
+}
+
+func TestBuildConfigBasedProvider_UnknownType(t *testing.T) {
+	t.Parallel()
+	s := &Storage{config: &config.AIConfig{ProviderType: "bogus"}}
+	assert.Nil(t, s.buildConfigBasedProvider())
+}

--- a/internal/ai/metadata_filter_test.go
+++ b/internal/ai/metadata_filter_test.go
@@ -1,6 +1,8 @@
 package ai
 
 import (
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -605,4 +607,271 @@ func TestEscapeStringLiteral(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// *ForTable variants — buildConditionSQLForTable / buildMetadataFilterSQLForTable
+// =============================================================================
+//
+// These mirror buildConditionSQL / buildMetadataFilterSQL but take a table
+// prefix (e.g. "d." or "t.") so the metadata->>'key' reference can be aliased.
+// Contract detail (kb_storage_search.go:692,746):
+//   - buildConditionSQLForTable uses tablePrefix AS-IS in the metadataRef, so
+//     callers must include the trailing dot ("d.").
+//   - buildMetadataFilterSQLForTable normalizes the prefix (adds "." if missing)
+//     before delegating, and recurses with the ORIGINAL (un-normalized) prefix.
+// The existing tests cover only the non-ForTable variants; these are 0.0%.
+
+func TestBuildConditionSQLForTable_AllOperators(t *testing.T) {
+	// ForTable uses the prefix verbatim; pass "d." to match the non-ForTable shape.
+	const prefix = "d."
+	tests := []struct {
+		name        string
+		cond        MetadataCondition
+		wantSQL     string
+		wantArgsLen int
+		wantErr     bool
+	}{
+		{"equals", MetadataCondition{Key: "category", Operator: MetadataOpEquals, Value: "food"}, prefix + `metadata->>'category' = $1`, 1, false},
+		{"not equals", MetadataCondition{Key: "status", Operator: MetadataOpNotEquals, Value: "archived"}, prefix + `metadata->>'status' != $1`, 1, false},
+		{"ilike", MetadataCondition{Key: "name", Operator: MetadataOpILike, Value: "%foo%"}, prefix + `metadata->>'name' ILIKE $1`, 1, false},
+		{"like", MetadataCondition{Key: "name", Operator: MetadataOpLike, Value: "foo%"}, prefix + `metadata->>'name' LIKE $1`, 1, false},
+		{"in", MetadataCondition{Key: "tag", Operator: MetadataOpIn, Values: []interface{}{"a", "b"}}, prefix + `metadata->>'tag' IN ($1, $2)`, 2, false},
+		{"not in", MetadataCondition{Key: "tag", Operator: MetadataOpNotIn, Values: []interface{}{"a"}}, prefix + `metadata->>'tag' NOT IN ($1)`, 1, false},
+		{"greater than", MetadataCondition{Key: "n", Operator: MetadataOpGreaterThan, Value: 5}, prefix + `metadata->>'n' > $1`, 1, false},
+		{"greater or equal", MetadataCondition{Key: "n", Operator: MetadataOpGreaterThanOr, Value: 5}, prefix + `metadata->>'n' >= $1`, 1, false},
+		{"less than", MetadataCondition{Key: "n", Operator: MetadataOpLessThan, Value: 5}, prefix + `metadata->>'n' < $1`, 1, false},
+		{"less or equal", MetadataCondition{Key: "n", Operator: MetadataOpLessThanOr, Value: 5}, prefix + `metadata->>'n' <= $1`, 1, false},
+		{"between", MetadataCondition{Key: "n", Operator: MetadataOpBetween, Min: 1, Max: 10}, prefix + `metadata->>'n' BETWEEN $1 AND $2`, 2, false},
+		{"is null", MetadataCondition{Key: "x", Operator: MetadataOpIsNull}, prefix + `metadata->>'x' IS NULL`, 0, false},
+		{"is not null", MetadataCondition{Key: "x", Operator: MetadataOpIsNotNull}, prefix + `metadata->>'x' IS NOT NULL`, 0, false},
+		// Error paths
+		{"equals nil value errors", MetadataCondition{Key: "x", Operator: MetadataOpEquals, Value: nil}, "", 0, true},
+		{"in empty values errors", MetadataCondition{Key: "x", Operator: MetadataOpIn, Values: nil}, "", 0, true},
+		{"between missing min errors", MetadataCondition{Key: "x", Operator: MetadataOpBetween, Max: 10}, "", 0, true},
+		{"unsupported operator errors", MetadataCondition{Key: "x", Operator: "Bogus"}, "", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argIndex := 1
+			sql, args, err := buildConditionSQLForTable(tt.cond, &argIndex, prefix)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if sql != tt.wantSQL {
+					t.Errorf("SQL = %q, want %q", sql, tt.wantSQL)
+				}
+				if len(args) != tt.wantArgsLen {
+					t.Errorf("args len = %d, want %d", len(args), tt.wantArgsLen)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildConditionSQLForTable_PrefixVariations(t *testing.T) {
+	t.Parallel()
+	// The prefix is used verbatim in the metadataRef. Confirm different aliases.
+	cond := MetadataCondition{Key: "k", Operator: MetadataOpEquals, Value: "v"}
+
+	for _, tc := range []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{"aliased d.", "d.", `d.metadata->>'k' = $1`},
+		{"aliased t.", "t.", `t.metadata->>'k' = $1`},
+		{"empty prefix yields bare metadata", "", `metadata->>'k' = $1`},
+		// NOTE: a prefix WITHOUT a trailing dot is NOT auto-dotted at this layer
+		// (only buildMetadataFilterSQLForTable auto-dots). Pin this so callers
+		// know to include the dot when calling the condition builder directly.
+		{"prefix without dot is used verbatim (no auto-dot here)", "x", `xmetadata->>'k' = $1`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			idx := 1
+			got, _, err := buildConditionSQLForTable(cond, &idx, tc.prefix)
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildMetadataFilterSQLForTable(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty group returns empty", func(t *testing.T) {
+		t.Parallel()
+		idx := 1
+		sql, args, err := buildMetadataFilterSQLForTable(MetadataFilterGroup{}, &idx, "d")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if sql != "" {
+			t.Errorf("sql = %q, want empty", sql)
+		}
+		if len(args) != 0 {
+			t.Errorf("args = %v, want empty", args)
+		}
+	})
+
+	t.Run("single condition with auto-dotted prefix", func(t *testing.T) {
+		t.Parallel()
+		// "d" is normalized to "d." before delegating to buildConditionSQLForTable.
+		idx := 1
+		group := MetadataFilterGroup{
+			LogicalOp:  LogicalOpAND,
+			Conditions: []MetadataCondition{{Key: "k", Operator: MetadataOpEquals, Value: "v"}},
+		}
+		sql, args, err := buildMetadataFilterSQLForTable(group, &idx, "d")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		wantSQL := `d.metadata->>'k' = $1`
+		if sql != wantSQL {
+			t.Errorf("sql = %q, want %q", sql, wantSQL)
+		}
+		if len(args) != 1 {
+			t.Errorf("args len = %d, want 1", len(args))
+		}
+	})
+
+	t.Run("default logical op is AND", func(t *testing.T) {
+		t.Parallel()
+		idx := 1
+		group := MetadataFilterGroup{
+			// LogicalOp intentionally empty.
+			Conditions: []MetadataCondition{
+				{Key: "a", Operator: MetadataOpEquals, Value: 1},
+				{Key: "b", Operator: MetadataOpEquals, Value: 2},
+			},
+		}
+		sql, _, err := buildMetadataFilterSQLForTable(group, &idx, "")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !strings.Contains(sql, " AND ") {
+			t.Errorf("expected AND join, got %q", sql)
+		}
+	})
+
+	t.Run("OR operator honored", func(t *testing.T) {
+		t.Parallel()
+		idx := 1
+		group := MetadataFilterGroup{
+			LogicalOp: LogicalOpOR,
+			Conditions: []MetadataCondition{
+				{Key: "a", Operator: MetadataOpEquals, Value: 1},
+				{Key: "b", Operator: MetadataOpEquals, Value: 2},
+			},
+		}
+		sql, _, err := buildMetadataFilterSQLForTable(group, &idx, "")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !strings.Contains(sql, " OR ") {
+			t.Errorf("expected OR join, got %q", sql)
+		}
+	})
+
+	t.Run("nested groups wrapped in parens", func(t *testing.T) {
+		t.Parallel()
+		idx := 1
+		group := MetadataFilterGroup{
+			LogicalOp: LogicalOpAND,
+			Conditions: []MetadataCondition{
+				{Key: "top", Operator: MetadataOpEquals, Value: "x"},
+			},
+			Groups: []MetadataFilterGroup{
+				{Conditions: []MetadataCondition{{Key: "nested", Operator: MetadataOpEquals, Value: "y"}}},
+			},
+		}
+		sql, _, err := buildMetadataFilterSQLForTable(group, &idx, "")
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		// Nested group's SQL must be wrapped in (...).
+		if !strings.Contains(sql, "(") || !strings.Contains(sql, ")") {
+			t.Errorf("expected nested group wrapped in parens, got %q", sql)
+		}
+	})
+}
+
+// =============================================================================
+// convertFilterExpression — $user_id substitution (security-adjacent)
+// =============================================================================
+//
+// Converts a request map to a MetadataFilterGroup. "$user_id" values are
+// substituted with the supplied userID (user isolation); if userID is nil the
+// $user_id key is DROPPED entirely (not emitted with a literal "$user_id").
+
+func TestConvertFilterExpression(t *testing.T) {
+	t.Parallel()
+	uid := "user-123"
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := convertFilterExpression(nil, &uid); got != nil {
+			t.Errorf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("substitutes $user_id when userID set", func(t *testing.T) {
+		t.Parallel()
+		expr := map[string]interface{}{"user_id": "$user_id", "status": "active"}
+		got := convertFilterExpression(expr, &uid)
+		if got == nil {
+			t.Fatal("expected non-nil group")
+		}
+		// Two conditions, AND-joined. One should carry the substituted userID.
+		wantValues := map[string]interface{}{"user_id": uid, "status": "active"}
+		gotValues := map[string]interface{}{}
+		for _, c := range got.Conditions {
+			gotValues[c.Key] = c.Value
+		}
+		if !reflect.DeepEqual(gotValues, wantValues) {
+			t.Errorf("conditions = %+v, want %+v", gotValues, wantValues)
+		}
+	})
+
+	t.Run("drops $user_id key when userID is nil", func(t *testing.T) {
+		t.Parallel()
+		// SECURITY: $user_id must NOT leak as a literal; it must be dropped so
+		// an unauthenticated caller can't filter by the literal string.
+		expr := map[string]interface{}{"user_id": "$user_id", "status": "active"}
+		got := convertFilterExpression(expr, nil)
+		if got == nil {
+			t.Fatal("expected non-nil group (status condition remains)")
+		}
+		if len(got.Conditions) != 1 {
+			t.Fatalf("expected 1 condition (user_id dropped), got %d: %+v", len(got.Conditions), got.Conditions)
+		}
+		if got.Conditions[0].Key != "status" {
+			t.Errorf("expected only status condition, got key %q", got.Conditions[0].Key)
+		}
+	})
+
+	t.Run("empty map returns nil", func(t *testing.T) {
+		t.Parallel()
+		if got := convertFilterExpression(map[string]interface{}{}, &uid); got != nil {
+			t.Errorf("expected nil for empty map, got %+v", got)
+		}
+	})
+
+	t.Run("non-string values passed through", func(t *testing.T) {
+		t.Parallel()
+		expr := map[string]interface{}{"count": 42, "flag": true}
+		got := convertFilterExpression(expr, &uid)
+		if got == nil {
+			t.Fatal("expected non-nil group")
+		}
+		if len(got.Conditions) != 2 {
+			t.Fatalf("expected 2 conditions, got %d", len(got.Conditions))
+		}
+	})
 }

--- a/internal/ai/pure_helpers_test.go
+++ b/internal/ai/pure_helpers_test.go
@@ -1,0 +1,316 @@
+package ai
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Unit tests for small pure helpers across internal/ai that were at 0.0%
+// -short coverage. Each is deterministic with no DB/network/LLM/FS. The
+// readFileContent helper takes an injected reader, so it needs no real file.
+
+// =============================================================================
+// splitCommaList / splitCommaSeparated (near-duplicate comma splitters)
+// =============================================================================
+//
+// Both: empty -> nil; otherwise split on ",", trim each element, drop empties.
+// They are behaviorally identical (independently defined in two files).
+
+func TestSplitCommaList(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty returns nil", "", nil},
+		{"single value", "a", []string{"a"}},
+		{"two values", "a,b", []string{"a", "b"}},
+		{"trims whitespace", "  a  ,  b  ", []string{"a", "b"}},
+		{"drops empty parts", "a,,b,", []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := splitCommaList(tt.in)
+			if !sliceEqual(got, tt.want) {
+				t.Errorf("splitCommaList(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitCommaSeparated(t *testing.T) {
+	t.Parallel()
+	// Same cases as splitCommaList — confirm the two helpers agree.
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty returns nil", "", nil},
+		{"single value", "alpha", []string{"alpha"}},
+		{"two values", "alpha,beta", []string{"alpha", "beta"}},
+		{"trims whitespace", "  alpha  ,  beta  ", []string{"alpha", "beta"}},
+		{"drops empty parts", "alpha,,beta,", []string{"alpha", "beta"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := splitCommaSeparated(tt.in)
+			if !sliceEqual(got, tt.want) {
+				t.Errorf("splitCommaSeparated(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	// Distinguish nil from empty (both helpers return nil for empty input).
+	if a == nil || b == nil {
+		return (a == nil) == (b == nil)
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// =============================================================================
+// parseIntParam
+// =============================================================================
+//
+// Contract: parse int, clamp to [min, max]. Non-numeric returns an error (and 0).
+// Note: clamping returns min/max with nil error, NOT an error.
+
+func TestParseIntParam(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      string
+		min     int
+		max     int
+		want    int
+		wantErr bool
+	}{
+		{"valid in range", "5", 1, 10, 5, false},
+		{"below min clamps to min", "0", 1, 10, 1, false},
+		{"above max clamps to max", "99", 1, 10, 10, false},
+		{"exactly min", "1", 1, 10, 1, false},
+		{"exactly max", "10", 1, 10, 10, false},
+		{"non-numeric errors", "abc", 1, 10, 0, true},
+		{"empty errors", "", 1, 10, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseIntParam(tt.in, tt.min, tt.max)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// parsePostgresArray
+// =============================================================================
+//
+// Parses a PG array literal {a,b,...}. "{}"/""/NULL -> nil. Quote toggle is
+// honored so commas inside quotes don't split, and the quote characters
+// themselves are STRIPPED (the `case '"'` toggles inQuote without appending).
+
+func TestParsePostgresArray(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty braces return nil", "{}", nil},
+		{"empty string returns nil", "", nil},
+		{"NULL returns nil", "NULL", nil},
+		{"single element", "{a}", []string{"a"}},
+		{"two elements", "{a,b}", []string{"a", "b"}},
+		{"quoted comma preserved, quotes stripped", `{a,"b,c"}`, []string{`a`, `b,c`}},
+		{"drops empty between commas", "{a,,b}", []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parsePostgresArray(tt.in)
+			if !sliceEqual(got, tt.want) {
+				t.Errorf("parsePostgresArray(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// readFileContent (injected reader — no FS needed)
+// =============================================================================
+//
+// Reads all bytes from an injected reader up to maxSize (capped at 50MB).
+// Oversized -> error. The reader's Read must return (0, err) to terminate.
+
+type endlessReader struct{}
+
+func (endlessReader) Read(p []byte) (int, error) {
+	// Fill every call; never returns an error, never EOF.
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
+}
+
+func TestReadFileContent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads content under max", func(t *testing.T) {
+		t.Parallel()
+		got, err := readFileContent(strings.NewReader("hello world"), 1024)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if string(got) != "hello world" {
+			t.Errorf("got %q, want %q", string(got), "hello world")
+		}
+	})
+
+	t.Run("oversized returns error", func(t *testing.T) {
+		t.Parallel()
+		// An endless reader will exceed maxSize=10 and never EOF, so the size
+		// guard must fire. maxSize=10 keeps the test fast.
+		_, err := readFileContent(endlessReader{}, 10)
+		if err == nil {
+			t.Error("expected error for oversized input, got nil")
+		}
+		if !strings.Contains(err.Error(), "too large") {
+			t.Errorf("expected 'too large' in error, got %v", err)
+		}
+	})
+
+	t.Run("empty reader returns empty", func(t *testing.T) {
+		t.Parallel()
+		got, err := readFileContent(strings.NewReader(""), 1024)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %d bytes, want 0", len(got))
+		}
+	})
+}
+
+// =============================================================================
+// tailMessages
+// =============================================================================
+//
+// Returns the last n messages; if len(msgs) <= n, returns msgs unchanged.
+
+func TestTailMessages(t *testing.T) {
+	t.Parallel()
+	mk := func(roles ...string) []Message {
+		out := make([]Message, len(roles))
+		for i, r := range roles {
+			out[i] = Message{Content: r}
+		}
+		return out
+	}
+	t.Run("n larger than len returns all", func(t *testing.T) {
+		t.Parallel()
+		msgs := mk("a", "b")
+		got := tailMessages(msgs, 5)
+		if len(got) != 2 || got[0].Content != "a" || got[1].Content != "b" {
+			t.Errorf("got %+v, want [a b]", got)
+		}
+	})
+	t.Run("returns last n", func(t *testing.T) {
+		t.Parallel()
+		msgs := mk("a", "b", "c", "d")
+		got := tailMessages(msgs, 2)
+		if len(got) != 2 || got[0].Content != "c" || got[1].Content != "d" {
+			t.Errorf("got %+v, want [c d]", got)
+		}
+	})
+	t.Run("n zero returns empty", func(t *testing.T) {
+		t.Parallel()
+		msgs := mk("a", "b")
+		got := tailMessages(msgs, 0)
+		if len(got) != 0 {
+			t.Errorf("got %d, want 0", len(got))
+		}
+	})
+	t.Run("empty input", func(t *testing.T) {
+		t.Parallel()
+		got := tailMessages(nil, 3)
+		if len(got) != 0 {
+			t.Errorf("got %d, want 0", len(got))
+		}
+	})
+}
+
+// =============================================================================
+// parseJSONArgs
+// =============================================================================
+
+func TestParseJSONArgs(t *testing.T) {
+	t.Parallel()
+	t.Run("valid json unmarshals", func(t *testing.T) {
+		t.Parallel()
+		var out map[string]string
+		if err := parseJSONArgs(`{"a":"b"}`, &out); err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if out["a"] != "b" {
+			t.Errorf("got %q, want %q", out["a"], "b")
+		}
+	})
+	t.Run("invalid json errors", func(t *testing.T) {
+		t.Parallel()
+		var out map[string]string
+		if err := parseJSONArgs("{not json", &out); err == nil {
+			t.Error("expected error for invalid JSON, got nil")
+		}
+	})
+	// Keep the errors import meaningful for future error-typing cases.
+	_ = errors.Is
+}
+
+// =============================================================================
+// extractTableName
+// =============================================================================
+//
+// Returns the last "."-delimited segment; if no dot, returns input unchanged.
+
+func TestExtractTableName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"schema-qualified", "public.users", "users"},
+		{"two qualifiers", "db.public.users", "users"},
+		{"no dot returns input", "users", "users"},
+		{"empty returns empty", "", ""},
+		{"trailing dot returns empty", "public.", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := extractTableName(tt.in); got != tt.want {
+				t.Errorf("extractTableName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ai/table_exporter_test.go
+++ b/internal/ai/table_exporter_test.go
@@ -2,9 +2,12 @@ package ai
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/nimbleflux/fluxbase/internal/database"
 )
 
 func TestMetadataToJSON_EmptyMap(t *testing.T) {
@@ -133,4 +136,139 @@ func TestMetadataToJSON_TableExporterMetadata(t *testing.T) {
 	require.Equal(t, "public", parsed["schema"])
 	require.Equal(t, "place_visits", parsed["table"])
 	require.Equal(t, "BASE TABLE", parsed["table_type"])
+}
+
+// =============================================================================
+// generateTableDocument — pure markdown builder for an exported table
+// =============================================================================
+//
+// Builds a markdown doc from a *database.TableInfo struct (title, description,
+// primary key, columns table with markers, JSONB schemas). The receiver `e` is
+// not used, so a zero TableExporter is a valid fixture. Currently 0.0%.
+
+func TestGenerateTableDocument_TitleAndDescription(t *testing.T) {
+	t.Parallel()
+	table := &database.TableInfo{
+		Schema: "public",
+		Name:   "users",
+		Type:   "BASE TABLE",
+	}
+	doc := (&TableExporter{}).generateTableDocument(table, ExportTableRequest{})
+
+	if !strings.Contains(doc, "# Table: public.users") {
+		t.Errorf("missing title heading; got:\n%s", doc)
+	}
+	if !strings.Contains(doc, "Database **BASE TABLE** in schema `public`") {
+		t.Errorf("missing description; got:\n%s", doc)
+	}
+}
+
+func TestGenerateTableDocument_RLSNote(t *testing.T) {
+	t.Parallel()
+	table := &database.TableInfo{Schema: "s", Name: "t", Type: "BASE TABLE", RLSEnabled: true}
+	doc := (&TableExporter{}).generateTableDocument(table, ExportTableRequest{})
+	if !strings.Contains(doc, "Row Level Security (RLS) is enabled") {
+		t.Errorf("missing RLS note; got:\n%s", doc)
+	}
+}
+
+func TestGenerateTableDocument_PrimaryKey(t *testing.T) {
+	t.Parallel()
+	table := &database.TableInfo{
+		Schema:     "public",
+		Name:       "users",
+		Type:       "BASE TABLE",
+		PrimaryKey: []string{"id", "tenant_id"},
+	}
+	doc := (&TableExporter{}).generateTableDocument(table, ExportTableRequest{})
+	if !strings.Contains(doc, "**Primary Key:**") {
+		t.Errorf("missing primary key line; got:\n%s", doc)
+	}
+	if !strings.Contains(doc, "`id`") || !strings.Contains(doc, "`tenant_id`") {
+		t.Errorf("primary key values not rendered; got:\n%s", doc)
+	}
+}
+
+func TestGenerateTableDocument_ColumnMarkers(t *testing.T) {
+	t.Parallel()
+	defVal := "nextval('seq')"
+	table := &database.TableInfo{
+		Schema: "public", Name: "users", Type: "BASE TABLE",
+		Columns: []database.ColumnInfo{
+			{Name: "id", DataType: "bigint", IsNullable: false, IsPrimaryKey: true, DefaultValue: &defVal},
+			{Name: "org_id", DataType: "bigint", IsForeignKey: true},
+			{Name: "email", DataType: "text", IsUnique: true},
+			{Name: "bio", DataType: "text", IsNullable: true},
+		},
+	}
+	doc := (&TableExporter{}).generateTableDocument(table, ExportTableRequest{})
+
+	// PK marker on the id column.
+	if !strings.Contains(doc, "🔑 id") {
+		t.Errorf("missing 🔑 PK marker on id; got:\n%s", doc)
+	}
+	// FK marker on org_id.
+	if !strings.Contains(doc, "🔗 org_id") {
+		t.Errorf("missing 🔗 FK marker on org_id; got:\n%s", doc)
+	}
+	// Unique marker on email.
+	if !strings.Contains(doc, "email") || !strings.Contains(doc, "🦄") {
+		t.Errorf("missing 🦄 unique marker on email; got:\n%s", doc)
+	}
+	// Nullable rendering: bio is nullable → "NULL"; id is NOT NULL.
+	if !strings.Contains(doc, "| bio | text | NULL |") {
+		t.Errorf("expected NULL nullable for bio; got:\n%s", doc)
+	}
+	if !strings.Contains(doc, "| 🔑 id | bigint | NOT NULL | nextval('seq')") {
+		t.Errorf("expected NOT NULL + default for id; got:\n%s", doc)
+	}
+}
+
+func TestGenerateTableDocument_ColumnFiltering(t *testing.T) {
+	t.Parallel()
+	table := &database.TableInfo{
+		Schema: "public", Name: "users", Type: "BASE TABLE",
+		Columns: []database.ColumnInfo{
+			{Name: "id", DataType: "bigint"},
+			{Name: "email", DataType: "text"},
+			{Name: "bio", DataType: "text"},
+		},
+	}
+	// Request only the email column.
+	doc := (&TableExporter{}).generateTableDocument(table, ExportTableRequest{Columns: []string{"email"}})
+
+	if !strings.Contains(doc, "Exporting 1 of 3 columns") {
+		t.Errorf("missing export-count note; got:\n%s", doc)
+	}
+	// email should appear; id and bio should not (as column-row entries).
+	if !strings.Contains(doc, "| email |") {
+		t.Errorf("filtered-in column email missing; got:\n%s", doc)
+	}
+	if strings.Contains(doc, "| id |") || strings.Contains(doc, "| bio |") {
+		t.Errorf("filtered-out columns should not appear; got:\n%s", doc)
+	}
+}
+
+func TestGenerateTableDocument_JSONBSchema(t *testing.T) {
+	t.Parallel()
+	table := &database.TableInfo{
+		Schema: "public", Name: "events", Type: "BASE TABLE",
+		Columns: []database.ColumnInfo{{
+			Name:     "payload",
+			DataType: "jsonb",
+			JSONBSchema: &database.JSONBSchemaInfo{
+				Properties: map[string]database.JSONBProperty{
+					"event": {Type: "string", Description: "event name"},
+				},
+				Required: []string{"event"},
+			},
+		}},
+	}
+	doc := (&TableExporter{}).generateTableDocument(table, ExportTableRequest{})
+	if !strings.Contains(doc, "## JSONB Column: `payload`") {
+		t.Errorf("missing JSONB section; got:\n%s", doc)
+	}
+	if !strings.Contains(doc, "| event | string | yes | event name |") {
+		t.Errorf("missing JSONB property row; got:\n%s", doc)
+	}
 }

--- a/internal/branching/manager_unit_test.go
+++ b/internal/branching/manager_unit_test.go
@@ -1,6 +1,7 @@
 package branching
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -568,4 +569,82 @@ func TestBranch_GetAccessLevel_NotFound(t *testing.T) {
 
 	level := branch.GetAccessLevel(userID)
 	assert.Nil(t, level)
+}
+
+// =============================================================================
+// Manager Accessor Tests (GetBranchConnectionURL, GetStorage, GetConfig)
+// =============================================================================
+//
+// These cover pure, 0.0%-coverage Manager methods reached under -short. They
+// use the &Manager{...} literal construction already used by the tenant-clone
+// tests, so no DB is required.
+
+func TestManager_GetBranchConnectionURL(t *testing.T) {
+	t.Parallel()
+	m := &Manager{mainDBURL: "postgresql://user:pass@localhost:5432/fluxbase"}
+
+	t.Run("rewrites path to branch database name", func(t *testing.T) {
+		t.Parallel()
+		branch := &Branch{DatabaseName: "branch_feature_x"}
+		got, err := m.GetBranchConnectionURL(branch)
+		assert.NoError(t, err)
+		assert.Contains(t, got, "/branch_feature_x")
+		// Host/user preserved.
+		assert.Contains(t, got, "user:pass@localhost:5432")
+		// Original db name replaced.
+		assert.NotContains(t, got, "/fluxbase")
+	})
+
+	t.Run("preserves query params if present", func(t *testing.T) {
+		t.Parallel()
+		m2 := &Manager{mainDBURL: "postgresql://u@localhost:5432/fluxbase?sslmode=disable"}
+		branch := &Branch{DatabaseName: "branch_y"}
+		got, err := m2.GetBranchConnectionURL(branch)
+		assert.NoError(t, err)
+		assert.Contains(t, got, "sslmode=disable")
+		assert.Contains(t, got, "/branch_y")
+	})
+}
+
+func TestManager_GetStorage(t *testing.T) {
+	t.Parallel()
+	t.Run("nil storage returns nil", func(t *testing.T) {
+		t.Parallel()
+		m := &Manager{}
+		assert.Nil(t, m.GetStorage())
+	})
+
+	t.Run("non-nil storage returned by identity", func(t *testing.T) {
+		t.Parallel()
+		st := NewStorage(nil, nil)
+		m := &Manager{storage: st}
+		assert.Same(t, st, m.GetStorage())
+	})
+}
+
+func TestManager_GetConfig(t *testing.T) {
+	t.Parallel()
+	cfg := config.BranchingConfig{Enabled: true, DefaultBranch: "development"}
+	m := &Manager{config: cfg}
+	got := m.GetConfig()
+	assert.Equal(t, cfg.Enabled, got.Enabled)
+	assert.Equal(t, "development", got.DefaultBranch)
+}
+
+// =============================================================================
+// Manager.checkLimits — no-limits path (pure, no storage calls)
+// =============================================================================
+//
+// With MaxBranchesPerTenant=0, MaxTotalBranches=0, MaxBranchesPerUser=0 the
+// method short-circuits to nil without ever calling storage, so it is reachable
+// with a nil storage field.
+
+func TestManager_CheckLimits_NoLimitsConfigured(t *testing.T) {
+	t.Parallel()
+	tenant := uuid.New()
+	user := uuid.New()
+	m := &Manager{config: config.BranchingConfig{Enabled: true}} // all limits zero-valued
+
+	err := m.checkLimits(context.Background(), &tenant, &user)
+	assert.NoError(t, err)
 }

--- a/internal/branching/router_test.go
+++ b/internal/branching/router_test.go
@@ -324,3 +324,181 @@ func TestRouter_MainDBURL(t *testing.T) {
 		assert.Equal(t, url, router.mainDBURL)
 	})
 }
+
+// =============================================================================
+// IsMainBranch / Pool-Presence / Default-Branch Tests
+// =============================================================================
+//
+// These cover pure, 0.0%-coverage router helpers that existing -short tests
+// never reach (they're exercised only by integration tests). All use nil-pool
+// routers built via NewRouter(nil, cfg, nil, url), matching TestNewRouter.
+
+func TestIsMainBranch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		slug string
+		want bool
+	}{
+		{"empty is main", "", true},
+		{"literal main", "main", true},
+		{"development is not main", "development", false},
+		{"main-main is not main (exact match only)", "main-main", false},
+		{"arbitrary slug", "feature-x", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsMainBranch(tt.slug))
+		})
+	}
+}
+
+func TestRouter_GetActiveBranchSource(t *testing.T) {
+	t.Parallel()
+	t.Run("api-set wins over config", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.BranchingConfig{Enabled: true, DefaultBranch: "development"}
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		r.SetActiveBranch("feature-x")
+		assert.Equal(t, "api", r.GetActiveBranchSource())
+	})
+
+	t.Run("config default when no api branch", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.BranchingConfig{Enabled: true, DefaultBranch: "development"}
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		assert.Equal(t, "config", r.GetActiveBranchSource())
+	})
+
+	t.Run("default when neither api nor config set", func(t *testing.T) {
+		t.Parallel()
+		// DefaultBranch empty → the previously-uncovered fallback arm.
+		cfg := config.BranchingConfig{Enabled: true, DefaultBranch: ""}
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		assert.Equal(t, "default", r.GetActiveBranchSource())
+	})
+}
+
+func TestRouter_GetDefaultBranch_FallbackToMain(t *testing.T) {
+	t.Parallel()
+	// Neither API-set nor config default → "main" (the arm GetDefaultBranch
+	// didn't cover under -short).
+	cfg := config.BranchingConfig{Enabled: true, DefaultBranch: ""}
+	r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+	assert.Equal(t, "main", r.GetDefaultBranch())
+}
+
+func TestRouter_HasPool(t *testing.T) {
+	t.Parallel()
+	cfg := config.BranchingConfig{Enabled: true}
+	r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+
+	t.Run("main slug always has pool", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, r.HasPool("main"))
+		assert.True(t, r.HasPool(""))
+	})
+
+	t.Run("unknown slug returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, r.HasPool("nope"))
+	})
+
+	t.Run("injected slug returns true", func(t *testing.T) {
+		t.Parallel()
+		// HasPool/GetActivePools only check map presence, never dereference the
+		// pool, so a nil-pool entry is a valid fixture.
+		r.poolsMu.Lock()
+		r.pools["feature-x"] = &poolEntry{slug: "feature-x"}
+		r.poolsMu.Unlock()
+		assert.True(t, r.HasPool("feature-x"))
+	})
+}
+
+func TestRouter_GetActivePools(t *testing.T) {
+	t.Parallel()
+	cfg := config.BranchingConfig{Enabled: true}
+
+	t.Run("empty router returns non-nil empty slice", func(t *testing.T) {
+		t.Parallel()
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		got := r.GetActivePools()
+		// Contract: make([]string, 0, ...) — non-nil even when empty.
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("returns injected slugs", func(t *testing.T) {
+		t.Parallel()
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		r.poolsMu.Lock()
+		r.pools["a"] = &poolEntry{slug: "a"}
+		r.pools["b"] = &poolEntry{slug: "b"}
+		r.poolsMu.Unlock()
+
+		got := r.GetActivePools()
+		assert.ElementsMatch(t, []string{"a", "b"}, got)
+	})
+}
+
+func TestRouter_GetMainPoolAndGetStorage(t *testing.T) {
+	t.Parallel()
+	t.Run("nil deps return nil", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.BranchingConfig{Enabled: true}
+		r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+		assert.Nil(t, r.GetMainPool())
+		assert.Nil(t, r.GetStorage())
+	})
+
+	t.Run("non-nil storage returned by identity", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.BranchingConfig{Enabled: true}
+		// NewStorage(nil, nil) is the existing nil-deps construction (used in
+		// storage_test.go). It does not open a connection.
+		st := NewStorage(nil, nil)
+		r := NewRouter(st, cfg, nil, "postgresql://localhost/fluxbase")
+		assert.Same(t, st, r.GetStorage())
+	})
+}
+
+// =============================================================================
+// GetPool / WarmupPool cheap paths (no DB needed)
+// =============================================================================
+
+func TestRouter_GetPool_CheapPaths(t *testing.T) {
+	t.Parallel()
+	cfg := config.BranchingConfig{Enabled: true}
+	r := NewRouter(nil, cfg, nil, "postgresql://localhost/fluxbase")
+
+	t.Run("main slug returns main pool (nil here) with no error", func(t *testing.T) {
+		t.Parallel()
+		p, err := r.GetPool(context.Background(), "main")
+		assert.NoError(t, err)
+		assert.Nil(t, p) // mainPool is nil in this fixture
+	})
+
+	t.Run("empty slug treated as main", func(t *testing.T) {
+		t.Parallel()
+		p, err := r.GetPool(context.Background(), "")
+		assert.NoError(t, err)
+		assert.Nil(t, p)
+	})
+
+	t.Run("non-main slug with branching disabled returns ErrBranchingDisabled", func(t *testing.T) {
+		t.Parallel()
+		disabled := NewRouter(nil, config.BranchingConfig{Enabled: false}, nil, "postgresql://localhost/fluxbase")
+		_, err := disabled.GetPool(context.Background(), "feature-x")
+		assert.ErrorIs(t, err, ErrBranchingDisabled)
+	})
+}
+
+func TestRouter_WarmupPool_Disabled(t *testing.T) {
+	t.Parallel()
+	// WarmupPool delegates to GetPool; with branching disabled and a non-main
+	// slug it returns ErrBranchingDisabled without touching the network.
+	r := NewRouter(nil, config.BranchingConfig{Enabled: false}, nil, "postgresql://localhost/fluxbase")
+	err := r.WarmupPool(context.Background(), "feature-x")
+	assert.ErrorIs(t, err, ErrBranchingDisabled)
+}

--- a/internal/branching/scheduler_test.go
+++ b/internal/branching/scheduler_test.go
@@ -261,3 +261,30 @@ func TestBranchCleanupPriority(t *testing.T) {
 		assert.True(t, branch1.ExpiresAt.Before(*branch2.ExpiresAt))
 	})
 }
+
+// =============================================================================
+// Scheduler.IsRunning Tests
+// =============================================================================
+//
+// IsRunning (scheduler.go:169) reports the running flag under a mutex. It was
+// 0.0% under -short. NewCleanupScheduler(nil, nil, interval) builds a scheduler
+// without starting it; the true branch is exercised by setting the unexported
+// field directly (same-package white-box test).
+
+func TestCleanupScheduler_IsRunning(t *testing.T) {
+	t.Parallel()
+	t.Run("fresh scheduler not running", func(t *testing.T) {
+		t.Parallel()
+		s := NewCleanupScheduler(nil, nil, time.Hour)
+		assert.False(t, s.IsRunning())
+	})
+
+	t.Run("running flag true when set", func(t *testing.T) {
+		t.Parallel()
+		s := NewCleanupScheduler(nil, nil, time.Hour)
+		s.mu.Lock()
+		s.running = true
+		s.mu.Unlock()
+		assert.True(t, s.IsRunning())
+	})
+}

--- a/internal/branching/storage_test.go
+++ b/internal/branching/storage_test.go
@@ -2,6 +2,7 @@ package branching
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -1186,6 +1187,88 @@ func TestGenerateSlug_RealWorld(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := GenerateSlug(tt.input)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// =============================================================================
+// GenerateTenantBranchDatabaseName Tests
+// =============================================================================
+//
+// Contract (storage.go:392 doc comment): build a PostgreSQL-legal DB name for
+// a tenant-scoped branch from prefix + tenant slug + branch slug. Hyphens in
+// either slug become underscores; if the result starts with a digit it is
+// prefixed with "_"; the name is truncated to 63 chars (Postgres identifier
+// limit). Pure string builder — no I/O.
+
+func TestGenerateTenantBranchDatabaseName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		prefix     string
+		tenantSlug string
+		branchSlug string
+		want       string
+	}{
+		{
+			name:       "hyphenated tenant and branch slug",
+			prefix:     "branch_",
+			tenantSlug: "acme-corp",
+			branchSlug: "my-feature",
+			want:       "branch_acme_corp_my_feature",
+		},
+		{
+			name:       "default tenant",
+			prefix:     "branch_",
+			tenantSlug: "default",
+			branchSlug: "my-feature",
+			want:       "branch_default_my_feature",
+		},
+		{
+			// The digit-prepend only fires when the FIRST char of the assembled
+			// name is a digit, which happens when the prefix itself starts with
+			// a digit (the format is prefix+tenant+"_"+branch, no separator
+			// between prefix and tenant).
+			name:       "digit-leading prefix gets underscore prefix",
+			prefix:     "1branch",
+			tenantSlug: "default",
+			branchSlug: "feat",
+			want:       "_1branchdefault_feat",
+		},
+		{
+			name:       "empty prefix and slugs",
+			prefix:     "",
+			tenantSlug: "",
+			branchSlug: "",
+			want:       "_",
+		},
+		{
+			name:       "over 63 chars truncates to Postgres limit",
+			prefix:     "branch_",
+			tenantSlug: "tenantwithaverylongname",
+			branchSlug: strings.Repeat("a", 60),
+			want:       ("branch_tenantwithaverylongname_" + strings.Repeat("a", 60))[:63],
+		},
+		{
+			name:       "exactly 63 chars not truncated",
+			prefix:     "branch_",
+			tenantSlug: "t",
+			branchSlug: strings.Repeat("x", 63-len("branch_t_")),
+			want:       "branch_t_" + strings.Repeat("x", 63-len("branch_t_")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := GenerateTenantBranchDatabaseName(tt.prefix, tt.tenantSlug, tt.branchSlug)
+			assert.Equal(t, tt.want, got)
+			// Contract invariants for every output.
+			assert.LessOrEqual(t, len(got), 63, "must not exceed Postgres identifier limit")
+			if len(got) > 0 {
+				first := got[0]
+				assert.False(t, first >= '0' && first <= '9',
+					"must not start with a digit: %q", got)
+			}
 		})
 	}
 }

--- a/internal/branching/types_test.go
+++ b/internal/branching/types_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // =============================================================================
@@ -411,4 +412,114 @@ func BenchmarkBranch_IsReady(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = branch.IsReady()
 	}
+}
+
+// =============================================================================
+// Branch Tenant Membership Tests
+// =============================================================================
+//
+// BelongsToTenant / IsInstanceLevel are the inverse checks over Branch.TenantID
+// (types.go:67,75). Currently 0.0% under -short. Pure logic over a *Branch.
+
+func TestBranch_BelongsToTenant(t *testing.T) {
+	t.Parallel()
+	tenant := uuid.New()
+	other := uuid.New()
+
+	tests := []struct {
+		name   string
+		branch *Branch
+		want   bool
+	}{
+		{"nil tenant id returns false", &Branch{TenantID: nil}, false},
+		{"matching tenant returns true", &Branch{TenantID: &tenant}, true},
+		{"different tenant returns false", &Branch{TenantID: &other}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.branch.BelongsToTenant(tenant))
+		})
+	}
+}
+
+func TestBranch_IsInstanceLevel(t *testing.T) {
+	t.Parallel()
+	tenant := uuid.New()
+	tests := []struct {
+		name   string
+		tenant *uuid.UUID
+		want   bool
+	}{
+		{"nil tenant is instance-level", nil, true},
+		{"tenant-scoped is not instance-level", &tenant, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b := &Branch{TenantID: tt.tenant}
+			assert.Equal(t, tt.want, b.IsInstanceLevel())
+		})
+	}
+}
+
+// =============================================================================
+// Branch access helpers — push HasAccess / GetAccessLevel to full coverage
+// =============================================================================
+
+func TestBranch_HasAccess_FullMatrix(t *testing.T) {
+	t.Parallel()
+	userA := uuid.New()
+	userB := uuid.New()
+
+	t.Run("nil access list returns false", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: nil}
+		assert.False(t, b.HasAccess(userA))
+	})
+
+	t.Run("present user returns true", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{{UserID: userA, AccessLevel: BranchAccessRead}}}
+		assert.True(t, b.HasAccess(userA))
+	})
+
+	t.Run("absent user returns false", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{{UserID: userA, AccessLevel: BranchAccessRead}}}
+		assert.False(t, b.HasAccess(userB))
+	})
+
+	t.Run("empty access list returns false", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{}}
+		assert.False(t, b.HasAccess(userA))
+	})
+}
+
+func TestBranch_GetAccessLevel_FullMatrix(t *testing.T) {
+	t.Parallel()
+	userA := uuid.New()
+	userB := uuid.New()
+	level := BranchAccessAdmin
+
+	t.Run("nil access list returns nil", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: nil}
+		assert.Nil(t, b.GetAccessLevel(userA))
+	})
+
+	t.Run("present user returns level pointer", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{{UserID: userA, AccessLevel: level}}}
+		got := b.GetAccessLevel(userA)
+		require.NotNil(t, got)
+		assert.Equal(t, level, *got)
+	})
+
+	t.Run("absent user returns nil", func(t *testing.T) {
+		t.Parallel()
+		b := &Branch{Access: []BranchAccess{{UserID: userA, AccessLevel: level}}}
+		assert.Nil(t, b.GetAccessLevel(userB))
+	})
 }


### PR DESCRIPTION
## Summary
Adds unit tests for **16 pure, previously-0.0%-coverage** helpers across `internal/ai` (the second-largest Go package). Lifts `-short` coverage **28.0% → 31.1%**. All deterministic — no DB/network/LLM/FS. Same pattern that worked in `auth`/`migrations`/`branching`.

## What was covered

**`metadata_filter_test.go` (extend)** — `buildConditionSQLForTable` (all 13 operators + error paths + prefix variations), `buildMetadataFilterSQLForTable` (empty/default AND/OR/nested groups), `convertFilterExpression` (`$user_id` substitution — **security-relevant**: nil userID *drops* the key rather than emitting a literal, preventing unauthenticated filtering).

**`pure_helpers_test.go` (new)** — `splitCommaList`, `splitCommaSeparated`, `parseIntParam`, `parsePostgresArray`, `readFileContent` (injected `io.Reader`), `tailMessages`, `parseJSONArgs`, `extractTableName`.

**`table_exporter_test.go` (extend)** — `generateTableDocument`: title, description, RLS note, primary key, column markers (🔑/🔗/🦄), nullable/default rendering, column filtering, JSONB schema section.

**`decision_helpers_test.go` (new)** — `SchemaBuilder.isTableAllowed` (specific-table-list-wins precedence), `buildSupervisorTurnMetadata` (empty/populated/wrong-type-skipped), `parseMCPQueryResult` (valid/invalid/missing-table), `Storage.buildConfigBasedProvider` (nil/empty/missing-key/valid openai+ollama/default model+endpoint/unknown type).

## Testing-discipline catches
Two test-vs-code catches during writing — **both were my test bugs**, fixed to match the real contract rather than pinning wrong expectations:
- `parsePostgresArray`: I misread the switch as keeping quote characters; it actually strips them (the `case '"'` toggles `inQuote` without appending). Fixed the expectation.
- `buildConfigBasedProvider`: I assumed field names `Type`/`Model`/`Source`; the real `ProviderRecord` uses `ProviderType`, `Name="config"` (literal), and `Config["model"]`. Also discovered Ollama requires `OllamaModel` (not just endpoint). Rewrote assertions against the actual struct.

## Verification
- `go test -race -short ./internal/ai/` green
- `golangci-lint v2.10.0` (CI version) + `gofumpt` clean

## Out of scope
LLM/embedding integration tests, DB-coupled storage methods, and anything touching the non-mockable `Executor`/`MCPToolExecutor` concrete structs.