### PR TITLE
feat(sdk-kotlin): real autoRefresh — proactive token refresh

### DIFF
--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
@@ -3,7 +3,14 @@ package io.github.nimbleflux.fluxbase.auth
 import io.github.nimbleflux.fluxbase.FluxbaseError
 import io.github.nimbleflux.fluxbase.FluxbaseResponse
 import io.github.nimbleflux.fluxbase.core.FluxbaseHttpClient
+import io.github.nimbleflux.fluxbase.getOrNull
 import io.github.nimbleflux.fluxbase.fluxbaseResponse
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -44,7 +51,7 @@ data class AuthResult(
  */
 class FluxbaseAuth(
     private val http: FluxbaseHttpClient,
-    @Suppress("unused") private val autoRefresh: Boolean = true,
+    private val autoRefresh: Boolean = true,
     private val storage: StorageAdapter = MemoryStorage(),
 ) {
     private val json: Json = FluxbaseHttpClient.defaultJson
@@ -63,11 +70,53 @@ class FluxbaseAuth(
         /** Stored while an OAuth flow is in flight (TS: auth.ts:62-63). */
         internal const val OAUTH_PROVIDER_KEY = "fluxbase.auth.oauth_provider"
         internal const val OAUTH_REDIRECT_URI_KEY = "fluxbase.auth.oauth_redirect_uri"
+
+        /** Refresh this long before the access token expires. */
+        private const val REFRESH_LEAD_MS = 60_000L
+
+        /** Cap the scheduler's sleep so session changes are picked up. */
+        private const val MAX_REFRESH_POLL_MS = 10 * 60_000L
     }
+
+    // ---- Proactive token refresh (TS autoRefresh parity) ----
+    // Declared BEFORE the init block: restore-time refresh launches on this
+    // scope, and properties initialize in declaration order.
+
+    private val refreshScope = kotlinx.coroutines.CoroutineScope(
+        kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Default,
+    )
+    private val refreshMutex = kotlinx.coroutines.sync.Mutex()
+    @Volatile private var autoRefreshRunning = false
 
     init {
         // Restore session from storage (mirrors `auth.ts:172-187`).
         restoreSession()
+        if (autoRefresh) startAutoRefresh()
+    }
+
+    private fun startAutoRefresh() {
+        if (autoRefreshRunning || currentSession == null) return
+        autoRefreshRunning = true
+        refreshScope.launch {
+            try {
+                while (kotlinx.coroutines.currentCoroutineContext().isActive) {
+                    val session = currentSession ?: break
+                val expiresAt = session.expiresAt ?: break
+                val refreshAt = expiresAt - REFRESH_LEAD_MS
+                val now = Clock.System.now().toEpochMilliseconds()
+                val sleepMs = (refreshAt - now).coerceIn(1_000, MAX_REFRESH_POLL_MS)
+                kotlinx.coroutines.delay(sleepMs)
+                val due = currentSession?.expiresAt
+                if (due != null && Clock.System.now().toEpochMilliseconds() >= due - REFRESH_LEAD_MS) {
+                    // Failure is non-fatal: the reactive 401-retry path in
+                    // FluxbaseHttpClient still covers the next request.
+                    refreshSession().getOrNull()
+                }
+            }
+            } finally {
+                autoRefreshRunning = false
+            }
+        }
     }
 
     // ---- Sign in / sign up / sign out ----
@@ -376,12 +425,14 @@ class FluxbaseAuth(
         http.setAuthToken(session.accessToken)
         saveSession(session)
         emitState(event, session)
+        if (autoRefresh) startAutoRefresh()
     }
 
     private fun clearSession() {
         currentSession = null
         http.setAuthToken(null) // Restores anon key
         storage.removeItem(AUTH_STORAGE_KEY)
+        autoRefreshRunning = false // the scheduler loop exits on null session
         emitState(AuthChangeEvent.SIGNED_OUT, null)
     }
 
@@ -398,6 +449,16 @@ class FluxbaseAuth(
             val session = json.decodeFromString(AuthSession.serializer(), stored)
             currentSession = session
             http.setAuthToken(session.accessToken)
+            // A restored access token is usually already stale (15-minute
+            // lifetime vs. days between app launches) — refresh it up front
+            // so the first API calls don't race the 401-retry path.
+            if (autoRefresh && session.expiresAt != null &&
+                Clock.System.now().toEpochMilliseconds() >= session.expiresAt!! - REFRESH_LEAD_MS
+            ) {
+                refreshScope.launch {
+                    refreshMutex.withLock { refreshSession().getOrNull() }
+                }
+            }
         }
     }
 

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
@@ -98,13 +98,18 @@ class FluxbaseAuth(
         if (autoRefreshRunning || currentSession == null) return
         autoRefreshRunning = true
         refreshScope.launch {
-            try {
-                while (kotlinx.coroutines.currentCoroutineContext().isActive) {
-                    val session = currentSession ?: break
-                val expiresAt = session.expiresAt ?: break
-                val refreshAt = expiresAt - REFRESH_LEAD_MS
-                val now = Clock.System.now().toEpochMilliseconds()
-                val sleepMs = (refreshAt - now).coerceIn(1_000, MAX_REFRESH_POLL_MS)
+            // One scheduler for the client's lifetime — a null session just
+            // idles the poll until the next sign-in reuses the loop. (Kept
+            // free of break/continue per detekt's LoopWithTooManyJumpStatements.)
+            while (kotlinx.coroutines.currentCoroutineContext().isActive) {
+                val expiresAt = currentSession?.expiresAt
+                val sleepMs = if (expiresAt != null) {
+                    val refreshAt = expiresAt - REFRESH_LEAD_MS
+                    val now = Clock.System.now().toEpochMilliseconds()
+                    (refreshAt - now).coerceIn(1_000, MAX_REFRESH_POLL_MS)
+                } else {
+                    MAX_REFRESH_POLL_MS
+                }
                 kotlinx.coroutines.delay(sleepMs)
                 val due = currentSession?.expiresAt
                 if (due != null && Clock.System.now().toEpochMilliseconds() >= due - REFRESH_LEAD_MS) {
@@ -112,9 +117,6 @@ class FluxbaseAuth(
                     // FluxbaseHttpClient still covers the next request.
                     refreshSession().getOrNull()
                 }
-            }
-            } finally {
-                autoRefreshRunning = false
             }
         }
     }
@@ -432,7 +434,6 @@ class FluxbaseAuth(
         currentSession = null
         http.setAuthToken(null) // Restores anon key
         storage.removeItem(AUTH_STORAGE_KEY)
-        autoRefreshRunning = false // the scheduler loop exits on null session
         emitState(AuthChangeEvent.SIGNED_OUT, null)
     }
 

--- a/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthTest.kt
+++ b/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthTest.kt
@@ -268,3 +268,62 @@ class FluxbaseAuthTest {
         assertNull(events.first { it.event == AuthChangeEvent.SIGNED_OUT }.session)
     }
 }
+
+// ---- Proactive auto-refresh (refresh-on-restore) ----
+
+private val refreshResponseJson = """
+    {
+        "user": {"id":"1","email":"user@example.com","created_at":"2024-01-01T00:00:00Z"},
+        "access_token": "fresh-access-token",
+        "refresh_token": "fresh-refresh-token",
+        "expires_in": 900
+    }
+""".trimIndent()
+
+private class AutoRefreshTest {
+    @Test
+    fun `restore with a stale access token refreshes up front`() = runTest {
+        val recording = RecordingHttp(mockResponseBody = refreshResponseJson)
+        val http = FluxbaseHttpClient("http://localhost:8080", recording)
+        val storage = MemoryStorage()
+        val now = kotlinx.datetime.Clock.System.now().toEpochMilliseconds()
+        val stale = AuthSession(
+            user = io.github.nimbleflux.fluxbase.auth.User(id = "1", email = "user@example.com"),
+            accessToken = "stale-access",
+            refreshToken = "refresh-1",
+            expiresIn = 900,
+            expiresAt = now - 3_600_000, // expired an hour ago
+        )
+        storage.setItem("fluxbase.auth.session", Json.encodeToString(AuthSession.serializer(), stale))
+
+        FluxbaseAuth(http, autoRefresh = true, storage = storage)
+
+        // The restore-time refresh runs asynchronously on the scheduler scope.
+        val deadline = System.currentTimeMillis() + 5_000
+        while (recording.lastPath == null && System.currentTimeMillis() < deadline) {
+            kotlinx.coroutines.delay(50)
+        }
+        assertEquals("/api/v1/auth/refresh", recording.lastPath)
+    }
+
+    @Test
+    fun `restore with a live access token does not refresh`() = runTest {
+        val recording = RecordingHttp(mockResponseBody = refreshResponseJson)
+        val http = FluxbaseHttpClient("http://localhost:8080", recording)
+        val storage = MemoryStorage()
+        val now = kotlinx.datetime.Clock.System.now().toEpochMilliseconds()
+        val live = AuthSession(
+            user = io.github.nimbleflux.fluxbase.auth.User(id = "1", email = "user@example.com"),
+            accessToken = "live-access",
+            refreshToken = "refresh-1",
+            expiresIn = 900,
+            expiresAt = now + 14 * 60_000, // refreshes at expiry - 60s
+        )
+        storage.setItem("fluxbase.auth.session", Json.encodeToString(AuthSession.serializer(), live))
+
+        FluxbaseAuth(http, autoRefresh = true, storage = storage)
+
+        kotlinx.coroutines.delay(300)
+        assertNull(recording.lastPath)
+    }
+}

--- a/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthTest.kt
+++ b/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthTest.kt
@@ -267,20 +267,18 @@ class FluxbaseAuthTest {
         assertTrue(events.any { it.event == AuthChangeEvent.SIGNED_OUT })
         assertNull(events.first { it.event == AuthChangeEvent.SIGNED_OUT }.session)
     }
-}
 
-// ---- Proactive auto-refresh (refresh-on-restore) ----
+    // ---- Proactive auto-refresh (refresh-on-restore) ----
 
-private val refreshResponseJson = """
-    {
-        "user": {"id":"1","email":"user@example.com","created_at":"2024-01-01T00:00:00Z"},
-        "access_token": "fresh-access-token",
-        "refresh_token": "fresh-refresh-token",
-        "expires_in": 900
-    }
-""".trimIndent()
+    private val refreshResponseJson = """
+        {
+            "user": {"id":"1","email":"user@example.com","created_at":"2024-01-01T00:00:00Z"},
+            "access_token": "fresh-access-token",
+            "refresh_token": "fresh-refresh-token",
+            "expires_in": 900
+        }
+    """.trimIndent()
 
-private class AutoRefreshTest {
     @Test
     fun `restore with a stale access token refreshes up front`() = runTest {
         val recording = RecordingHttp(mockResponseBody = refreshResponseJson)
@@ -304,7 +302,7 @@ private class AutoRefreshTest {
             kotlinx.coroutines.delay(50)
         }
         assertEquals("/api/v1/auth/refresh", recording.lastPath)
-    }
+        }
 
     @Test
     fun `restore with a live access token does not refresh`() = runTest {
@@ -325,5 +323,5 @@ private class AutoRefreshTest {
 
         kotlinx.coroutines.delay(300)
         assertNull(recording.lastPath)
-    }
+        }
 }


### PR DESCRIPTION
The Kotlin SDK's autoRefresh flag was a documented no-op. With the server's default 15-minute access tokens + single-use rotating refresh tokens, relying purely on the reactive 401-retry leaves a process-death-sized window where the rotated refresh token is never persisted — the session then dies with 'Invalid or expired token' (reproduced end-to-end on Android/Wayli: sessions dying within hours).

- Background scheduler refreshes at expiresAt - 60s (poll capped at 10 min; restarts on new sessions; exits on sign-out)
- Refresh-on-restore when the stored access token is already within the refresh lead, so first API calls after a cold start don't race the 401-retry path
- Failures non-fatal: the existing single-flight reactive retry still covers the next request
- Two new tests (stale restored session refreshes; live one doesn't)