### PR TITLE
fix(helm): set DENO_DIR on the server so deno's cache stays on the deno-cache volume

### DIFF
--- a/deploy/helm/fluxbase/templates/deployment.yaml
+++ b/deploy/helm/fluxbase/templates/deployment.yaml
@@ -672,6 +672,10 @@ spec:
             - name: FLUXBASE_DENO_JSR_REGISTRY
               value: {{ .Values.config.deno.jsr_registry | quote }}
             {{- end }}
+            {{- if .Values.config.deno.cache_dir }}
+            - name: DENO_DIR
+              value: {{ .Values.config.deno.cache_dir | quote }}
+            {{- end }}
 
             # ===========================================
             # Jobs Configuration

--- a/deploy/helm/fluxbase/values.yaml
+++ b/deploy/helm/fluxbase/values.yaml
@@ -429,10 +429,12 @@ config:
   ## Deno Runtime configuration (for edge functions and background jobs)
   ## @param config.deno.npm_registry Custom npm registry URL (air-gapped environments)
   ## @param config.deno.jsr_registry Custom JSR registry URL (air-gapped environments)
+  ## @param config.deno.cache_dir Deno cache directory (DENO_DIR). Keep it inside the deno-cache volume mount (/.cache) so runtime npm downloads — e.g. the esbuild binary fetched when bundling edge functions — stay off the container's writable layer.
   ##
   deno:
     npm_registry: ""  # e.g., "https://npm.your-company.com/"
     jsr_registry: ""  # e.g., "https://jsr.your-company.com/"
+    cache_dir: /.cache/deno
 
   ## Background Jobs configuration
   ## @param config.jobs.enabled Enable background jobs


### PR DESCRIPTION
## Problem

The server-side function bundler (`internal/functions/bundler.go`) spawns `deno` to bundle edge functions when they are deployed via the dashboard/API. When `DENO_DIR` is unset it defaults to `/tmp/deno` — which is **not** covered by the `deno-cache` emptyDir the chart mounts at `/.cache`. Runtime npm downloads — notably the esbuild binary deno fetches for bundling — land on the container's writable layer, and executing them trips Falco's *"Drop and execute new binary in container"* (`proc.is_exe_upper_layer`) at Critical. Observed on the wayli deployment's sync init container (same bundler default, `cli/bundler/bundler.go`); this PR fixes the server-side variant of the same gap.

## Change

- New `config.deno.cache_dir` value, default `/.cache/deno` (inside the existing volume mount), documented with a `@param` annotation.
- Rendered unconditionally-as-configured as `DENO_DIR` env on the main container, next to the existing `FLUXBASE_DENO_*` env.

Behavior matrix (all verified with `helm template`):

| Setting | Result |
| --- | --- |
| default | `DENO_DIR=/.cache/deno` — cache on the volume |
| `config.deno.cache_dir=/custom/path` | `DENO_DIR=/custom/path` |
| `config.deno.cache_dir=""` | no `DENO_DIR` env — previous behavior (opt-out) |
| `extraEnvVars` with `DENO_DIR` | user value wins — it renders after the built-in env and Kubernetes takes the last occurrence, so existing workarounds keep working |

## Notes

- `internal/runtime/env.go` hard-codes `DENO_DIR=/tmp/deno` for user-code execution. Bundles are self-contained, so nothing is downloaded at exec time; if that ever changes it needs a Go-side follow-up (honoring an env override).
- Full-render diff against `main` shows only the new env entry (plus render-time random secrets/checksums, which churn on every render).