### PR TITLE
fix(sdk-kotlin): pass JsonElement RPC bodies through; floor autoRefresh retry at 5s

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -536,12 +536,36 @@ jobs:
           Write the summary now (1-2 sentences only):
           PROMPT_EOF
 
+          # Groq decommissions models regularly (llama-3.3-70b-versatile was
+          # shut down for non-Enterprise tiers on 2026-08-16 and has 404ed
+          # since). Discover what this API key can actually use and pick a
+          # preferred model instead of hard-coding one that breaks again.
+          AVAILABLE_MODELS=$(curl -sf https://api.groq.com/openai/v1/models \
+            -H "Authorization: Bearer $GROQ_API_KEY" | jq -r '.data[].id' || true)
+          MODEL=""
+          for candidate in openai/gpt-oss-120b openai/gpt-oss-20b moonshotai/kimi-k2-instruct meta-llama/llama-4-scout-17b-16e-instruct; do
+            if echo "$AVAILABLE_MODELS" | grep -qx "$candidate"; then
+              MODEL="$candidate"
+              break
+            fi
+          done
+          # Preference list exhausted or discovery failed: take any chat model.
+          if [ -z "$MODEL" ]; then
+            MODEL=$(echo "$AVAILABLE_MODELS" | grep -vE 'whisper|tts|guard|embed' | head -n1)
+          fi
+          if [ -z "$MODEL" ]; then
+            echo "::warning::No usable Groq model for this API key, skipping AI summary"
+            echo "summary=This release includes bug fixes, improvements, and new features. See the changelog below for details." >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "Using Groq model: $MODEL"
+
           # Call Groq API (OpenAI-compatible) and capture both response and HTTP status
           HTTP_RESPONSE=$(curl -s -w "\n%{http_code}" https://api.groq.com/openai/v1/chat/completions \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer $GROQ_API_KEY" \
             -d "{
-              \"model\": \"llama-3.3-70b-versatile\",
+              \"model\": \"$MODEL\",
               \"max_tokens\": 300,
               \"messages\": [{
                 \"role\": \"user\",

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
@@ -76,6 +76,9 @@ class FluxbaseAuth(
 
         /** Cap the scheduler's sleep so session changes are picked up. */
         private const val MAX_REFRESH_POLL_MS = 10 * 60_000L
+
+        /** Minimum spacing between refresh attempts (retry backoff floor). */
+        private const val REFRESH_RETRY_MS = 5_000L
     }
 
     // ---- Proactive token refresh (TS autoRefresh parity) ----
@@ -106,7 +109,9 @@ class FluxbaseAuth(
                 val sleepMs = if (expiresAt != null) {
                     val refreshAt = expiresAt - REFRESH_LEAD_MS
                     val now = Clock.System.now().toEpochMilliseconds()
-                    (refreshAt - now).coerceIn(1_000, MAX_REFRESH_POLL_MS)
+                    // Floor at REFRESH_RETRY_MS: an overdue token (e.g. after
+                    // a failed refresh) otherwise spins the loop every second.
+                    (refreshAt - now).coerceIn(REFRESH_RETRY_MS, MAX_REFRESH_POLL_MS)
                 } else {
                     MAX_REFRESH_POLL_MS
                 }

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransport.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransport.kt
@@ -147,14 +147,17 @@ class KtorHttpTransport(
 
     /**
      * Convert an arbitrary Kotlin object to a [kotlinx.serialization.json.JsonElement].
-     * Handles Maps, Lists, primitives. @Serializable types are handled by the
-     * `else` branch via reflection-free `encodeToJsonElement` extension. Mirrors
-     * how the TS SDK passes plain objects through `JSON.stringify`. Note: binary
-     * payloads are NOT routed through here — [rawRequest] sends [ByteArray] verbatim.
+     * Handles Maps, Lists, primitives, and passes pre-built [JsonElement] bodies
+     * through untouched (RPC bodies are built as JsonObjects by the caller —
+     * re-wrapping their leaves via `toString()` would corrupt booleans into
+     * "false" strings and quote string values, which servers reject). Mirrors
+     * how the TS SDK passes plain JS objects through `JSON.stringify`. Note:
+     * binary payloads are NOT routed through here — [rawRequest] sends
+     * [ByteArray] verbatim.
      */
-    @Suppress("UNCHECKED_CAST")
-    private fun encodeToJsonElement(value: Any?): kotlinx.serialization.json.JsonElement = when (value) {
+    internal fun encodeToJsonElement(value: Any?): kotlinx.serialization.json.JsonElement = when (value) {
         null -> kotlinx.serialization.json.JsonNull
+        is kotlinx.serialization.json.JsonElement -> value
         is String -> kotlinx.serialization.json.JsonPrimitive(value)
         is Number -> kotlinx.serialization.json.JsonPrimitive(value)
         is Boolean -> kotlinx.serialization.json.JsonPrimitive(value)

--- a/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransportJsonTest.kt
+++ b/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransportJsonTest.kt
@@ -1,0 +1,58 @@
+package io.github.nimbleflux.fluxbase.core
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * RPC request bodies are built as pre-assembled [JsonObject]s (see
+ * [io.github.nimbleflux.fluxbase.rpc.FluxbaseRpc]). The transport must pass
+ * them through untouched: re-wrapping leaves via `toString()` turned booleans
+ * into "false" strings and quoted string values, which servers reject
+ * ("missing required parameter: label" — the body bind failed and the whole
+ * request was treated as bodyless).
+ */
+class KtorHttpTransportJsonTest {
+
+    private fun transport() = KtorHttpTransport(
+        baseUrl = "https://example.com",
+    )
+
+    @Test
+    fun `rpc-style body survives serialization unchanged`() {
+        val body = transport().encodeToJsonElement(
+            JsonObject(
+                mapOf(
+                    "params" to JsonObject(
+                        mapOf(
+                            "label" to Json.parseToJsonElement("\"Android\""),
+                            "token_hash" to Json.parseToJsonElement("\"abc123\""),
+                        ),
+                    ),
+                    "async" to Json.parseToJsonElement("false"),
+                ),
+            ),
+        )
+
+        val obj = body.jsonObject
+        assertEquals("Android", obj["params"]!!.jsonObject["label"]!!.jsonPrimitive.content)
+        assertEquals("abc123", obj["params"]!!.jsonObject["token_hash"]!!.jsonPrimitive.content)
+        assertEquals(false, obj["async"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test
+    fun `plain maps and primitives still encode`() {
+        val body = transport().encodeToJsonElement(
+            mapOf("name" to "Trip", "days" to 30, "enabled" to true),
+        )
+
+        val obj = body.jsonObject
+        assertEquals("Trip", obj["name"]!!.jsonPrimitive.content)
+        assertEquals(30, obj["days"]!!.jsonPrimitive.content.toInt())
+        assertEquals(true, obj["enabled"]!!.jsonPrimitive.boolean)
+    }
+}


### PR DESCRIPTION
## 1. RPC bodies corrupted by the transport serializer

`KtorHttpTransport.encodeToJsonElement` had no `JsonElement` branch. RPC bodies built by `FluxbaseRpc.invoke` (JsonObjects with boolean/primitive leaves) were therefore re-wrapped leaf-by-leaf via `toString()`:

- `async: false` became the **string** `"false"`
- string params gained embedded quotes: `"\"Android\""`

The Go server's `InvokeRequest` bind failed on `"async": "false"` (`bool` field), the handler silently treated the request as bodyless, and validation returned `missing required parameter: label` for every parameterized RPC — `create-device-token`, `revoke-device-token`, trip approve/reject, `add-want-to-visit`. Parameterless RPCs worked by accident. Unit tests missed it because the `RecordingHttp` fake never exercised the transport serializer.

Fix: pass pre-built `JsonElement` bodies through untouched (one branch), make the function `internal`, and add a regression test asserting an RPC-style body survives serialization unchanged (boolean stays boolean, strings unquoted).

## 2. autoRefresh scheduler floor

With an expired/overdue access token the scheduler's sleep collapsed to its 1s lower bound and spun refresh attempts every second — during server-side rate limiting that became a 429-per-second flood masking the real 401. Floor the retry at 5 seconds.

## Verification

- `KtorHttpTransportJsonTest` locks the wire format (boolean stays boolean, strings unquoted).
- Full sdk-kotlin test suite green; published and consumed by the Wayli Android app (fluxbase-kotlin 2026.9.5) where device-token provisioning now completes end to end.