### PR TITLE
fix(auth): CAS session token rotation + refresh cookie follows auth.refresh_expiry

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -107,12 +107,18 @@ func (h *AuthHandler) setAuthCookies(c fiber.Ctx, accessToken, refreshToken stri
 		SameSite: "Lax",
 	})
 
-	// Refresh token cookie - longer expiry (7 days default)
+	// Refresh token cookie - aligned with auth.refresh_expiry (the same
+	// lifetime the server slides on every refresh); fall back to 7 days if
+	// unset so the cookie can never outlive (or cut short) the session.
+	refreshMaxAge := 7 * 24 * 60 * 60
+	if h.authService != nil && h.authService.RefreshExpiry() > 0 {
+		refreshMaxAge = int(h.authService.RefreshExpiry().Seconds())
+	}
 	c.Cookie(&fiber.Cookie{
 		Name:     RefreshTokenCookieName,
 		Value:    refreshToken,
-		Path:     "/api/v1/auth",   // Only sent to auth endpoints
-		MaxAge:   7 * 24 * 60 * 60, // 7 days
+		Path:     "/api/v1/auth", // Only sent to auth endpoints
+		MaxAge:   refreshMaxAge,
 		Secure:   h.secureCookie,
 		HTTPOnly: true,
 		SameSite: "Strict",

--- a/internal/auth/interfaces.go
+++ b/internal/auth/interfaces.go
@@ -91,8 +91,11 @@ type SessionRepositoryInterface interface {
 	// GetByUserID retrieves all sessions for a user
 	GetByUserID(ctx context.Context, userID string) ([]*Session, error)
 
-	// UpdateTokens updates the tokens and expiry for a session
-	UpdateTokens(ctx context.Context, id, accessToken, refreshToken string, expiresAt time.Time) error
+	// UpdateTokens rotates the tokens and expiry for a session.
+	// Compare-and-swap: it only applies while the stored refresh-token hash
+	// still matches expectedRefreshToken; otherwise ErrRefreshTokenRotated.
+	// Note: Tokens should be hashed before storage
+	UpdateTokens(ctx context.Context, id, expectedRefreshToken, accessToken, refreshToken string, expiresAt time.Time) error
 
 	// Delete removes a session by ID
 	Delete(ctx context.Context, id string) error

--- a/internal/auth/mock_repositories.go
+++ b/internal/auth/mock_repositories.go
@@ -375,13 +375,18 @@ func (m *MockSessionRepository) GetByUserID(ctx context.Context, userID string) 
 	return activeSessions, nil
 }
 
-func (m *MockSessionRepository) UpdateTokens(ctx context.Context, id, accessToken, refreshToken string, expiresAt time.Time) error {
+func (m *MockSessionRepository) UpdateTokens(ctx context.Context, id, expectedRefreshToken, accessToken, refreshToken string, expiresAt time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	session, exists := m.sessions[id]
 	if !exists {
 		return ErrSessionNotFound
+	}
+
+	// Compare-and-swap: reject a refresh token that was already rotated.
+	if session.RefreshToken != expectedRefreshToken {
+		return ErrRefreshTokenRotated
 	}
 
 	// Remove old token mappings

--- a/internal/auth/mock_repositories_test.go
+++ b/internal/auth/mock_repositories_test.go
@@ -195,7 +195,7 @@ func TestMockSessionRepository_UpdateTokens(t *testing.T) {
 	newRefresh := "new-refresh"
 	newExpiry := time.Now().Add(2 * time.Hour)
 
-	err := repo.UpdateTokens(ctx, session.ID, newAccess, newRefresh, newExpiry)
+	err := repo.UpdateTokens(ctx, session.ID, "old-refresh", newAccess, newRefresh, newExpiry)
 	if err != nil {
 		t.Fatalf("UpdateTokens failed: %v", err)
 	}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -51,6 +51,13 @@ func (s *Service) SetEncryptionKey(key []byte) {
 	}
 }
 
+// RefreshExpiry returns the configured refresh-token/session lifetime — the
+// same value RefreshToken uses to slide a session's expiry, so callers (e.g.
+// the web refresh-cookie MaxAge) stay consistent with the stored session.
+func (s *Service) RefreshExpiry() time.Duration {
+	return s.config.RefreshExpiry
+}
+
 // SetTOTPRateLimiter sets the TOTP rate limiter for protecting against brute force attacks
 func (s *Service) SetTOTPRateLimiter(limiter *TOTPRateLimiter) {
 	if s.mfaService != nil {
@@ -621,8 +628,20 @@ func (s *Service) RefreshToken(ctx context.Context, req RefreshTokenRequest) (*R
 	// Calculate new expiry (extend session)
 	newExpiresAt := time.Now().Add(s.config.RefreshExpiry)
 
-	// Update session with new tokens (rotation)
-	if err := s.sessionRepo.UpdateTokens(ctx, session.ID, newAccessToken, newRefreshToken, newExpiresAt); err != nil {
+	// Update session with new tokens (rotation). Compare-and-swap on the old
+	// refresh-token hash: if a concurrent refresh already rotated it, keep the
+	// winner's session intact instead of clobbering it with this (older) token.
+	if err := s.sessionRepo.UpdateTokens(ctx, session.ID, req.RefreshToken, newAccessToken, newRefreshToken, newExpiresAt); err != nil {
+		if errors.Is(err, ErrRefreshTokenRotated) {
+			// SECURITY: a valid refresh token replayed after rotation usually
+			// means either a racing client or a stolen token. The stored
+			// (rotated) credentials win; this request is rejected.
+			log.Warn().
+				Str("user_id", claims.UserID).
+				Str("session_id", claims.SessionID).
+				Msg("Refresh token already rotated - rejecting replayed refresh, existing session kept")
+			return nil, ErrSessionNotFound
+		}
 		return nil, fmt.Errorf("failed to update session: %w", err)
 	}
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -25,6 +25,9 @@ var (
 	ErrSessionNotFound = errors.New("session not found")
 	// ErrSessionExpired is returned when a session has expired
 	ErrSessionExpired = errors.New("session has expired")
+	// ErrRefreshTokenRotated is returned when a refresh token no longer matches
+	// the stored hash because a concurrent refresh already rotated it
+	ErrRefreshTokenRotated = errors.New("refresh token already rotated")
 )
 
 // Session represents a user session
@@ -215,9 +218,12 @@ func (r *SessionRepository) GetByUserID(ctx context.Context, userID string) ([]*
 	return sessions, err
 }
 
-// UpdateTokens updates the tokens for a session
-// SECURITY: Tokens are hashed before storage.
-func (r *SessionRepository) UpdateTokens(ctx context.Context, id, accessToken, refreshToken string, expiresAt time.Time) error {
+// UpdateTokens rotates the tokens for a session (compare-and-swap).
+// SECURITY: Tokens are hashed before storage. The update only applies when the
+// stored refresh-token hash still matches the caller's pre-rotation token, so
+// two racing refreshes can never clobber each other's rotated tokens — the
+// loser gets ErrRefreshTokenRotated while the winner's session stays valid.
+func (r *SessionRepository) UpdateTokens(ctx context.Context, id, expectedRefreshToken, accessToken, refreshToken string, expiresAt time.Time) error {
 	// Hash tokens before storage
 	accessTokenHash := hashToken(accessToken)
 	var refreshTokenHash *string
@@ -225,21 +231,24 @@ func (r *SessionRepository) UpdateTokens(ctx context.Context, id, accessToken, r
 		h := hashToken(refreshToken)
 		refreshTokenHash = &h
 	}
+	expectedRefreshTokenHash := hashToken(expectedRefreshToken)
 
 	query := `
 		UPDATE auth.sessions
-		SET access_token_hash = $2, refresh_token_hash = $3, expires_at = $4
-		WHERE id = $1
+		SET access_token_hash = $3, refresh_token_hash = $4, expires_at = $5
+		WHERE id = $1 AND refresh_token_hash = $2
 	`
 
 	return database.WrapWithServiceRole(ctx, r.db, func(tx pgx.Tx) error {
-		result, err := tx.Exec(ctx, query, id, accessTokenHash, refreshTokenHash, expiresAt)
+		result, err := tx.Exec(ctx, query, id, expectedRefreshTokenHash, accessTokenHash, refreshTokenHash, expiresAt)
 		if err != nil {
 			return err
 		}
 
 		if result.RowsAffected() == 0 {
-			return ErrSessionNotFound
+			// The session was just fetched by this refresh token, so a miss
+			// means the token was rotated (or the session deleted) meanwhile.
+			return ErrRefreshTokenRotated
 		}
 
 		return nil

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -185,7 +185,7 @@ func TestMockSessionRepository_UpdateTokens_WithValidation(t *testing.T) {
 
 	// Update tokens
 	newExpiry := time.Now().Add(2 * time.Hour)
-	err = repo.UpdateTokens(ctx, session.ID, "new-access", "new-refresh", newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, "old-refresh", "new-access", "new-refresh", newExpiry)
 	require.NoError(t, err)
 
 	// Verify old tokens no longer work
@@ -202,8 +202,31 @@ func TestMockSessionRepository_UpdateTokens_NotFound(t *testing.T) {
 	repo := NewMockSessionRepository()
 	ctx := context.Background()
 
-	err := repo.UpdateTokens(ctx, "nonexistent-id", "access", "refresh", time.Now().Add(time.Hour))
+	err := repo.UpdateTokens(ctx, "nonexistent-id", "old-refresh", "access", "refresh", time.Now().Add(time.Hour))
 
+	assert.ErrorIs(t, err, ErrSessionNotFound)
+}
+
+func TestMockSessionRepository_UpdateTokens_ReplayRejected(t *testing.T) {
+	repo := NewMockSessionRepository()
+	ctx := context.Background()
+
+	// A session whose refresh token has already been rotated once.
+	session, err := repo.Create(ctx, "user-123", "old-access", "old-refresh", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+	err = repo.UpdateTokens(ctx, session.ID, "old-refresh", "new-access", "new-refresh", time.Now().Add(2*time.Hour))
+	require.NoError(t, err)
+
+	// A replay of the pre-rotation token must be rejected…
+	err = repo.UpdateTokens(ctx, session.ID, "old-refresh", "replay-access", "replay-refresh", time.Now().Add(3*time.Hour))
+	assert.ErrorIs(t, err, ErrRefreshTokenRotated)
+
+	// …without clobbering the winner's rotated tokens.
+	retrieved, err := repo.GetByRefreshToken(ctx, "new-refresh")
+	require.NoError(t, err)
+	assert.Equal(t, session.ID, retrieved.ID)
+
+	_, err = repo.GetByAccessToken(ctx, "replay-access")
 	assert.ErrorIs(t, err, ErrSessionNotFound)
 }
 
@@ -544,7 +567,7 @@ func TestMockSessionRepository_UpdateTokens_NoRefreshToken(t *testing.T) {
 
 	// Update tokens with new refresh token
 	newExpiry := time.Now().Add(2 * time.Hour)
-	err = repo.UpdateTokens(ctx, session.ID, "new-access", "new-refresh", newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, "", "new-access", "new-refresh", newExpiry)
 	require.NoError(t, err)
 
 	// Verify new tokens work
@@ -563,7 +586,7 @@ func TestMockSessionRepository_UpdateTokens_ClearRefreshToken(t *testing.T) {
 
 	// Update to clear refresh token
 	newExpiry := time.Now().Add(2 * time.Hour)
-	err = repo.UpdateTokens(ctx, session.ID, "new-access", "", newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, "refresh-token", "new-access", "", newExpiry)
 	require.NoError(t, err)
 
 	// Verify session was updated
@@ -654,7 +677,7 @@ func TestMockSessionRepository_UpdateTokens_RotateRefreshToken(t *testing.T) {
 
 	// Simulate token rotation (generate new tokens)
 	newExpiry := time.Now().Add(2 * time.Hour)
-	err = repo.UpdateTokens(ctx, session.ID, "new-access", "new-refresh", newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, "old-refresh", "new-access", "new-refresh", newExpiry)
 	require.NoError(t, err)
 
 	// Verify old tokens are invalidated

--- a/internal/auth/session_workflow_test.go
+++ b/internal/auth/session_workflow_test.go
@@ -220,7 +220,7 @@ func TestRefreshSession_Success(t *testing.T) {
 	newRefreshToken := "new-refresh-token"
 	newExpiry := time.Now().Add(2 * time.Hour)
 
-	err = repo.UpdateTokens(ctx, session.ID, newAccessToken, newRefreshToken, newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, oldRefreshToken, newAccessToken, newRefreshToken, newExpiry)
 	require.NoError(t, err)
 
 	// Verify old tokens no longer work
@@ -248,7 +248,7 @@ func TestRefreshSession_Expired(t *testing.T) {
 	newRefreshToken := "new-refresh-token"
 	newExpiry := time.Now().Add(2 * time.Hour)
 
-	err = repo.UpdateTokens(ctx, session.ID, newAccessToken, newRefreshToken, newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, "expired-refresh", newAccessToken, newRefreshToken, newExpiry)
 	require.NoError(t, err)
 
 	// Verify session can still be refreshed even if expired
@@ -268,7 +268,7 @@ func TestRefreshSession_InvalidToken(t *testing.T) {
 	newRefreshToken := "new-refresh-token"
 	newExpiry := time.Now().Add(2 * time.Hour)
 
-	err := repo.UpdateTokens(ctx, "invalid-session-id", newAccessToken, newRefreshToken, newExpiry)
+	err := repo.UpdateTokens(ctx, "invalid-session-id", "old-refresh", newAccessToken, newRefreshToken, newExpiry)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrSessionNotFound)
@@ -293,7 +293,7 @@ func TestRefreshSession_RevokedSession(t *testing.T) {
 	newRefreshToken := "new-refresh-token"
 	newExpiry := time.Now().Add(2 * time.Hour)
 
-	err = repo.UpdateTokens(ctx, session.ID, newAccessToken, newRefreshToken, newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, "refresh-token", newAccessToken, newRefreshToken, newExpiry)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrSessionNotFound)
@@ -578,7 +578,7 @@ func TestSession_TokenRotation(t *testing.T) {
 	newExpiry := time.Now().Add(1 * time.Hour)
 
 	// Step 3: Update session with new tokens
-	err = repo.UpdateTokens(ctx, session.ID, newAccess, newRefresh, newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, oldRefresh, newAccess, newRefresh, newExpiry)
 	require.NoError(t, err)
 
 	// Step 4: Verify old tokens no longer work
@@ -660,7 +660,7 @@ func TestSession_Workflow_CompleteLifecycle(t *testing.T) {
 	newRefreshToken := "new-refresh-token"
 	newExpiry := time.Now().Add(2 * time.Hour)
 
-	err = repo.UpdateTokens(ctx, session.ID, newAccessToken, newRefreshToken, newExpiry)
+	err = repo.UpdateTokens(ctx, session.ID, refreshToken, newAccessToken, newRefreshToken, newExpiry)
 	require.NoError(t, err)
 
 	// Step 6: Verify new tokens work


### PR DESCRIPTION
## Why

Users got signed out after being away longer than the access-token TTL. Root cause (together with the already-merged single-flight SDK fix in #337): two concurrent refreshes with the same valid refresh token raced on `SessionRepository.UpdateTokens`. The server rotates the stored token hash with a **last-write-wins** update, so the loser's response left the client holding a refresh token the server no longer stored. Every subsequent refresh then failed with 401 `Invalid or expired refresh token`, which the Wayli Android app treats as a dead session → forced re-login, persisting across restarts until the user signs in again.

## What changed

- **Compare-and-swap rotation** — `UpdateTokens` now takes the pre-rotation refresh token and only applies the update while the stored hash still matches it (`WHERE id = $1 AND refresh_token_hash = $2`). A replayed token gets `ErrRefreshTokenRotated`; the winner's rotated session survives instead of being clobbered. `Service.RefreshToken` logs the rejected replay as a security event (racing client or token theft) and returns the usual invalid-refresh error.
- **Refresh cookie lifetime** — `setAuthCookies` hard-coded a 7-day MaxAge on the refresh cookie regardless of `auth.refresh_expiry` (90d default). It now derives the MaxAge from the same `RefreshExpiry` the service uses to slide session expiry, so browser sessions last as long as the server keeps them alive (7d fallback if unset).
- Mock repository, interface and tests updated to the new signature; added `TestMockSessionRepository_UpdateTokens_ReplayRejected`.

## Testing

- `go build ./...` clean
- `go test ./internal/auth/ ./internal/api/` — **ok** (run against the dev Postgres container; includes the real-repository workflow tests)

## Notes for reviewers / deploy

- Server redeploy required for the CAS behavior to take effect.
- Existing bricked sessions can't be repaired server-side; affected users sign in once more after upgrading.
- Escalation follow-up (not included): treat repeated replays as token theft and revoke the session family.