### PR TITLE
feat(auth): allow private-use app schemes in OAuth redirect URLs

### DIFF
--- a/admin/src/components/authentication/oauth-providers-tab.tsx
+++ b/admin/src/components/authentication/oauth-providers-tab.tsx
@@ -735,8 +735,9 @@ export function OAuthProvidersTab({ onProviderTest }: OAuthProvidersTabProps) {
               <div className="mt-1 space-y-2">
                 <Label>Additional Redirect URLs (Optional)</Label>
                 <p className="text-muted-foreground text-xs">
-                  Extra allowed callback URLs (e.g., custom domains). Each URL
-                  must also be registered with the OAuth provider.
+                  Extra allowed callback URLs (e.g., custom domains or mobile
+                  app schemes like myapp://oauth/callback). Each URL must also
+                  be registered with the OAuth provider.
                 </p>
                 <div className="space-y-2">
                   {additionalRedirectUrls.map((url, index) => (
@@ -963,8 +964,10 @@ export function OAuthProvidersTab({ onProviderTest }: OAuthProvidersTabProps) {
             <div className="grid gap-2">
               <Label>Redirect URLs</Label>
               <p className="text-muted-foreground text-xs">
-                Allowed OAuth callback URLs. The first URL is the default; each
-                URL must also be registered with the provider.
+                Allowed OAuth callback URLs — absolute http(s) URLs or mobile
+                app schemes (e.g., myapp://oauth/callback). The first URL is
+                the default; each URL must also be registered with the
+                provider.
               </p>
               <div className="space-y-2">
                 {editRedirectUrls.map((url, index) => (
@@ -977,7 +980,7 @@ export function OAuthProvidersTab({ onProviderTest }: OAuthProvidersTabProps) {
                         setEditRedirectUrls(next);
                       }}
                       className="bg-muted font-mono text-xs"
-                      placeholder="https://app.example.com/api/v1/auth/oauth/{provider}/callback"
+                      placeholder="https://app.example.com/... or myapp://oauth/callback"
                       aria-label={`Redirect URL ${index + 1}`}
                     />
                     <Button

--- a/docs/src/content/docs/sdk/oauth.md
+++ b/docs/src/content/docs/sdk/oauth.md
@@ -76,13 +76,25 @@ const result = await client.admin.oauth.providers.createProvider({
   enabled: true,
   client_id: process.env.GITHUB_CLIENT_ID!,
   client_secret: process.env.GITHUB_CLIENT_SECRET!,
-  redirect_url: 'https://yourapp.com/auth/callback',
+  redirect_urls: [
+    'https://yourapp.com/auth/callback', // web callback (default)
+    'wayli://oauth/callback' // mobile app deep link (optional)
+  ],
   scopes: ['user:email', 'read:user'],
   is_custom: false
 })
 
 console.log('Provider created:', result.id)
 ```
+
+#### Redirect URLs
+
+`redirect_urls` is the allowlist of OAuth callback URLs. Entries may be absolute
+`http`/`https` URLs or private-use app schemes for native apps (RFC 8252), such
+as `myapp://oauth/callback`. The first entry is the default used when no
+`redirect_uri` is passed to the authorize endpoint; any `redirect_uri` passed at
+runtime must exactly match one of the configured entries. The legacy singular
+`redirect_url` field is deprecated and treated as a single-element list.
 
 #### Built-in Provider Names
 
@@ -189,9 +201,9 @@ await client.admin.oauth.providers.updateProvider('provider-id', {
   scopes: ['user:email', 'read:user', 'read:org']
 })
 
-// Update redirect URL
+// Update redirect URLs
 await client.admin.oauth.providers.updateProvider('provider-id', {
-  redirect_url: 'https://newdomain.com/auth/callback'
+  redirect_urls: ['https://newdomain.com/auth/callback', 'myapp://oauth/callback']
 })
 
 // Rotate credentials

--- a/internal/api/oauth_provider_handler_test.go
+++ b/internal/api/oauth_provider_handler_test.go
@@ -731,7 +731,7 @@ func TestCreateOAuthProvider_RedirectURLs(t *testing.T) {
 		assert.Contains(t, result["error"], "empty")
 	})
 
-	t.Run("non-http scheme in redirect_urls", func(t *testing.T) {
+	t.Run("dangerous scheme in redirect_urls", func(t *testing.T) {
 		resp, result := postProvider(t, `{
 			"provider_name": "google",
 			"display_name": "Google",
@@ -741,7 +741,20 @@ func TestCreateOAuthProvider_RedirectURLs(t *testing.T) {
 		}`)
 
 		assert.Equal(t, fiber.StatusBadRequest, resp.StatusCode)
-		assert.Contains(t, result["error"], "absolute http/https URL")
+		assert.Contains(t, result["error"], "not allowed")
+	})
+
+	t.Run("private-use app scheme in redirect_urls", func(t *testing.T) {
+		resp, _ := postProvider(t, `{
+			"provider_name": "google",
+			"display_name": "Google",
+			"client_id": "id",
+			"client_secret": "secret",
+			"redirect_urls": ["https://app.example.com/cb", "wayli://oauth/callback"]
+		}`)
+
+		// Validation passed; request proceeds to DB (nil here) which returns 503
+		assert.Equal(t, fiber.StatusServiceUnavailable, resp.StatusCode)
 	})
 }
 

--- a/internal/api/oauth_redirect_urls.go
+++ b/internal/api/oauth_redirect_urls.go
@@ -11,8 +11,32 @@ import (
 // maxRedirectURLs caps how many redirect URLs a single OAuth provider may configure.
 const maxRedirectURLs = 50
 
+// forbiddenRedirectSchemes lists schemes that must never appear in a redirect
+// URL allowlist. Web schemes (http/https) are validated separately; any other
+// scheme is treated as a private-use app scheme (RFC 8252, e.g.
+// "wayli://oauth/callback") and allowed unless listed here. This is safe
+// because authorize/callback enforce an exact-string match against the
+// stored allowlist, so entries only redirect where an admin explicitly
+// configured.
+var forbiddenRedirectSchemes = map[string]bool{
+	"javascript": true,
+	"data":       true,
+	"file":       true,
+	"blob":       true,
+	"vbscript":   true,
+	"ftp":        true,
+	"ftps":       true,
+	"ws":         true,
+	"wss":        true,
+	"mailto":     true,
+	"urn":        true,
+	"about":      true,
+	"intent":     true,
+}
+
 // normalizeRedirectURLs validates and normalizes a redirect URL list for storage.
-// Entries are trimmed, must be absolute http/https URLs, duplicates are removed
+// Entries are trimmed, must be absolute http/https URLs or private-use app
+// schemes (RFC 8252, e.g. "wayli://oauth/callback"), duplicates are removed
 // (order preserved), and the list is capped at maxRedirectURLs entries.
 func normalizeRedirectURLs(urls []string) ([]string, error) {
 	if len(urls) > maxRedirectURLs {
@@ -26,11 +50,22 @@ func normalizeRedirectURLs(urls []string) ([]string, error) {
 			return nil, fmt.Errorf("redirect URLs cannot contain empty entries")
 		}
 		parsed, err := url.Parse(u)
-		if err != nil || parsed.Host == "" {
-			return nil, fmt.Errorf("invalid redirect URL '%s': must be an absolute http/https URL", u)
+		if err != nil || parsed.Scheme == "" {
+			return nil, fmt.Errorf("invalid redirect URL '%s': must be an absolute http/https URL or app scheme URI", u)
 		}
-		if parsed.Scheme != "http" && parsed.Scheme != "https" {
-			return nil, fmt.Errorf("invalid redirect URL '%s': scheme must be http or https", u)
+		scheme := strings.ToLower(parsed.Scheme)
+		if scheme == "http" || scheme == "https" {
+			if parsed.Host == "" {
+				return nil, fmt.Errorf("invalid redirect URL '%s': http/https URLs must include a host", u)
+			}
+		} else {
+			if forbiddenRedirectSchemes[scheme] {
+				return nil, fmt.Errorf("invalid redirect URL '%s': scheme '%s' is not allowed", u, parsed.Scheme)
+			}
+			// Reject scheme-only URIs with nothing to match against (e.g. "wayli:")
+			if parsed.Host == "" && parsed.Opaque == "" && parsed.Path == "" {
+				return nil, fmt.Errorf("invalid redirect URL '%s': app scheme URIs must include a host or path", u)
+			}
 		}
 		if !seen[u] {
 			seen[u] = true

--- a/internal/api/oauth_redirect_urls_test.go
+++ b/internal/api/oauth_redirect_urls_test.go
@@ -48,10 +48,47 @@ func TestNormalizeRedirectURLs(t *testing.T) {
 		assert.Contains(t, err.Error(), "absolute")
 	})
 
-	t.Run("rejects non-http schemes", func(t *testing.T) {
-		_, err := normalizeRedirectURLs([]string{"ftp://app.example.com/callback"})
+	t.Run("rejects scheme-less URLs", func(t *testing.T) {
+		_, err := normalizeRedirectURLs([]string{"app.example.com/callback"})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "scheme")
+		assert.Contains(t, err.Error(), "absolute")
+	})
+
+	t.Run("rejects http/https URLs without a host", func(t *testing.T) {
+		_, err := normalizeRedirectURLs([]string{"https:/callback"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host")
+	})
+
+	t.Run("allows private-use app schemes", func(t *testing.T) {
+		urls, err := normalizeRedirectURLs([]string{"wayli://oauth/callback"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"wayli://oauth/callback"}, urls)
+	})
+
+	t.Run("allows private-use schemes without an authority", func(t *testing.T) {
+		urls, err := normalizeRedirectURLs([]string{"com.example.app:/oauth2redirect"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"com.example.app:/oauth2redirect"}, urls)
+	})
+
+	t.Run("rejects scheme-only app URIs", func(t *testing.T) {
+		_, err := normalizeRedirectURLs([]string{"wayli:"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host or path")
+	})
+
+	t.Run("rejects dangerous and non-redirect schemes", func(t *testing.T) {
+		for _, u := range []string{
+			"javascript:alert(1)",
+			"data:text/html;base64,PHNjcmlwdD4=",
+			"ftp://app.example.com/callback",
+			"mailto:admin@example.com",
+		} {
+			_, err := normalizeRedirectURLs([]string{u})
+			require.Error(t, err, "expected %q to be rejected", u)
+			assert.Contains(t, err.Error(), "not allowed")
+		}
 	})
 
 	t.Run("rejects malformed URLs", func(t *testing.T) {
@@ -95,6 +132,12 @@ func TestMatchRedirectURL(t *testing.T) {
 
 	t.Run("empty candidate means no override and matches", func(t *testing.T) {
 		assert.True(t, matchRedirectURL(allowlist, "", baseURL))
+	})
+
+	t.Run("deep link exact match", func(t *testing.T) {
+		withDeepLink := append(allowlist, "wayli://oauth/callback")
+		assert.True(t, matchRedirectURL(withDeepLink, "wayli://oauth/callback", baseURL))
+		assert.False(t, matchRedirectURL(withDeepLink, "wayli://other", baseURL))
 	})
 
 	t.Run("empty allowlist rejects any override", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #331. Providers configured via the admin API could only store `http`/`https` redirect URLs, so native-app OAuth flows using deep-link callbacks (e.g. `wayli://oauth/callback`, RFC 8252) were impossible. This PR accepts private-use app schemes in the `redirect_urls` allowlist.

## Changes

- `normalizeRedirectURLs` (`internal/api/oauth_redirect_urls.go`):
  - `http`/`https` entries are unchanged — still require a host.
  - Any other scheme is treated as a private-use app scheme and accepted unless it is in a blocklist of dangerous/well-known non-redirect schemes (`javascript`, `data`, `file`, `blob`, `vbscript`, `ftp`, `ftps`, `ws`, `wss`, `mailto`, `urn`, `about`, `intent`).
  - App-scheme entries must carry a host or path (rejects a bare `wayli:`).
- Security is unchanged: the authorize and callback handlers already enforce **exact-string matching** of the runtime `redirect_uri` against this admin-configured allowlist, so entries can only redirect where an admin explicitly configured.
- Tests: replaced the old "rejects non-http schemes" unit test with coverage for deep-link acceptance (`wayli://oauth/callback`, `com.example.app:/oauth2redirect`), dangerous-scheme rejection, and a `matchRedirectURL` deep-link case; updated the handler-level validation test and added a deep-link acceptance case.
- Docs: `redirect_urls` section in the SDK OAuth guide (web URLs + app schemes, first entry = default, exact-match rule, deprecated singular field), dashboard helper text and placeholders now mention app schemes.

## Examples

```ts
await client.admin.oauth.providers.createProvider({
  provider_name: 'google',
  /* ... */
  redirect_urls: [
    'https://yourapp.com/auth/callback', // web callback (default)
    'wayli://oauth/callback'             // mobile app deep link
  ]
})
```

## Testing

- `go test ./internal/api/ -run 'RedirectURL|OAuthProvider_Validation|CreateOAuthProvider' -count=1` ✅
- `golangci-lint run ./internal/api/` — 0 issues ✅
- `cd admin && bun run type-check` ✅