### PR TITLE
feat(auth): default refresh token lifetime 7d → 90d (sliding)

### DIFF
--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -63,7 +63,10 @@ func setDefaults() {
 	// Auth defaults
 	viper.SetDefault("auth.jwt_secret", "your-secret-key-change-in-production")
 	viper.SetDefault("auth.jwt_expiry", "15m")
-	viper.SetDefault("auth.refresh_expiry", "168h")  // 7 days in hours
+	// 90 days: refresh tokens ROTATE on every refresh, so this is a sliding
+	// session window — mobile clients expect to reopen after weeks and stay
+	// signed in. 7 days logged users out over a vacation-length absence.
+	viper.SetDefault("auth.refresh_expiry", "2160h")
 	viper.SetDefault("auth.service_role_ttl", "24h") // Service role tokens: 24 hours (was 365 days)
 	viper.SetDefault("auth.anon_ttl", "24h")         // Anonymous tokens: 24 hours (was 365 days)
 	viper.SetDefault("auth.magic_link_expiry", "15m")


### PR DESCRIPTION
Refresh tokens rotate on every refresh, so the lifetime is effectively a **sliding session window**: any use renews it. The 7-day default logged mobile clients out over a vacation-length absence — reopening after a couple of weeks hit an expired refresh token and forced a full re-login (paired fix: nimbleflux/fluxbase#335 makes the Kotlin SDK refresh proactively and on restore).

- `auth.refresh_expiry` default: 168h → 2160h (90 days)
- 90 days is the common mobile-session norm (Auth0/Okta territory); the rotation-on-use keeps the effective window sliding rather than absolute
- Deployments that prefer the stricter window set `auth.refresh_expiry` explicitly — validation and all existing tests pass explicit values, nothing asserts the default