### PR TITLE
fix(sdk-kotlin): single-flight refreshSession — concurrent refreshes bricked sessions

### DIFF
--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
@@ -316,21 +316,38 @@ class FluxbaseAuth(
      */
     suspend fun refreshSession(): FluxbaseResponse<AuthSession> =
         fluxbaseResponse {
-            val current = currentSession ?: return@fluxbaseResponse throw FluxbaseError(message = "No active session")
-            val body = mapOf("refresh_token" to current.refreshToken)
-            // Bypass the 401-retry path so a refresh whose own token is expired
-            // can't recurse into another refresh.
-            val responseText = http.postWithoutRetry("/api/v1/auth/refresh", body).body
-            val authResponse = json.decodeFromString(AuthResponse.serializer(), responseText)
-            val session = AuthSession(
-                user = authResponse.user,
-                accessToken = authResponse.accessToken,
-                refreshToken = authResponse.refreshToken,
-                expiresIn = authResponse.expiresIn,
-                expiresAt = Clock.System.now().toEpochMilliseconds() + authResponse.expiresIn * 1000,
-            )
-            setSessionInternal(session, AuthChangeEvent.TOKEN_REFRESHED)
-            session
+            val requestedRefreshToken = currentSession?.refreshToken
+                ?: return@fluxbaseResponse throw FluxbaseError(message = "No active session")
+            // Single-flight: every caller (the autoRefresh scheduler, the
+            // restore-time refresh, and the HTTP client's reactive 401-retry)
+            // funnels through this lock. Concurrent refreshes with the same
+            // token otherwise race the server's rotation — the loser's
+            // persisted refresh token stops matching the stored hash and the
+            // whole session bricks ("possible token theft" server-side).
+            refreshMutex.withLock {
+                // A sibling refreshed while we waited for the lock: its tokens
+                // are already current — return them instead of refreshing
+                // again with the now-rotated token.
+                currentSession?.let { live ->
+                    if (live.refreshToken != requestedRefreshToken) {
+                        return@fluxbaseResponse live
+                    }
+                }
+                val body = mapOf("refresh_token" to requestedRefreshToken)
+                // Bypass the 401-retry path so a refresh whose own token is expired
+                // can't recurse into another refresh.
+                val responseText = http.postWithoutRetry("/api/v1/auth/refresh", body).body
+                val authResponse = json.decodeFromString(AuthResponse.serializer(), responseText)
+                val session = AuthSession(
+                    user = authResponse.user,
+                    accessToken = authResponse.accessToken,
+                    refreshToken = authResponse.refreshToken,
+                    expiresIn = authResponse.expiresIn,
+                    expiresAt = Clock.System.now().toEpochMilliseconds() + authResponse.expiresIn * 1000,
+                )
+                setSessionInternal(session, AuthChangeEvent.TOKEN_REFRESHED)
+                session
+            }
         }
 
     /**
@@ -456,9 +473,7 @@ class FluxbaseAuth(
             if (autoRefresh && session.expiresAt != null &&
                 Clock.System.now().toEpochMilliseconds() >= session.expiresAt!! - REFRESH_LEAD_MS
             ) {
-                refreshScope.launch {
-                    refreshMutex.withLock { refreshSession().getOrNull() }
-                }
+                refreshScope.launch { refreshSession().getOrNull() }
             }
         }
     }

--- a/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthTest.kt
+++ b/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuthTest.kt
@@ -2,6 +2,9 @@ package io.github.nimbleflux.fluxbase.auth
 
 import io.github.nimbleflux.fluxbase.core.FluxbaseHttpClient
 import io.github.nimbleflux.fluxbase.core.test.RecordingHttp
+import io.github.nimbleflux.fluxbase.getOrNull
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
@@ -303,6 +306,49 @@ class FluxbaseAuthTest {
         }
         assertEquals("/api/v1/auth/refresh", recording.lastPath)
         }
+
+    @Test
+    fun `concurrent refreshes single-flight — one wire call, both get fresh tokens`() = runTest {
+        val recording = RecordingHttp()
+        recording.queueResponse(body = signInResponseJson)
+
+        val firstRefreshGate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        var refreshWireCalls = 0
+        val gated = object : io.github.nimbleflux.fluxbase.core.HttpTransport by recording {
+            override suspend fun request(
+                method: io.github.nimbleflux.fluxbase.core.HttpMethod,
+                path: String,
+                body: Any?,
+                headers: Map<String, String>,
+            ): io.github.nimbleflux.fluxbase.core.HttpResponse {
+                if (path.contains("/auth/refresh")) {
+                    refreshWireCalls++
+                    if (refreshWireCalls == 1) firstRefreshGate.await() // hold the first mid-flight
+                }
+                return recording.request(method, path, body, headers)
+            }
+        }
+        val http = FluxbaseHttpClient("http://localhost:8080", gated)
+        val auth = FluxbaseAuth(http, autoRefresh = false)
+        auth.signIn("user@example.com", "password123")
+
+        // Exactly ONE refresh response queued: a second wire call would fail
+        // to decode the default "[]" body and surface as an error.
+        recording.queueResponse(body = refreshResponseJson)
+
+        val results: Pair<AuthSession?, AuthSession?> = kotlinx.coroutines.coroutineScope {
+            val first = async { auth.refreshSession() }
+            val second = async { auth.refreshSession() } // piles onto the mutex while the first is mid-flight
+            launch { firstRefreshGate.complete(Unit) }
+            first.await().getOrNull() to second.await().getOrNull()
+        }
+
+        assertEquals(1, refreshWireCalls)
+        assertNotNull(results.first)
+        assertNotNull(results.second)
+        assertEquals(results.first?.refreshToken, results.second?.refreshToken)
+        assertEquals("fresh-refresh-token", auth.currentSession?.refreshToken)
+    }
 
     @Test
     fun `restore with a live access token does not refresh`() = runTest {


### PR DESCRIPTION
Follow-up to #335 (shipped in 2026.8.13). The autoRefresh scheduler/restore path and the HTTP client's reactive 401-retry could both call `refreshSession` concurrently with the **same** refresh token. The server rotates the stored token hash on every refresh (last-write-wins `UpdateTokens`), so the loser's response leaves the SDK persisting a refresh token that no longer matches the session — the next refresh hits `possible token theft` and the session is dead.

With the default 15-minute access tokens this raced on virtually every cold start (stale restored token → restore-refresh races the first API call's 401-retry) — reproduced repeatedly on Android/Wayli today: fresh sessions dying within an hour.

**Fix:** `refreshSession` funnels every caller through one mutex and, once the lock is held, re-checks whether a sibling already rotated the token — returning the current session instead of refreshing again. Regression test holds the first refresh mid-flight behind a gate and asserts the concurrent caller makes **zero** additional wire calls while still receiving the fresh session.