### PR TITLE
fix(jobs): attach tenant_id to execution logs so getLogs returns them

### DIFF
--- a/internal/jobs/worker.go
+++ b/internal/jobs/worker.go
@@ -748,13 +748,24 @@ func (w *Worker) handleLogMessage(jobID uuid.UUID, level string, message string)
 	}
 	lineNumber := atomic.AddInt32(counterPtr, 1) - 1 // AddInt32 returns new value, so subtract 1 for 0-indexed
 
-	// Log to zerolog - central logging service will capture this via execution_id field
-	log.Info().
+	// Log to zerolog - central logging service will capture this via execution_id field.
+	// Attach tenant_id so the row is persisted with the correct tenant and survives the
+	// tenant-scoped RLS policy when fetched back via GetExecutionLogs (without this, the
+	// row is written with tenant_id NULL and filtered out on read, so getLogs returns
+	// empty for finished jobs). Mirrors internal/functions/handler.go handleLogMessage.
+	event := log.Info().
 		Str("execution_id", jobID.String()).
 		Str("execution_type", "job").
 		Str("level", level).
-		Int("line_number", int(lineNumber)).
-		Msg(message)
+		Int("line_number", int(lineNumber))
+
+	if tenantVal, ok := w.jobTenants.Load(jobID); ok {
+		if tenantID, ok := tenantVal.(string); ok && tenantID != "" {
+			event = event.Str("tenant_id", tenantID)
+		}
+	}
+
+	event.Msg(message)
 }
 
 // cancelJob cancels a running job


### PR DESCRIPTION
## Problem

`fluxbase.jobs.getLogs(jobId)` returns an empty array for finished jobs. The realtime stream only shows "Created execution log subscription" with no past logs. Users opening job logs (e.g. from a completed-job notification) see nothing.

## Root cause

`Worker.handleLogMessage` (`internal/jobs/worker.go`) emits the zerolog event **without a `tenant_id`**. The full chain:

1. **Write:** the event reaches `logging.entries` with `tenant_id = NULL` — the logging `Writer` only sets `TenantID` if the JSON carries the field, and `Service.Log` falls back to `database.TenantFromContext` but is called with bare `context.Background()`. The `BEFORE INSERT` trigger reads `app.current_tenant_id`, which is unset → NULL.
2. **Read:** `GetExecutionLogs` runs under a tenant-scoped (RLS-enforced) role with `app.current_tenant_id` set to the user's tenant. The `has_tenant_access(tenant_id)` policy predicate evaluates `NULL = '<tenant>'` → false → every row filtered out → empty array.

Edge functions already get this right (`internal/functions/handler.go:153-155` attaches `tenant_id`); the jobs worker omits it.

The realtime channel appears to "work" only because it doesn't query the DB — it subscribes to future PubSub events and emits the subscription confirmation. It does no backfill by design; the client is expected to backfill via `getLogs`, which returns empty because of this bug.

## Fix

Attach `tenant_id` to the zerolog event in `handleLogMessage`, reading from the `w.jobTenants` map that is already maintained per execution (`worker.go:515`, before the runtime call; deleted via `defer` after execution). This mirrors the functions handler.

```go
if tenantVal, ok := w.jobTenants.Load(jobID); ok {
    if tenantID, ok := tenantVal.(string); ok && tenantID != "" {
        event = event.Str("tenant_id", tenantID)
    }
}
```

There's no status-based filtering or deletion of logs — it's purely the tenant-id write gap.

## Verification
- `gofmt`, `go vet`, `go build ./internal/jobs/` — clean.
- `go test ./internal/jobs/` — passes.
- Note: only fixes **new** job runs. Existing rows with `tenant_id IS NULL` remain unreadable via the tenant-scoped path; an optional one-time backfill (`UPDATE logging.entries e SET tenant_id = j.tenant_id FROM jobs.queue j WHERE e.execution_id = j.id AND e.tenant_id IS NULL`) can recover history if desired.

🤖 Generated with ZCode