### PR TITLE
fix: Android client compat — RPC body serialization, uuid results, refresh tolerance, auth middleware

### DIFF
--- a/internal/rpc/executor.go
+++ b/internal/rpc/executor.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/rs/zerolog/log"
 
 	"github.com/nimbleflux/fluxbase/internal/auth"
@@ -741,6 +742,11 @@ func convertValue(v interface{}) interface{} {
 		return string(val)
 	case time.Time:
 		return val.Format(time.RFC3339)
+	case [16]byte:
+		// Native uuid columns decode to a 16-byte array, which json.Marshal
+		// would emit as an array of numbers — clients expect the canonical
+		// hyphenated string (same treatment as time.Time above).
+		return pgtype.UUID{Bytes: val, Valid: true}.String()
 	case pgx.Rows:
 		return nil // Skip complex types
 	default:

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/AuthTypes.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/AuthTypes.kt
@@ -41,7 +41,9 @@ data class AuthSession(
  */
 @Serializable
 internal data class AuthResponse(
-    val user: User,
+    // Nullable: some server versions omit `user` from the /auth/refresh
+    // response — the caller then carries the signed-in user forward.
+    val user: User? = null,
     @SerialName("access_token") val accessToken: String,
     @SerialName("refresh_token") val refreshToken: String,
     @SerialName("expires_in") val expiresIn: Long,

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
@@ -76,6 +76,9 @@ class FluxbaseAuth(
 
         /** Cap the scheduler's sleep so session changes are picked up. */
         private const val MAX_REFRESH_POLL_MS = 10 * 60_000L
+
+        /** Minimum spacing between refresh attempts (retry backoff floor). */
+        private const val REFRESH_RETRY_MS = 5_000L
     }
 
     // ---- Proactive token refresh (TS autoRefresh parity) ----
@@ -106,7 +109,9 @@ class FluxbaseAuth(
                 val sleepMs = if (expiresAt != null) {
                     val refreshAt = expiresAt - REFRESH_LEAD_MS
                     val now = Clock.System.now().toEpochMilliseconds()
-                    (refreshAt - now).coerceIn(1_000, MAX_REFRESH_POLL_MS)
+                    // Floor at REFRESH_RETRY_MS: an overdue token (e.g. after
+                    // a failed refresh) otherwise spins the loop every second.
+                    (refreshAt - now).coerceIn(REFRESH_RETRY_MS, MAX_REFRESH_POLL_MS)
                 } else {
                     MAX_REFRESH_POLL_MS
                 }

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/auth/FluxbaseAuth.kt
@@ -155,7 +155,7 @@ class FluxbaseAuth(
             // Normal sign-in: parse as AuthResponse and build session.
             val authResponse = json.decodeFromString(AuthResponse.serializer(), responseText)
             val session = AuthSession(
-                user = authResponse.user,
+                user = authResponse.user ?: User(id = "", email = ""),
                 accessToken = authResponse.accessToken,
                 refreshToken = authResponse.refreshToken,
                 expiresIn = authResponse.expiresIn,
@@ -234,7 +234,7 @@ class FluxbaseAuth(
 
             val authResponse = json.decodeFromString(AuthResponse.serializer(), responseText)
             val session = AuthSession(
-                user = authResponse.user,
+                user = authResponse.user ?: User(id = "", email = ""),
                 accessToken = authResponse.accessToken,
                 refreshToken = authResponse.refreshToken,
                 expiresIn = authResponse.expiresIn,
@@ -264,8 +264,11 @@ class FluxbaseAuth(
             // If tokens are present, email confirmation is disabled → establish session.
             if (parsed["access_token"] != null && parsed["refresh_token"] != null) {
                 val authResponse = json.decodeFromString(AuthResponse.serializer(), responseText)
+                // The refresh response may omit `user` (older servers) —
+                // keep the signed-in user so callers depending on
+                // session.user.id keep working across refreshes.
                 val session = AuthSession(
-                    user = authResponse.user,
+                    user = authResponse.user ?: currentSession?.user ?: User(id = "", email = ""),
                     accessToken = authResponse.accessToken,
                     refreshToken = authResponse.refreshToken,
                     expiresIn = authResponse.expiresIn,
@@ -343,8 +346,10 @@ class FluxbaseAuth(
                 // can't recurse into another refresh.
                 val responseText = http.postWithoutRetry("/api/v1/auth/refresh", body).body
                 val authResponse = json.decodeFromString(AuthResponse.serializer(), responseText)
+                // Older servers omit `user` from the refresh response —
+                // keep the signed-in user instead of nulling it out.
                 val session = AuthSession(
-                    user = authResponse.user,
+                    user = authResponse.user ?: currentSession?.user ?: User(id = "", email = ""),
                     accessToken = authResponse.accessToken,
                     refreshToken = authResponse.refreshToken,
                     expiresIn = authResponse.expiresIn,

--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransport.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransport.kt
@@ -147,14 +147,17 @@ class KtorHttpTransport(
 
     /**
      * Convert an arbitrary Kotlin object to a [kotlinx.serialization.json.JsonElement].
-     * Handles Maps, Lists, primitives. @Serializable types are handled by the
-     * `else` branch via reflection-free `encodeToJsonElement` extension. Mirrors
-     * how the TS SDK passes plain objects through `JSON.stringify`. Note: binary
-     * payloads are NOT routed through here — [rawRequest] sends [ByteArray] verbatim.
+     * Handles Maps, Lists, primitives, and passes pre-built [JsonElement] bodies
+     * through untouched (RPC bodies are built as JsonObjects by the caller —
+     * re-wrapping their leaves via `toString()` would corrupt booleans into
+     * "false" strings and quote string values, which servers reject). Mirrors
+     * how the TS SDK passes plain JS objects through `JSON.stringify`. Note:
+     * binary payloads are NOT routed through here — [rawRequest] sends
+     * [ByteArray] verbatim.
      */
-    @Suppress("UNCHECKED_CAST")
-    private fun encodeToJsonElement(value: Any?): kotlinx.serialization.json.JsonElement = when (value) {
+    internal fun encodeToJsonElement(value: Any?): kotlinx.serialization.json.JsonElement = when (value) {
         null -> kotlinx.serialization.json.JsonNull
+        is kotlinx.serialization.json.JsonElement -> value
         is String -> kotlinx.serialization.json.JsonPrimitive(value)
         is Number -> kotlinx.serialization.json.JsonPrimitive(value)
         is Boolean -> kotlinx.serialization.json.JsonPrimitive(value)

--- a/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransportJsonTest.kt
+++ b/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/core/KtorHttpTransportJsonTest.kt
@@ -1,0 +1,58 @@
+package io.github.nimbleflux.fluxbase.core
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * RPC request bodies are built as pre-assembled [JsonObject]s (see
+ * [io.github.nimbleflux.fluxbase.rpc.FluxbaseRpc]). The transport must pass
+ * them through untouched: re-wrapping leaves via `toString()` turned booleans
+ * into "false" strings and quoted string values, which servers reject
+ * ("missing required parameter: label" — the body bind failed and the whole
+ * request was treated as bodyless).
+ */
+class KtorHttpTransportJsonTest {
+
+    private fun transport() = KtorHttpTransport(
+        baseUrl = "https://example.com",
+    )
+
+    @Test
+    fun `rpc-style body survives serialization unchanged`() {
+        val body = transport().encodeToJsonElement(
+            JsonObject(
+                mapOf(
+                    "params" to JsonObject(
+                        mapOf(
+                            "label" to Json.parseToJsonElement("\"Android\""),
+                            "token_hash" to Json.parseToJsonElement("\"abc123\""),
+                        ),
+                    ),
+                    "async" to Json.parseToJsonElement("false"),
+                ),
+            ),
+        )
+
+        val obj = body.jsonObject
+        assertEquals("Android", obj["params"]!!.jsonObject["label"]!!.jsonPrimitive.content)
+        assertEquals("abc123", obj["params"]!!.jsonObject["token_hash"]!!.jsonPrimitive.content)
+        assertEquals(false, obj["async"]!!.jsonPrimitive.boolean)
+    }
+
+    @Test
+    fun `plain maps and primitives still encode`() {
+        val body = transport().encodeToJsonElement(
+            mapOf("name" to "Trip", "days" to 30, "enabled" to true),
+        )
+
+        val obj = body.jsonObject
+        assertEquals("Trip", obj["name"]!!.jsonPrimitive.content)
+        assertEquals(30, obj["days"]!!.jsonPrimitive.content.toInt())
+        assertEquals(true, obj["enabled"]!!.jsonPrimitive.boolean)
+    }
+}


### PR DESCRIPTION
## Summary

Four fixes required for the Wayli Android client to work against fluxbase. Found end-to-end while debugging why GPS ingestion returned 401/400 and why the app kept signing users out. Each is independent; together they close the Android ingest loop.

### 1. sdk-kotlin: pass JsonElement RPC bodies through the transport untouched

`KtorHttpTransport.encodeToJsonElement` had no `JsonElement` branch — RPC bodies built by `FluxbaseRpc.invoke` were re-wrapped leaf-by-leaf via `toString()`:

- `async: false` became the **string** `"false"`
- string params gained embedded quotes: `"\"Android\""`

The Go `InvokeRequest` bind then failed on the boolean, the handler silently treated the request as bodyless, and validation returned `missing required parameter: <x>` for **every parameterized RPC** (`create-device-token`, `revoke-device-token`, trip approve/reject, `add-want-to-visit`). Parameterless RPCs worked by accident, which masked it. Unit tests missed it because the `RecordingHttp` fake skips the transport serializer.

Fix: pass pre-built `JsonElement` bodies through untouched + regression test locking the wire format.

### 2. sdk-kotlin: floor the autoRefresh scheduler retry at 5s

With an expired/overdue access token the scheduler's sleep collapsed to its 1s lower bound and spun refresh attempts every second — under the server's per-token `auth_refresh` rate limiter that became a 429-per-second flood masking the real 401.

### 3. rpc: serialize native uuid columns as canonical strings

`pgx v5` decodes native `uuid` columns into `[16]byte`, which `json.Marshal` emits as an **array of 16 numbers**. RPC procedures returning uuid columns (e.g. `create-device-token`'s `INSERT ... RETURNING id`) shipped rows no string-typed client could decode — the row was inserted, but provisioning clients read an empty result and re-provisioned in a loop.

Fix: emit the canonical hyphenated uuid string (same treatment as `time.Time` → RFC3339).

### 4. sdk-kotlin: tolerate /auth/refresh responses without `user`

The 2026.9.x SDK's `AuthResponse` requires `user`; older fluxbase servers omit it from the refresh response. The refresh **succeeds server-side** (rotating the refresh token), but the client fails to decode the response and never persists the rotated tokens — the next refresh replays the now-stale token, the session is rejected as "possible token theft", and the user is signed out within the hour of every login. `user` is now optional and `refreshSession` carries the signed-in user forward.

## Testing

- sdk-kotlin suite green, including the new `KtorHttpTransportJsonTest` wire-format regression test.
- Verified end-to-end against a live instance via the Wayli Android app: device-token provisioning now completes (previously `missing required parameter: label`), and the refresh cycle no longer signs the user out.