### PR TITLE
fix(ci): arch must be a matrix key in publish-docker-arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -967,6 +967,10 @@ jobs:
         #   full = default image (OCR + ffmpeg + libvips image transforms)
         #   lite = smaller distroless image (no OCR/ffmpeg/transforms)
         flavor: [full, lite]
+        # arch MUST be a matrix key: if it only appears in include entries, all
+        # includes merge into the same flavor combo and the last one wins
+        # (arm64), silently dropping the amd64 builds.
+        arch: [amd64, arm64]
         include:
           - flavor: full
             arch: amd64


### PR DESCRIPTION
## Problem

Since #320, every Release run fails at **Create Docker Multi-arch Manifest** with:

```
ERROR: ghcr.io/nimbleflux/fluxbase:<version>-amd64: not found
```

(e.g. runs 31938622907, 31534379138, 31422346726)

## Root cause

`publish-docker-arch` defined `flavor` as the only top-level matrix key, with the arch/runner combos in `include`. GitHub Actions merges each include entry into a matching base combo when it doesn't overwrite original matrix values — so both the amd64 and arm64 entries merged into the same `{full}` (and `{lite}`) combo, and the last one (arm64) won. Only 2 arm64 jobs ever spawned; the amd64 images were never pushed, so the manifest step that unconditionally references `…-amd64` failed.

## Fix

Add `arch: [amd64, arm64]` as a top-level matrix key. The 2×2 cross-product creates all 4 combos; each include entry now matches exactly one combo and only contributes `runner`.

Verified against the failed runs' job lists: only `Build Docker Image (full / arm64)` and `(lite / arm64)` existed — amd64 jobs were absent entirely (not skipped), matching this collapse behavior.