### PR TITLE
feat(sdk-kotlin): OAuth methods — providers, authorize URL, code exchange

### DIFF
--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
@@ -59,6 +59,12 @@ class FluxbaseAuth(
 
     private val stateListeners = mutableListOf<(AuthState) -> Unit>()
 
+    companion object {
+        /** Stored while an OAuth flow is in flight (TS: auth.ts:62-63). */
+        internal const val OAUTH_PROVIDER_KEY = "fluxbase.auth.oauth_provider"
+        internal const val OAUTH_REDIRECT_URI_KEY = "fluxbase.auth.oauth_redirect_uri"
+    }
+
     init {
         // Restore session from storage (mirrors `auth.ts:172-187`).
         restoreSession()
@@ -106,6 +112,83 @@ class FluxbaseAuth(
     /** Alias for [signIn] — Supabase-compatible method name. */
     suspend fun signInWithPassword(email: String, password: String): FluxbaseResponse<AuthResult> =
         signIn(email, password)
+
+    // ---- OAuth ----
+
+    /**
+     * List the app-login-enabled OAuth providers.
+     * GETs `/api/v1/auth/oauth/providers`. Port of `getOAuthProviders()` (auth.ts:913).
+     */
+    suspend fun getOAuthProviders(): FluxbaseResponse<List<OAuthProviderInfo>> = fluxbaseResponse {
+        val responseText = http.getWithHeaders("/api/v1/auth/oauth/providers").body
+        json.decodeFromString(OAuthProvidersResponse.serializer(), responseText).providers
+    }
+
+    /**
+     * Get the authorization URL for [provider] to open in a system browser.
+     * GETs `/api/v1/auth/oauth/{provider}/authorize`. Port of `getOAuthUrl()` (auth.ts:923).
+     *
+     * The provider and [OAuthOptions.redirectUri] are remembered (storage) for
+     * the matching [exchangeCodeForSession] call.
+     */
+    suspend fun getOAuthUrl(
+        provider: String,
+        options: OAuthOptions = OAuthOptions(),
+    ): FluxbaseResponse<OAuthUrlResponse> = fluxbaseResponse {
+        val params = buildList {
+            options.redirectTo?.let { add("redirect_to=${encode(it)}") }
+            options.redirectUri?.let { add("redirect_uri=${encode(it)}") }
+            if (options.scopes.isNotEmpty()) {
+                add("scopes=${encode(options.scopes.joinToString(","))}")
+            }
+        }
+        val query = if (params.isEmpty()) "" else "?" + params.joinToString("&")
+        val responseText = http.getWithHeaders("/api/v1/auth/oauth/$provider/authorize$query").body
+
+        // Remember for exchangeCodeForSession (mirrors the TS storage keys).
+        storage.setItem(OAUTH_PROVIDER_KEY, provider)
+        options.redirectUri?.let { storage.setItem(OAUTH_REDIRECT_URI_KEY, it) }
+
+        json.decodeFromString(OAuthUrlResponse.serializer(), responseText)
+    }
+
+    /**
+     * Exchange the OAuth authorization code (from the deep-link/callback)
+     * for a session and establish it. GETs
+     * `/api/v1/auth/oauth/{provider}/callback?code&state&redirect_uri`.
+     * Port of `exchangeCodeForSession()` (auth.ts:955).
+     *
+     * Requires a preceding [getOAuthUrl] call (for the stored provider).
+     */
+    suspend fun exchangeCodeForSession(code: String, state: String? = null): FluxbaseResponse<AuthResult> =
+        fluxbaseResponse {
+            val provider = storage.getItem(OAUTH_PROVIDER_KEY)
+                ?: throw FluxbaseAuthException("No OAuth provider found. Call getOAuthUrl first.")
+            val redirectUri = storage.getItem(OAUTH_REDIRECT_URI_KEY)
+
+            val params = buildList {
+                add("code=$code")
+                state?.let { add("state=$it") }
+                redirectUri?.let { add("redirect_uri=${encode(it)}") }
+            }
+            val responseText = http.getWithHeaders("/api/v1/auth/oauth/$provider/callback?${params.joinToString("&")}").body
+
+            storage.removeItem(OAUTH_PROVIDER_KEY)
+            storage.removeItem(OAUTH_REDIRECT_URI_KEY)
+
+            val authResponse = json.decodeFromString(AuthResponse.serializer(), responseText)
+            val session = AuthSession(
+                user = authResponse.user,
+                accessToken = authResponse.accessToken,
+                refreshToken = authResponse.refreshToken,
+                expiresIn = authResponse.expiresIn,
+                expiresAt = Clock.System.now().toEpochMilliseconds() + authResponse.expiresIn * 1000,
+            )
+            setSessionInternal(session, AuthChangeEvent.SIGNED_IN)
+            AuthResult(user = session.user, session = session)
+        }
+
+    private fun encode(s: String): String = java.net.URLEncoder.encode(s, "UTF-8")
 
     /**
      * Sign up with email and password.

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthException.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthException.kt
@@ -1,0 +1,4 @@
+package io.github.nimbleflux.fluxbase.auth
+
+/** Thrown for client-side OAuth flow errors (e.g. missing pending provider). */
+class FluxbaseAuthException(message: String) : Exception(message)

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/OAuthTypes.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/OAuthTypes.kt
@@ -1,0 +1,40 @@
+package io.github.nimbleflux.fluxbase.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * An app-login-enabled OAuth provider.
+ * Port of `OAuthProviderInfo` from `sdk/src/types.ts:861`.
+ */
+@Serializable
+data class OAuthProviderInfo(
+    val provider: String,
+    @SerialName("display_name") val displayName: String = "",
+    @SerialName("authorize_url") val authorizeUrl: String? = null,
+)
+
+/** Options for [FluxbaseAuth.getOAuthUrl]. Port of `OAuthOptions` (types.ts:872). */
+data class OAuthOptions(
+    /** Post-login redirect URL (where to go after successful login). */
+    val redirectTo: String? = null,
+    /** OAuth callback URL (where the provider redirects with the code). */
+    val redirectUri: String? = null,
+    val scopes: List<String> = emptyList(),
+)
+
+/**
+ * The authorization URL to open in a browser.
+ * Port of `OAuthUrlResponse` from `sdk/src/types.ts:878`.
+ */
+@Serializable
+data class OAuthUrlResponse(
+    val url: String,
+    val provider: String = "",
+)
+
+/** Wraps the /oauth/providers list. */
+@Serializable
+internal data class OAuthProvidersResponse(
+    val providers: List<OAuthProviderInfo> = emptyList(),
+)

--- a/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthOAuthTest.kt
+++ b/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthOAuthTest.kt
@@ -1,0 +1,148 @@
+package io.github.nimbleflux.fluxbase.auth
+
+import io.github.nimbleflux.fluxbase.core.FluxbaseHttpClient
+import io.github.nimbleflux.fluxbase.auth.FluxbaseAuth.Companion.OAUTH_PROVIDER_KEY
+import io.github.nimbleflux.fluxbase.auth.FluxbaseAuth.Companion.OAUTH_REDIRECT_URI_KEY
+import io.github.nimbleflux.fluxbase.core.test.RecordingHttp
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * OAuth method tests — porting the TS `auth.test.ts` OAuth cases:
+ * providers list, authorize URL (with stored provider/redirect_uri), and
+ * the code-for-session exchange that establishes the session.
+ */
+class FluxbaseAuthOAuthTest {
+
+    private val providersJson = """
+        {"providers": [
+            {"provider": "authentik", "display_name": "Authentik SSO",
+             "authorize_url": "http://localhost:8080/api/v1/auth/oauth/authentik/authorize"},
+            {"provider": "google"}
+        ]}
+    """.trimIndent()
+
+    private val authorizeJson = """
+        {"url": "https://idp.example.com/authorize?state=abc", "provider": "authentik"}
+    """.trimIndent()
+
+    private val callbackJson = """
+        {"user": {"id": "u1", "email": "sso@example.com"},
+         "access_token": "oauth-access", "refresh_token": "oauth-refresh",
+         "expires_in": 3600, "is_new_user": false}
+    """.trimIndent()
+
+    @Test
+    fun `getOAuthProviders lists app-login providers`() = runTest {
+        val recording = RecordingHttp(mockResponseBody = providersJson)
+        val auth = FluxbaseAuth(FluxbaseHttpClient("http://localhost:8080", recording), autoRefresh = false)
+
+        val result = auth.getOAuthProviders()
+
+        assertNull(result.error)
+        assertEquals("/api/v1/auth/oauth/providers", recording.lastPath)
+        val providers = result.data!!
+        assertEquals(2, providers.size)
+        assertEquals("authentik", providers[0].provider)
+        assertEquals("Authentik SSO", providers[0].displayName)
+        assertEquals("google", providers[1].provider)
+        assertEquals("", providers[1].displayName) // absent → default
+    }
+
+    @Test
+    fun `getOAuthUrl passes redirect_uri and remembers provider`() = runTest {
+        val recording = RecordingHttp(mockResponseBody = authorizeJson)
+        val storage = MapStorage()
+        val auth = FluxbaseAuth(
+            FluxbaseHttpClient("http://localhost:8080", recording),
+            autoRefresh = false,
+            storage = storage,
+        )
+
+        val result = auth.getOAuthUrl(
+            "authentik",
+            OAuthOptions(redirectUri = "wayli://oauth/callback"),
+        )
+
+        assertNull(result.error)
+        assertTrue(recording.lastPath!!.startsWith("/api/v1/auth/oauth/authentik/authorize?"))
+        assertTrue("redirect_uri=wayli%3A%2F%2Foauth%2Fcallback" in recording.lastPath!!)
+        assertEquals("https://idp.example.com/authorize?state=abc", result.data!!.url)
+        // Remembered for the exchange call.
+        assertEquals("authentik", storage.getItem(OAUTH_PROVIDER_KEY))
+        assertEquals("wayli://oauth/callback", storage.getItem(OAUTH_REDIRECT_URI_KEY))
+    }
+
+    @Test
+    fun `exchangeCodeForSession establishes the session and clears stored state`() = runTest {
+        val recording = RecordingHttp(mockResponseBody = callbackJson)
+        val storage = MapStorage().apply {
+            setItem(OAUTH_PROVIDER_KEY, "authentik")
+            setItem(OAUTH_REDIRECT_URI_KEY, "wayli://oauth/callback")
+        }
+        val auth = FluxbaseAuth(
+            FluxbaseHttpClient("http://localhost:8080", recording),
+            autoRefresh = false,
+            storage = storage,
+        )
+
+        val result = auth.exchangeCodeForSession("code-123", state = "abc")
+
+        assertNull(result.error)
+        val path = recording.lastPath!!
+        assertTrue(path.startsWith("/api/v1/auth/oauth/authentik/callback?"))
+        assertTrue("code=code-123" in path)
+        assertTrue("state=abc" in path)
+        assertTrue("redirect_uri=wayli%3A%2F%2Foauth%2Fcallback" in path)
+
+        val session = result.data!!.session!!
+        assertEquals("oauth-access", session.accessToken)
+        assertEquals("sso@example.com", session.user.email)
+        assertNotNull(session.expiresAt)
+        assertEquals(session, auth.currentSession)
+        // Stored OAuth state cleared after the exchange.
+        assertNull(storage.getItem(OAUTH_PROVIDER_KEY))
+        assertNull(storage.getItem(OAUTH_REDIRECT_URI_KEY))
+    }
+
+    @Test
+    fun `exchangeCodeForSession without a prior getOAuthUrl fails`() = runTest {
+        val recording = RecordingHttp(mockResponseBody = callbackJson)
+        val auth = FluxbaseAuth(FluxbaseHttpClient("http://localhost:8080", recording), autoRefresh = false)
+
+        val result = auth.exchangeCodeForSession("code-123")
+
+        assertNotNull(result.error)
+        assertTrue("getOAuthUrl" in result.error!!.message)
+        assertNull(auth.currentSession)
+    }
+
+    @Test
+    fun `auth state change fires SIGNED_IN on exchange`() = runTest {
+        val recording = RecordingHttp(mockResponseBody = callbackJson)
+        val storage = MapStorage().apply { setItem(OAUTH_PROVIDER_KEY, "authentik") }
+        val auth = FluxbaseAuth(
+            FluxbaseHttpClient("http://localhost:8080", recording),
+            autoRefresh = false,
+            storage = storage,
+        )
+        val events = mutableListOf<AuthChangeEvent>()
+        auth.onAuthStateChange { events.add(it.event) }
+
+        auth.exchangeCodeForSession("code-123")
+
+        assertEquals(listOf(AuthChangeEvent.SIGNED_IN), events)
+    }
+
+    /** Minimal StorageAdapter backed by a map. */
+    private class MapStorage : StorageAdapter {
+        private val map = mutableMapOf<String, String>()
+        override fun getItem(key: String): String? = map[key]
+        override fun setItem(key: String, value: String) { map[key] = value }
+        override fun removeItem(key: String) { map.remove(key) }
+    }
+}


### PR DESCRIPTION
## What

Ports the TS SDK's app-facing OAuth surface to Kotlin (`auth.ts`), enabling native OIDC sign-in (the Wayli Android app uses these now):

- **`getOAuthProviders()`** — `GET /auth/oauth/providers` → `List<OAuthProviderInfo>` (`provider`, `display_name`, `authorize_url`)
- **`getOAuthUrl(provider, OAuthOptions)`** — `GET /auth/oauth/{p}/authorize` → `OAuthUrlResponse(url)`. Remembers the provider + `redirect_uri` in storage (same keys as TS: `fluxbase.auth.oauth_provider` / `oauth_redirect_uri`) for the matching exchange
- **`exchangeCodeForSession(code, state?)`** — `GET /auth/oauth/{p}/callback?code&state&redirect_uri` → establishes + persists the `AuthSession` and emits `SIGNED_IN`, exactly like password sign-in

Mobile flow this enables: app gets the authorize URL → opens it in the system browser (custom scheme `redirect_uri`, e.g. `wayli://oauth/callback`) → IdP redirects back via deep link → app exchanges the code. The pending state survives process death (encrypted storage).

## Tests

5 new tests in the existing `RecordingHttp` pattern: provider parsing with default fallbacks, query encoding + remembered flow state, session establishment + storage cleanup after exchange, missing-provider error, and the `SIGNED_IN` auth-state event. Full suite (135+ tests) green, detekt clean.

## Release note

The Wayli app branch consumes these methods — cutting the next SDK RC from this PR unblocks its CI (which builds against the published artifact).