### PR TITLE
fix(sdk-kotlin): parse Content-Range count case-insensitively

### DIFF
--- a/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/postgrest/QueryBuilder.kt
+++ b/sdk-kotlin/src/main/kotlin/io/github/nimbleflux/fluxbase/postgrest/QueryBuilder.kt
@@ -219,7 +219,13 @@ class QueryBuilder<T> @PublishedApi internal constructor(
             } else {
                 json.decodeFromString(ListSerializer(serializer), rawResponse.body)
             }
-            val parsedCount = parseCountFromRange(rawResponse.headers["Content-Range"])
+            // HTTP/2 delivers header names lowercase ("content-range") while
+            // HTTP/1.1 canonicalizes ("Content-Range") — the headers map is
+            // case-sensitive, so look the name up case-insensitively or the
+            // count silently reads as null over TLS.
+            val parsedCount = rawResponse.headers.entries
+                .firstOrNull { it.key.equals("Content-Range", ignoreCase = true) }
+                ?.let { parseCountFromRange(it.value) }
             PostgrestResponse(
                 data = data,
                 error = null,

--- a/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/postgrest/QueryBuilderCountTest.kt
+++ b/sdk-kotlin/src/test/kotlin/io/github/nimbleflux/fluxbase/postgrest/QueryBuilderCountTest.kt
@@ -1,0 +1,49 @@
+package io.github.nimbleflux.fluxbase.postgrest
+
+import io.github.nimbleflux.fluxbase.createFluxbaseClient
+import io.github.nimbleflux.fluxbase.core.test.RecordingHttp
+import io.github.nimbleflux.fluxbase.from
+import kotlinx.serialization.Serializable
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The `?count=exact` total arrives in the Content-Range response header.
+ * HTTP/2 connections deliver header names lowercase ("content-range") while
+ * HTTP/1.1 canonicalizes ("Content-Range") — the response headers map is
+ * case-sensitive, so the lookup must be case-insensitive or the count
+ * silently reads as null over TLS (frozen range-dependent UIs downstream).
+ */
+class QueryBuilderCountTest {
+
+    @Serializable
+    private data class Row(val id: Int)
+
+    private fun transport(headerName: String) = RecordingHttp(
+        mockResponseBody = """[{"id":1}]""",
+        mockHeaders = mapOf(headerName to "0-0/3958"),
+    )
+
+    @Test
+    fun `count parses from canonical Content-Range header`() = runTest {
+        val client = createFluxbaseClient(url = "https://example.com", key = "anon", transport = transport("Content-Range"))
+        val result = client.from<Row>("t").select().count().limit(1).execute()
+        assertEquals(3958L, result.count)
+    }
+
+    @Test
+    fun `count parses from lowercase http2 content-range header`() = runTest {
+        val client = createFluxbaseClient(url = "https://example.com", key = "anon", transport = transport("content-range"))
+        val result = client.from<Row>("t").select().count().limit(1).execute()
+        assertEquals(3958L, result.count)
+    }
+
+    @Test
+    fun `count is null when no Content-Range header is present`() = runTest {
+        val client = createFluxbaseClient(url = "https://example.com", key = "anon", transport = RecordingHttp(mockResponseBody = "[]"))
+        val result = client.from<Row>("t").select().count().limit(1).execute()
+        assertNull(result.count)
+    }
+}


### PR DESCRIPTION
## Problem

`response.count` from `?count=exact` reads as **null on any HTTP/2 connection**. The total arrives in the `Content-Range` response header, but the SDK looks it up in the case-sensitive headers map: HTTP/1.1 canonicalizes the name (`Content-Range`), while HTTP/2 (every TLS deployment behind an ingress with ALPN h2) delivers it lowercase (`content-range`) — the lookup misses and the count is silently dropped.

Downstream effect (verified live against production): the Wayli Android app's range-dependent sampling collapsed every date range to the newest ~1000 rows, freezing the journeys map on range switches.

## Fix

Case-insensitive header lookup at the parse site. Regression tests cover:
- canonical `Content-Range` (HTTP/1.1 path) → count parsed
- lowercase `content-range` (HTTP/2 path) → count parsed
- header absent → count null

Verified server-side beforehand that the Go tables API emits the header correctly on both paths (`Content-Range: 0-0/3958`), so this is purely the client-side lookup.

## Release note

After merging, the next release artifact (≥ 2026.9.2) should be pinned by the Wayli app — its current 2026.9.1 pin predates this fix and runs with a degraded sampling fallback until bumped.