### PR TITLE
fix(rpc): serialize native uuid columns as canonical strings

### DIFF
--- a/internal/rpc/executor.go
+++ b/internal/rpc/executor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/auth"
@@ -741,6 +742,11 @@ func convertValue(v interface{}) interface{} {
 		return string(val)
 	case time.Time:
 		return val.Format(time.RFC3339)
+	case [16]byte:
+		// Native uuid columns decode to a 16-byte array, which json.Marshal
+		// would emit as an array of numbers — clients expect the canonical
+		// hyphenated string (same treatment as time.Time above).
+		return pgtype.UUID{Bytes: val, Valid: true}.String()
 	case pgx.Rows:
 		return nil // Skip complex types
 	default:


### PR DESCRIPTION
## Problem

RPC procedures that return native `uuid` columns ship broken rows. `pgx v5` decodes `uuid` into `[16]byte`, and `convertValue` (internal/rpc/executor.go) had no case for it — `json.Marshal` then emitted the id as an **array of 16 numbers** instead of a string.

Any SDK that decodes result columns as strings silently dropped every such row. Concrete symptom: `create-device-token` (INSERT ... RETURNING id, label, scopes, created_at) executed successfully — the row **was** inserted — but the client read an empty result and reported `create-device-token returned no row`, so GPS clients could never finish provisioning (retry loops kept inserting new tokens that the client could never save). `list-device-tokens` was affected the same way (HTTP `rows_returned: 2`, client-side list empty).

Parameterless RPCs and RPCs returning only text/timestamp columns worked by accident, which is why this stayed hidden.

## Fix

Add a `[16]byte` case to `convertValue` emitting the canonical hyphenated uuid string via `pgtype.UUID{Bytes: val, Valid: true}.String()` — the same treatment `time.Time` already gets (RFC3339).

## Notes

- No wire-shape change for non-uuid columns; clients that (incorrectly) handled arrays would keep working only against servers with this fix — the canonical string is the documented contract everywhere else.
- Sibling SDK fixes for the Android client (RPC body serialization + refresh scheduler floor) are on `fix/sdk-rpc-transport`.