### PR TITLE
fix(build): build SDKs before admin UI in make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev dev-full ensure-embed-placeholder ensure-embedded-sdk build clean fmt lint test migrate-up migrate-down migrate-create db-reset db-reset-full db-grants deps setup-dev install-hooks uninstall-hooks docs docs-build docs-check-links version docker-build docker-push release cli cli-install cli-completions viz-deps viz-deps-svg viz-internal viz-callgraph viz-callgraph-svg viz-uml viz-uml-api viz-uml-auth viz-module-deps viz-all test-cleanup test-cli
+.PHONY: help dev dev-full ensure-embed-placeholder ensure-embedded-sdk ensure-sdks build clean fmt lint test migrate-up migrate-down migrate-create db-reset db-reset-full db-grants deps setup-dev install-hooks uninstall-hooks docs docs-build docs-check-links version docker-build docker-push release cli cli-install cli-completions viz-deps viz-deps-svg viz-internal viz-callgraph viz-callgraph-svg viz-uml viz-uml-api viz-uml-auth viz-module-deps viz-all test-cleanup test-cli
 
 # Variables
 BINARY_NAME=fluxbase-server
@@ -95,6 +95,7 @@ dev: ## Fast dev: backend + frontend (skips admin build, uses Vite HMR at :5050)
 		cd sdk && unset NODE_OPTIONS && bun install; \
 	fi
 	@$(MAKE) ensure-embedded-sdk
+	@$(MAKE) ensure-sdks
 	@if [ ! -d "admin/node_modules" ]; then \
 		echo "${YELLOW}Installing admin UI dependencies...${NC}"; \
 		cd admin && unset NODE_OPTIONS && bun install; \
@@ -133,6 +134,26 @@ ensure-embedded-sdk:
 		echo "${GREEN}Embedded SDK up to date, skipping generation${NC}"; \
 	fi
 
+ensure-sdks:
+	@for pkg in sdk sdk-react; do \
+		if [ ! -d "$$pkg/node_modules" ]; then \
+			echo "${YELLOW}Installing $$pkg dependencies...${NC}"; \
+			( cd $$pkg && unset NODE_OPTIONS && bun install ); \
+		fi; \
+	done
+	@if [ ! -f "sdk/dist/index.js" ] || [ -n "$$(find sdk/src -newer sdk/dist/index.js -type f 2>/dev/null | head -1)" ]; then \
+		echo "${YELLOW}Building TypeScript SDK (tsup)...${NC}"; \
+		cd sdk && unset NODE_OPTIONS && bun run build; \
+	else \
+		echo "${GREEN}TypeScript SDK up to date, skipping build${NC}"; \
+	fi
+	@if [ ! -f "sdk-react/dist/index.mjs" ] || [ -n "$$(find sdk-react/src -newer sdk-react/dist/index.mjs -type f 2>/dev/null | head -1)" ]; then \
+		echo "${YELLOW}Building React SDK (tsup)...${NC}"; \
+		cd sdk-react && unset NODE_OPTIONS && bun run build; \
+	else \
+		echo "${GREEN}React SDK up to date, skipping build${NC}"; \
+	fi
+
 dev-full: ## Full build + run (builds admin UI with type-check, slower)
 	@echo "${YELLOW}Starting Fluxbase with full admin UI build...${NC}"
 	@lsof -ti:8080 | xargs -r kill -9 2>/dev/null || true
@@ -147,6 +168,7 @@ dev-full: ## Full build + run (builds admin UI with type-check, slower)
 		echo "${YELLOW}Installing admin UI dependencies...${NC}"; \
 		cd admin && unset NODE_OPTIONS && bun install; \
 	fi
+	@$(MAKE) ensure-sdks
 	@echo "${YELLOW}Building admin UI...${NC}"
 	@cd admin && unset NODE_OPTIONS && bun run build
 	@rm -rf internal/adminui/dist
@@ -166,6 +188,7 @@ version: ## Show version information
 build: ## Build production binary with embedded admin UI
 	@echo "${YELLOW}Generating embedded SDK for job runtime...${NC}"
 	@cd sdk && unset NODE_OPTIONS && bun run generate:embedded-sdk
+	@$(MAKE) ensure-sdks
 	@echo "${YELLOW}Building admin UI...${NC}"
 	@cd admin && unset NODE_OPTIONS && bun run build
 	@rm -rf internal/adminui/dist

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A lightweight, single-binary Backend-as-a-Service (BaaS) alternative to Supabase
 git clone https://github.com/nimbleflux/fluxbase.git
 cd fluxbase
 
-# Build the binary
+# Build the binary (also builds the TypeScript + React SDKs and admin UI)
 make build
 
 # Or run in development mode (backend + admin UI)
@@ -61,6 +61,8 @@ make dev
 For Docker-based deployment, see the [deployment guide](https://fluxbase.eu/deployment/overview/).
 
 ### SDKs
+
+`make build` and `make dev` build the TypeScript and React SDKs automatically (rebuilding only when their sources change). Build them manually for standalone development or to test the published artifacts:
 
 ```bash
 # TypeScript SDK


### PR DESCRIPTION
## Summary

Fixes #323 — `make build` failed when compiling from source on a fresh clone.

## Root cause

`make build` ran `generate:embedded-sdk` (which only emits the embedded IIFE for the Go/Deno job runtime into `internal/jobs` & `internal/runtime`) and then `cd admin && bun run build` (`tsc -b && vite build`). The admin Vite build failed because `admin/vite.config.ts` hard-aliases the SDKs to their **built dist files**:

```ts
"@nimbleflux/fluxbase-sdk":       "../sdk/dist/index.js",
"@nimbleflux/fluxbase-sdk-react": "../sdk-react/dist/index.mjs",
```

`**/dist/` is gitignored (absent on a fresh clone) and **no Makefile target ever ran `tsup`** (`bun run build`) in `sdk/` or `sdk-react/`. `tsc -b` passed because `admin/tsconfig.app.json` points at SDK *source*, so the failure surfaced only at `vite build` — matching the reported error. The same latent bug existed in `make dev` and `make dev-full` (same Vite aliases, no SDK build).

## Fix

- Add a staleness-aware `ensure-sdks` Make target (mirrors the existing `ensure-embedded-sdk` idiom) that builds both SDK packages via tsup only when `dist/` is missing or their sources changed (fast incremental builds). Also adds an install guard for `sdk-react/node_modules`, which `dev`/`dev-full` were missing.
- Wire `ensure-sdks` into `build`, `dev`, and `dev-full` before the admin/Vite step.
- Update the README "Build & Run" and "SDKs" sections to reflect that SDKs are built automatically.

Note: `sdk-react/tsup.config.ts` marks `@nimbleflux/fluxbase-sdk` as `external`, so the two builds are independent — order is just for readability.

## Verification

- **Makefile wiring** — `make -n` dry runs confirm `ensure-sdks` is invoked in the right place in all three targets.
- **SDK builds produce the right artifacts** — ran tsup directly: `sdk/dist/index.js` and `sdk-react/dist/index.mjs` are generated, matching the Vite alias paths exactly.
- **Admin build now succeeds** — ran the exact failing command `tsc -b && vite build` → `✓ built in 1.50s`, exit 0 (previously the `[UNLOADABLE_DEPENDENCY]` failure from the issue).
- **Staleness logic** — fresh dist → skips; after touching a source file → rebuilds; missing dist → builds (no `find` error, thanks to `||` short-circuit).

The full `make build` could not be run end-to-end in this environment because `bun` and the OCR CGO libs (leptonica/tesseract) are not installed — both are pre-existing environment requirements unrelated to this change.

## Out of scope

- macOS leptonica/tesseract/CGO setup mentioned by the reporter (separate OCR build-tag concern).
- Repointing the Vite aliases at SDK source (alternative approach; higher risk to bundling behavior).

Closes #323