### PR TITLE
feat: anon-key discovery via /auth/config + opt-in TLS bypass (Kotlin SDK)

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -27,17 +27,19 @@ type AuthHandler struct {
 	captchaTrustService *auth.CaptchaTrustService
 	samlService         *auth.SAMLService
 	baseURL             string
-	secureCookie        bool // Whether to set Secure flag on cookies (true in production)
+	secureCookie        bool   // Whether to set Secure flag on cookies (true in production)
+	anonKey             string // Publishable anon key (safe to expose to clients); empty when unconfigured
 }
 
 // NewAuthHandler creates a new authentication handler
-func NewAuthHandler(db *database.Connection, authService *auth.Service, captchaService *auth.CaptchaService, baseURL string) *AuthHandler {
+func NewAuthHandler(db *database.Connection, authService *auth.Service, captchaService *auth.CaptchaService, baseURL string, anonKey string) *AuthHandler {
 	return &AuthHandler{
 		db:             db,
 		authService:    authService,
 		captchaService: captchaService,
 		baseURL:        baseURL,
 		secureCookie:   false, // Will be set based on environment
+		anonKey:        anonKey,
 	}
 }
 
@@ -71,6 +73,10 @@ type AuthConfigResponse struct {
 	OAuthProviders           []OAuthProviderPublic       `json:"oauth_providers"`
 	SAMLProviders            []SAMLProviderPublic        `json:"saml_providers"`
 	Captcha                  *auth.CaptchaConfigResponse `json:"captcha"`
+	// Publishable anon key (same key the web app exposes to browsers).
+	// Lets native clients discover their instance without manual key entry.
+	// Omitted when the server has none configured.
+	AnonKey                  string                      `json:"anon_key,omitempty"`
 }
 
 // OAuthProviderPublic represents public OAuth provider information

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -76,7 +76,7 @@ type AuthConfigResponse struct {
 	// Publishable anon key (same key the web app exposes to browsers).
 	// Lets native clients discover their instance without manual key entry.
 	// Omitted when the server has none configured.
-	AnonKey                  string                      `json:"anon_key,omitempty"`
+	AnonKey string `json:"anon_key,omitempty"`
 }
 
 // OAuthProviderPublic represents public OAuth provider information

--- a/internal/api/auth_handler_captcha_test.go
+++ b/internal/api/auth_handler_captcha_test.go
@@ -26,7 +26,7 @@ const validTestCaptchaToken = "valid-test-token-12345"
 func createTestHandlerWithCaptcha(endpoints []string) *AuthHandler {
 	authService := auth.NewTestAuthServiceWithSettings(true, true)
 	captchaService := auth.NewTestCaptchaService(endpoints, validTestCaptchaToken)
-	return NewAuthHandler(nil, authService, captchaService, "https://example.com")
+	return NewAuthHandler(nil, authService, captchaService, "https://example.com", "")
 }
 
 // parseErrorResponse parses the JSON error response
@@ -387,7 +387,7 @@ func TestNilCaptchaService_SkipsVerification(t *testing.T) {
 
 	// We verify this behavior by checking that the handler constructor
 	// accepts nil and the handler code has proper nil checks
-	handler := NewAuthHandler(nil, nil, nil, "https://example.com")
+	handler := NewAuthHandler(nil, nil, nil, "https://example.com", "")
 	assert.Nil(t, handler.captchaService, "Handler should accept nil captcha service")
 
 	// The actual nil-safety is tested implicitly - if the handler

--- a/internal/api/auth_handler_config.go
+++ b/internal/api/auth_handler_config.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/auth"
+	"github.com/nimbleflux/fluxbase/internal/config"
 	"github.com/nimbleflux/fluxbase/internal/middleware"
 )
 
@@ -32,6 +34,7 @@ func (h *AuthHandler) GetAuthConfig(c fiber.Ctx) error {
 		PasswordRequireSpecial:   settingsCache.GetBool(ctx, "app.auth.password_require_special", false),
 		OAuthProviders:           []OAuthProviderPublic{},
 		SAMLProviders:            []SAMLProviderPublic{},
+		AnonKey:                  h.anonKey,
 	}
 
 	// Fetch OAuth providers
@@ -93,4 +96,20 @@ func (h *AuthHandler) isPasswordLoginDisabled(ctx context.Context) bool {
 
 	settingsCache := h.authService.GetSettingsCache()
 	return settingsCache.GetBool(ctx, "app.auth.disable_app_password_login", false)
+}
+
+// resolvePublishableAnonKey returns the configured anon key (publishable —
+// safe to expose to clients, same key the web app ships in its HTML).
+// Reads the value or the key file; empty when neither is configured, in
+// which case /auth/config simply omits the field (omitempty).
+func resolvePublishableAnonKey(cfg *config.Config) string {
+	key := cfg.Tenants.Default.AnonKey
+	if cfg.Tenants.Default.AnonKeyFile != "" {
+		if data, err := os.ReadFile(cfg.Tenants.Default.AnonKeyFile); err == nil {
+			key = strings.TrimSpace(string(data))
+		} else {
+			log.Warn().Err(err).Str("file", cfg.Tenants.Default.AnonKeyFile).Msg("Failed to read anon key file")
+		}
+	}
+	return strings.TrimSpace(key)
 }

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -222,7 +222,7 @@ func TestAuthHandler_SetSAMLService(t *testing.T) {
 // =============================================================================
 
 func TestGetAccessToken_FromCookie(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -244,7 +244,7 @@ func TestGetAccessToken_FromCookie(t *testing.T) {
 }
 
 func TestGetAccessToken_FromBearerHeader(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -263,7 +263,7 @@ func TestGetAccessToken_FromBearerHeader(t *testing.T) {
 }
 
 func TestGetAccessToken_CookiePriority(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -287,7 +287,7 @@ func TestGetAccessToken_CookiePriority(t *testing.T) {
 }
 
 func TestGetAccessToken_HeaderWithoutBearer(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -306,7 +306,7 @@ func TestGetAccessToken_HeaderWithoutBearer(t *testing.T) {
 }
 
 func TestGetAccessToken_Empty(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -324,7 +324,7 @@ func TestGetAccessToken_Empty(t *testing.T) {
 }
 
 func TestGetAccessToken_ShortBearerHeader(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -349,7 +349,7 @@ func TestGetAccessToken_ShortBearerHeader(t *testing.T) {
 // =============================================================================
 
 func TestGetRefreshToken_FromCookie(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -371,7 +371,7 @@ func TestGetRefreshToken_FromCookie(t *testing.T) {
 }
 
 func TestGetRefreshToken_Empty(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -393,7 +393,7 @@ func TestGetRefreshToken_Empty(t *testing.T) {
 // =============================================================================
 
 func TestSetAuthCookies(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -430,7 +430,7 @@ func TestSetAuthCookies(t *testing.T) {
 }
 
 func TestSetAuthCookies_Secure(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 	handler.SetSecureCookie(true)
 
 	app := newTestApp(t)
@@ -452,7 +452,7 @@ func TestSetAuthCookies_Secure(t *testing.T) {
 }
 
 func TestClearAuthCookies(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -480,7 +480,7 @@ func TestClearAuthCookies(t *testing.T) {
 // =============================================================================
 
 func TestGetCSRFToken_ReturnsToken(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 
@@ -522,7 +522,7 @@ func TestGetCSRFToken_ReturnsToken(t *testing.T) {
 // =============================================================================
 
 func TestGetUser_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/user", handler.GetUser)
@@ -536,7 +536,7 @@ func TestGetUser_NoAuth(t *testing.T) {
 }
 
 func TestUpdateUser_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Patch("/auth/user", handler.UpdateUser)
@@ -552,7 +552,7 @@ func TestUpdateUser_NoAuth(t *testing.T) {
 }
 
 func TestSetupTOTP_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/2fa/setup", handler.SetupTOTP)
@@ -566,7 +566,7 @@ func TestSetupTOTP_NoAuth(t *testing.T) {
 }
 
 func TestEnableTOTP_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/2fa/enable", handler.EnableTOTP)
@@ -582,7 +582,7 @@ func TestEnableTOTP_NoAuth(t *testing.T) {
 }
 
 func TestDisableTOTP_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/2fa/disable", handler.DisableTOTP)
@@ -598,7 +598,7 @@ func TestDisableTOTP_NoAuth(t *testing.T) {
 }
 
 func TestGetTOTPStatus_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/2fa/status", handler.GetTOTPStatus)
@@ -616,7 +616,7 @@ func TestGetTOTPStatus_NoAuth(t *testing.T) {
 // =============================================================================
 
 func BenchmarkGetAccessToken_Cookie(b *testing.B) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 	app := fiber.New()
 	var captured fiber.Ctx
 
@@ -643,7 +643,7 @@ func BenchmarkGetAccessToken_Cookie(b *testing.B) {
 }
 
 func BenchmarkGetAccessToken_Header(b *testing.B) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 	app := fiber.New()
 	var captured fiber.Ctx
 
@@ -667,7 +667,7 @@ func BenchmarkGetAccessToken_Header(b *testing.B) {
 }
 
 func BenchmarkSetAuthCookies(b *testing.B) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 	app := fiber.New()
 
 	app.Get("/test", func(c fiber.Ctx) error {
@@ -687,7 +687,7 @@ func BenchmarkSetAuthCookies(b *testing.B) {
 // =============================================================================
 
 func TestSignOut_NoToken(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/signout", handler.SignOut)
@@ -702,7 +702,7 @@ func TestSignOut_NoToken(t *testing.T) {
 }
 
 func TestRefreshToken_NoToken(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/token/refresh", handler.RefreshToken)
@@ -718,7 +718,7 @@ func TestRefreshToken_NoToken(t *testing.T) {
 }
 
 func TestSendMagicLink_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/magiclink", handler.SendMagicLink)
@@ -755,7 +755,7 @@ func TestSendMagicLink_Validation(t *testing.T) {
 // VerifyMagicLink requires auth service - skipped for unit testing
 
 func TestRequestPasswordReset_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/password/reset", handler.RequestPasswordReset)
@@ -790,7 +790,7 @@ func TestRequestPasswordReset_Validation(t *testing.T) {
 }
 
 func TestResetPassword_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/password/reset/confirm", handler.ResetPassword)
@@ -835,7 +835,7 @@ func TestResetPassword_Validation(t *testing.T) {
 }
 
 func TestVerifyPasswordResetToken_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/password/reset/verify", handler.VerifyPasswordResetToken)
@@ -869,7 +869,7 @@ func TestVerifyPasswordResetToken_Validation(t *testing.T) {
 }
 
 func TestVerifyEmail_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/verify", handler.VerifyEmail)
@@ -904,7 +904,7 @@ func TestVerifyEmail_Validation(t *testing.T) {
 }
 
 func TestResendVerificationEmail_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/resend-verification", handler.ResendVerificationEmail)
@@ -939,7 +939,7 @@ func TestResendVerificationEmail_Validation(t *testing.T) {
 }
 
 func TestStartImpersonation_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/impersonation/start", handler.StartImpersonation)
@@ -956,7 +956,7 @@ func TestStartImpersonation_NoAuth(t *testing.T) {
 }
 
 func TestStopImpersonation_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/impersonation/stop", handler.StopImpersonation)
@@ -971,7 +971,7 @@ func TestStopImpersonation_NoAuth(t *testing.T) {
 }
 
 func TestGetActiveImpersonation_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/impersonation/active", handler.GetActiveImpersonation)
@@ -986,7 +986,7 @@ func TestGetActiveImpersonation_NoAuth(t *testing.T) {
 }
 
 func TestListImpersonationSessions_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/impersonation/sessions", handler.ListImpersonationSessions)
@@ -1001,7 +1001,7 @@ func TestListImpersonationSessions_NoAuth(t *testing.T) {
 }
 
 func TestGetCSRFToken_Handler(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/csrf-token", handler.GetCSRFToken)
@@ -1026,7 +1026,7 @@ func TestGetCSRFToken_Handler(t *testing.T) {
 // which requires a non-nil authService. Cannot test validation without mocking the full service.
 
 func TestUpdateUser_AuthHandlerValidation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Patch("/auth/user", handler.UpdateUser)
@@ -1072,7 +1072,7 @@ func TestUpdateUser_AuthHandlerValidation(t *testing.T) {
 // =============================================================================
 
 func TestStartAnonImpersonation_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/impersonate/anon", handler.StartAnonImpersonation)
@@ -1089,7 +1089,7 @@ func TestStartAnonImpersonation_NoAuth(t *testing.T) {
 }
 
 func TestStartAnonImpersonation_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/impersonate/anon", handler.StartAnonImpersonation)
@@ -1129,7 +1129,7 @@ func TestStartAnonImpersonation_Validation(t *testing.T) {
 }
 
 func TestStartServiceImpersonation_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/impersonate/service", handler.StartServiceImpersonation)
@@ -1146,7 +1146,7 @@ func TestStartServiceImpersonation_NoAuth(t *testing.T) {
 }
 
 func TestStartServiceImpersonation_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/impersonate/service", handler.StartServiceImpersonation)
@@ -1186,7 +1186,7 @@ func TestStartServiceImpersonation_Validation(t *testing.T) {
 }
 
 func TestGetCaptchaConfig_NilService(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/captcha/config", handler.GetCaptchaConfig)
@@ -1202,7 +1202,7 @@ func TestGetCaptchaConfig_NilService(t *testing.T) {
 }
 
 func TestCheckCaptcha_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/captcha/check", handler.CheckCaptcha)
@@ -1247,7 +1247,7 @@ func TestCheckCaptcha_Validation(t *testing.T) {
 }
 
 func TestVerifyMagicLink_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/magiclink/verify", handler.VerifyMagicLink)
@@ -1287,7 +1287,7 @@ func TestVerifyMagicLink_Validation(t *testing.T) {
 }
 
 func TestVerifyTOTP_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/2fa/verify", handler.VerifyTOTP)
@@ -1332,7 +1332,7 @@ func TestVerifyTOTP_Validation(t *testing.T) {
 }
 
 func TestSendOTP_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/otp/signin", handler.SendOTP)
@@ -1367,7 +1367,7 @@ func TestSendOTP_Validation(t *testing.T) {
 }
 
 func TestVerifyOTP_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/otp/verify", handler.VerifyOTP)
@@ -1407,7 +1407,7 @@ func TestVerifyOTP_Validation(t *testing.T) {
 }
 
 func TestResendOTP_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/otp/resend", handler.ResendOTP)
@@ -1442,7 +1442,7 @@ func TestResendOTP_Validation(t *testing.T) {
 }
 
 func TestGetUserIdentities_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/user/identities", handler.GetUserIdentities)
@@ -1456,7 +1456,7 @@ func TestGetUserIdentities_NoAuth(t *testing.T) {
 }
 
 func TestLinkIdentity_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/user/identities", handler.LinkIdentity)
@@ -1472,7 +1472,7 @@ func TestLinkIdentity_NoAuth(t *testing.T) {
 }
 
 func TestLinkIdentity_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/user/identities", handler.LinkIdentity)
@@ -1512,7 +1512,7 @@ func TestLinkIdentity_Validation(t *testing.T) {
 }
 
 func TestUnlinkIdentity_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Delete("/auth/user/identities/identity-123", handler.UnlinkIdentity)
@@ -1526,7 +1526,7 @@ func TestUnlinkIdentity_NoAuth(t *testing.T) {
 }
 
 func TestReauthenticate_NoAuth(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/reauthenticate", handler.Reauthenticate)
@@ -1540,7 +1540,7 @@ func TestReauthenticate_NoAuth(t *testing.T) {
 }
 
 func TestSignInWithIDToken_Validation(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Post("/auth/signin/idtoken", handler.SignInWithIDToken)
@@ -1594,7 +1594,7 @@ func TestSignInWithIDToken_Validation(t *testing.T) {
 // =============================================================================
 
 func TestListImpersonationSessions_QueryParameters(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "")
+	handler := NewAuthHandler(nil, nil, nil, "", "")
 
 	app := newTestApp(t)
 	app.Get("/auth/impersonation/sessions", handler.ListImpersonationSessions)

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -163,7 +163,7 @@ func TestSAMLProviderPublic_CommonProviders(t *testing.T) {
 // =============================================================================
 
 func TestNewAuthHandler_NilDependencies(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "https://example.com")
+	handler := NewAuthHandler(nil, nil, nil, "https://example.com", "")
 
 	assert.NotNil(t, handler)
 	assert.Nil(t, handler.db)
@@ -186,14 +186,14 @@ func TestNewAuthHandler_BaseURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			handler := NewAuthHandler(nil, nil, nil, tt.baseURL)
+			handler := NewAuthHandler(nil, nil, nil, tt.baseURL, "")
 			assert.Equal(t, tt.baseURL, handler.baseURL)
 		})
 	}
 }
 
 func TestAuthHandler_SetSecureCookie(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "https://example.com")
+	handler := NewAuthHandler(nil, nil, nil, "https://example.com", "")
 
 	// Default is false
 	assert.False(t, handler.secureCookie)
@@ -208,7 +208,7 @@ func TestAuthHandler_SetSecureCookie(t *testing.T) {
 }
 
 func TestAuthHandler_SetSAMLService(t *testing.T) {
-	handler := NewAuthHandler(nil, nil, nil, "https://example.com")
+	handler := NewAuthHandler(nil, nil, nil, "https://example.com", "")
 
 	assert.Nil(t, handler.samlService)
 

--- a/internal/api/auth_otp_test.go
+++ b/internal/api/auth_otp_test.go
@@ -111,7 +111,7 @@ func setupAuthTestServer(t *testing.T) (*fiber.App, *auth.Service, *database.Con
 	})
 
 	// Create auth handler (no captcha service in tests)
-	authHandler := NewAuthHandler(db, authService, nil, "http://localhost:3000")
+	authHandler := NewAuthHandler(db, authService, nil, "http://localhost:3000", "")
 
 	// Create optional auth middleware for routes that use JWT when available
 	optionalAuth := OptionalAuthMiddleware(authService)

--- a/internal/api/module_auth.go
+++ b/internal/api/module_auth.go
@@ -60,7 +60,7 @@ func (m *AuthModule) Init(ctx context.Context, registry *ServiceRegistry) error 
 	}
 	m.CaptchaService = captchaService
 
-	authHandler := NewAuthHandler(db, authService, captchaService, cfg.GetPublicBaseURL())
+	authHandler := NewAuthHandler(db, authService, captchaService, cfg.GetPublicBaseURL(), resolvePublishableAnonKey(cfg))
 
 	dashboardJWTManager, err := auth.NewJWTManager(cfg.Auth.JWTSecret, 24*time.Hour, 168*time.Hour)
 	if err != nil {

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/FluxbaseClient.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/FluxbaseClient.kt
@@ -25,6 +25,13 @@ data class FluxbaseClientOptions(
     val headers: Map<String, String> = emptyMap(),
     val timeout: Long = 30_000,
     val debug: Boolean = false,
+    /**
+     * Skip TLS certificate validation for this client's engine (HTTP and
+     * realtime WebSocket). For self-hosted instances behind self-signed
+     * certificates — opt in only, validation stays the default. Scoped to
+     * this client's connections, unlike a global trust-store override.
+     */
+    val trustSslCertificates: Boolean = false,
 )
 
 /**
@@ -42,6 +49,8 @@ data class FluxbaseClientOptions(
  * ```
  */
 class FluxbaseClient internal constructor(
+    /** When true, realtime channels skip TLS validation (self-signed instances). */
+    internal val trustSslCertificates: Boolean = false,
     /** The shared HTTP client used by all modules. */
     val http: FluxbaseHttpClient,
     /** The auth module. */
@@ -92,7 +101,9 @@ class FluxbaseClient internal constructor(
         name: String,
         transport: io.github.nimbleflux.fluxbase.realtime.WebSocketTransport? = null,
     ): io.github.nimbleflux.fluxbase.realtime.RealtimeChannel {
-        val wsTransport = transport ?: io.github.nimbleflux.fluxbase.realtime.KtorWebSocketTransport()
+        val wsTransport = transport ?: io.github.nimbleflux.fluxbase.realtime.KtorWebSocketTransport(
+            trustAllCertificates = trustSslCertificates,
+        )
         val token = auth.currentSession?.accessToken
         return io.github.nimbleflux.fluxbase.realtime.RealtimeChannel(
             baseUrl = http.baseUrl,
@@ -132,7 +143,11 @@ class FluxbaseClient internal constructor(
                 ?: System.getenv("FLUXBASE_ANON_KEY")
                 ?: error("Fluxbase key is required (pass it or set FLUXBASE_ANON_KEY)")
 
-            val resolvedTransport = transport ?: KtorHttpTransport(resolvedUrl, timeoutMillis = options.timeout)
+            val resolvedTransport = transport ?: KtorHttpTransport(
+                resolvedUrl,
+                timeoutMillis = options.timeout,
+                trustAllCertificates = options.trustSslCertificates,
+            )
 
             // The HTTP client holds apikey + Authorization headers.
             // In TS, the constructor sets `apikey: key, Authorization: Bearer key`.
@@ -174,8 +189,11 @@ class FluxbaseClient internal constructor(
             val management = io.github.nimbleflux.fluxbase.management.FluxbaseManagement(http)
 
             return FluxbaseClient(
-                http, auth, functions, jobs, secrets, settings, storage, rpc,
-                graphql, vector, branching, tenant, management,
+                trustSslCertificates = options.trustSslCertificates,
+                http = http, auth = auth, functions = functions, jobs = jobs,
+                secrets = secrets, settings = settings, storage = storage, rpc = rpc,
+                graphql = graphql, vector = vector, branching = branching, tenant = tenant,
+                management = management,
             )
         }
     }
@@ -200,7 +218,10 @@ fun createFluxbaseClient(
  *
  * Port of `client.from(table)` in `client.ts:447`.
  */
-inline fun <reified T> FluxbaseClient.from(table: String, schema: String? = null): io.github.nimbleflux.fluxbase.postgrest.QueryBuilder<T> {
+inline fun <reified T> FluxbaseClient.from(
+    table: String,
+    schema: String? = null,
+): io.github.nimbleflux.fluxbase.postgrest.QueryBuilder<T> {
     val serializer = kotlinx.serialization.serializer<T>()
     return io.github.nimbleflux.fluxbase.postgrest.QueryBuilder(this.http, serializer, table, schema)
 }

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/AuthConfig.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/AuthConfig.kt
@@ -24,4 +24,10 @@ data class AuthConfig(
     @SerialName("oauth_providers") val oauthProviders: List<String> = emptyList(),
     @SerialName("saml_providers") val samlProviders: List<String> = emptyList(),
     @SerialName("email_confirmation_required") val emailConfirmationRequired: Boolean = false,
+    /**
+     * Publishable anon key for this instance (the same key the web app
+     * exposes to browsers). Lets native clients connect without manual key
+     * entry. Null on servers that don't publish it.
+     */
+    @SerialName("anon_key") val anonKey: String? = null,
 )

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransport.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransport.kt
@@ -43,14 +43,23 @@ class KtorHttpTransport(
     private val baseUrl: String,
     private val json: Json = FluxbaseHttpClient.defaultJson,
     timeoutMillis: Long = 30_000,
+    trustAllCertificates: Boolean = false,
 ) : HttpTransport {
 
-    private val client: HttpClient = HttpClient(OkHttp) {
+    private val client = HttpClient(OkHttp) {
         install(ContentNegotiation) { json(this@KtorHttpTransport.json) }
         install(HttpTimeout) {
             requestTimeoutMillis = timeoutMillis
             connectTimeoutMillis = timeoutMillis
             socketTimeoutMillis = timeoutMillis
+        }
+        if (trustAllCertificates) {
+            engine {
+                config {
+                    sslSocketFactory(TrustAllCertificates.socketFactory, TrustAllCertificates.trustManager)
+                    hostnameVerifier(TrustAllCertificates.hostnameVerifier)
+                }
+            }
         }
         // TODO(S1): connection pool tuning.
     }

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/core/TrustAllCertificates.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/core/TrustAllCertificates.kt
@@ -1,0 +1,30 @@
+package io.github.nimbleflux.fluxbase.core
+
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Trust-all TLS material for [KtorHttpTransport] and the realtime WebSocket
+ * transport when the caller opts in via
+ * `FluxbaseClientOptions.trustSslCertificates` (self-signed self-hosted
+ * instances). Scoped to the transports' own OkHttp engines — nothing global
+ * is modified.
+ */
+internal object TrustAllCertificates {
+
+    val trustManager: X509TrustManager = object : X509TrustManager {
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) = Unit
+        override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+    }
+
+    val socketFactory: SSLSocketFactory = SSLContext.getInstance("TLS").apply {
+        init(null, arrayOf<TrustManager>(trustManager), SecureRandom())
+    }.socketFactory
+
+    val hostnameVerifier = javax.net.ssl.HostnameVerifier { _, _ -> true }
+}

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/realtime/KtorWebSocketTransport.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/realtime/KtorWebSocketTransport.kt
@@ -34,9 +34,22 @@ import kotlinx.coroutines.launch
  * in [RealtimeChannel]; this class is purely the transport seam — the same SPI
  * tests fake with [FakeWebSocketTransport].
  */
-class KtorWebSocketTransport : WebSocketTransport {
+class KtorWebSocketTransport(trustAllCertificates: Boolean = false) : WebSocketTransport {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val client = HttpClient(OkHttp) { install(WebSockets) }
+    private val client = HttpClient(OkHttp) {
+        install(WebSockets)
+        if (trustAllCertificates) {
+            engine {
+                config {
+                    sslSocketFactory(
+                        io.github.nimbleflux.fluxbase.core.TrustAllCertificates.socketFactory,
+                        io.github.nimbleflux.fluxbase.core.TrustAllCertificates.trustManager,
+                    )
+                    hostnameVerifier(io.github.nimbleflux.fluxbase.core.TrustAllCertificates.hostnameVerifier)
+                }
+            }
+        }
+    }
 
     private var session: ClientWebSocketSession? = null
     private var connectionJob: Job? = null

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -2362,6 +2362,12 @@ export interface AuthConfig {
   saml_providers: SAMLProviderInfo[];
   /** CAPTCHA configuration */
   captcha: CaptchaConfig | null;
+  /**
+   * Publishable anon key for this instance (same key the web app exposes to
+   * browsers). Lets native clients connect without manual key entry.
+   * Omitted by servers that don't publish it.
+   */
+  anon_key?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Two enablers for native-client (Wayli Android) login with **just a URL** — no manual anon key entry, and support for instances behind self-signed certificates.

### 1. Publish the anon key via `GET /api/v1/auth/config`

The anon key is publishable by design — it's the same key every web app ships in its HTML. Exposing it on the already-public auth config endpoint lets native clients discover it:

- **Server** (`internal/api`): `AuthConfigResponse.anon_key` (`omitempty`), resolved from `tenants.default.anon_key` (or `anon_key_file`) at handler construction. Unconfigured servers omit the field entirely.
- **TS SDK**: `AuthConfig.anon_key?: string`
- **Kotlin SDK**: `AuthConfig.anonKey` (nullable, `@SerialName("anon_key")`)

### 2. `FluxbaseClientOptions.trustSslCertificates` (Kotlin SDK)

Opt-in TLS validation bypass for the **Wayli app's connections to its Wayli/Fluxbase instance** (self-signed certificates). Scoped to the client's own OkHttp engines — the HTTP transport and the realtime WebSocket transport each get a private trust-all socket factory + hostname verifier only when the flag is set. Nothing global is modified; validation remains the default. Fluxbase's own outbound TLS behavior is untouched — this is purely a client-library option consumed by the app.

## Security notes

- The anon key grants the `anon` role only — same exposure level as the web app. RLS continues to govern what anon can read.
- TLS bypass is explicit opt-in per client instance; never a default.

## Verification

- `detekt` clean (MaxLineLength issues from the first CI run fixed) and SDK unit suite green
- End-to-end on the Wayli side (fake instance + self-signed HTTPS server): URL-only discovery → sign-in, and toggle-gated TLS bypass

## Follow-up

- Cut `2026.8.8-rc.3` from this branch once merged so the Wayli app can adopt the SDK-native TLS option (replacing its temporary host-scoped global workaround)