### PR TITLE
fix(api): /auth/config anon_key — fall back to FLUXBASE_ANON_KEY env

### DIFF
--- a/internal/api/auth_handler_config.go
+++ b/internal/api/auth_handler_config.go
@@ -34,7 +34,7 @@ func (h *AuthHandler) GetAuthConfig(c fiber.Ctx) error {
 		PasswordRequireSpecial:   settingsCache.GetBool(ctx, "app.auth.password_require_special", false),
 		OAuthProviders:           []OAuthProviderPublic{},
 		SAMLProviders:            []SAMLProviderPublic{},
-		AnonKey:                  h.anonKey,
+		AnonKey:                  h.publishableAnonKey(),
 	}
 
 	// Fetch OAuth providers
@@ -96,6 +96,18 @@ func (h *AuthHandler) isPasswordLoginDisabled(ctx context.Context) bool {
 
 	settingsCache := h.authService.GetSettingsCache()
 	return settingsCache.GetBool(ctx, "app.auth.disable_app_password_login", false)
+}
+
+// publishableAnonKey returns the anon key to expose in /auth/config.
+// Config path first, then the FLUXBASE_ANON_KEY environment variable —
+// standard deployments (docker-compose) pass the key via env, and the
+// server itself generates one there at boot when unset (main.go), so the
+// tenants config path alone is empty in practice.
+func (h *AuthHandler) publishableAnonKey() string {
+	if h.anonKey != "" {
+		return h.anonKey
+	}
+	return os.Getenv("FLUXBASE_ANON_KEY")
 }
 
 // resolvePublishableAnonKey returns the configured anon key (publishable —


### PR DESCRIPTION
## Problem

Follow-up to #327 (squash `2cc2742f`, released in 2026.8.8-rc.4): on a stock docker-compose deployment, `GET /api/v1/auth/config` still omits `anon_key`.

Root cause: `resolvePublishableAnonKey` read only `tenants.default.anon_key` (or key file). That config path is never populated in practice —

- the compose stack passes the key as `FLUXBASE_ANON_KEY`, but viper's env replacer maps the config path to `FLUXBASE_TENANTS_DEFAULT_ANON_KEY` (different name)
- when no key is provided at all, `main.go` generates an anon JWT and sets it into `FLUXBASE_ANON_KEY` at boot

So the resolver always saw an empty string.

## Fix

The handler resolves the publishable key at request time: config path first, then `os.Getenv("FLUXBASE_ANON_KEY")`. Verified against a live rc.4 instance — field absent before, and the env fallback is the only populated source.

`gofumpt` clean, `go build`/`go vet` green, package tests pass.